### PR TITLE
Make VQC tutorial plot colouring consistent 

### DIFF
--- a/demonstrations/tutorial_variational_classifier.py
+++ b/demonstrations/tutorial_variational_classifier.py
@@ -410,25 +410,25 @@ Y = data[:, -1]
 import matplotlib.pyplot as plt
 
 plt.figure()
-plt.scatter(X[:, 0][Y == 1], X[:, 1][Y == 1], c="r", marker="o", edgecolors="k")
-plt.scatter(X[:, 0][Y == -1], X[:, 1][Y == -1], c="b", marker="o", edgecolors="k")
+plt.scatter(X[:, 0][Y == 1], X[:, 1][Y == 1], c="b", marker="o", edgecolors="k")
+plt.scatter(X[:, 0][Y == -1], X[:, 1][Y == -1], c="r", marker="o", edgecolors="k")
 plt.title("Original data")
 plt.show()
 
 plt.figure()
 dim1 = 0
 dim2 = 1
-plt.scatter(X_norm[:, dim1][Y == 1], X_norm[:, dim2][Y == 1], c="r", marker="o", edgecolors="k")
-plt.scatter(X_norm[:, dim1][Y == -1], X_norm[:, dim2][Y == -1], c="b", marker="o", edgecolors="k")
+plt.scatter(X_norm[:, dim1][Y == 1], X_norm[:, dim2][Y == 1], c="b", marker="o", edgecolors="k")
+plt.scatter(X_norm[:, dim1][Y == -1], X_norm[:, dim2][Y == -1], c="r", marker="o", edgecolors="k")
 plt.title("Padded and normalised data (dims {} and {})".format(dim1, dim2))
 plt.show()
 
 plt.figure()
 dim1 = 0
 dim2 = 3
-plt.scatter(features[:, dim1][Y == 1], features[:, dim2][Y == 1], c="r", marker="o", edgecolors="k")
+plt.scatter(features[:, dim1][Y == 1], features[:, dim2][Y == 1], c="b", marker="o", edgecolors="k")
 plt.scatter(
-    features[:, dim1][Y == -1], features[:, dim2][Y == -1], c="b", marker="o", edgecolors="k"
+    features[:, dim1][Y == -1], features[:, dim2][Y == -1], c="r", marker="o", edgecolors="k"
 )
 plt.title("Feature vectors (dims {} and {})".format(dim1, dim2))
 plt.show()


### PR DESCRIPTION
**Title:** Make VQC tutorial plot colouring consistent 

**Summary:** In the Iris data example, the first 3 plots of the data colour class 1 red and class -1 blue, whereas the contour plot at the end does the opposite. I modified the first plots to match the contour plot for consistency.

**Relevant references:** None

**Possible Drawbacks:** None

**Related GitHub Issues:** None
