### PR TITLE
Update tutorial_quantum_chemistry.py

### DIFF
--- a/demonstrations/tutorial_quantum_chemistry.py
+++ b/demonstrations/tutorial_quantum_chemistry.py
@@ -284,7 +284,7 @@ print(qubit_hamiltonian)
 #
 #     If you have built your electronic Hamiltonian independently by using `OpenFermion
 #     <https://github.com/quantumlib/OpenFermion>`__ tools, no problem! The
-#     :func:`~.convert_hamiltonian` function converts the `OpenFermion
+#     :func:`~.convert_observable` function converts the `OpenFermion
 #     <https://github.com/quantumlib/OpenFermion>`__ QubitOperator to PennyLane observables.
 #
 # .. _qchem_references:


### PR DESCRIPTION
The method has been renamed: https://pennylane.readthedocs.io/en/stable/code/api/pennylane_qchem.qchem.convert_observable.html
https://github.com/PennyLaneAI/pennylane/blob/master/qchem/CHANGELOG.md#improvements-2