### PR TITLE
Add community card

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = .
-BUILDDIR      = _build
+BUILDDIR      = _build/html
 DATADIR       = _data
 
 # Put it first so that "make" without argument is like "make help".
@@ -17,7 +17,7 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)."
 

--- a/conf.py
+++ b/conf.py
@@ -191,9 +191,10 @@ htmlhelp_basename = "QMLdoc"
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {"https://pennylane.readthedocs.io/en/stable/": None}
 
-from custom_directives import CustomGalleryItemDirective, YoutubeItemDirective
+from custom_directives import CustomGalleryItemDirective, YoutubeItemDirective, CommunityCardDirective
 
 def setup(app):
     app.add_directive("customgalleryitem", CustomGalleryItemDirective)
     app.add_directive("youtube", YoutubeItemDirective)
+    app.add_directive("community-card", CommunityCardDirective)
     app.add_stylesheet("xanadu_gallery.css")

--- a/custom_directives.py
+++ b/custom_directives.py
@@ -181,3 +181,87 @@ class YoutubeItemDirective(Directive):
         thumb = nodes.paragraph()
         self.state.nested_parse(thumbnail, self.content_offset, thumb)
         return [thumb]
+
+
+COMMUNITY_CARD_TEMPLATE = """
+.. raw:: html
+
+    <div class="card plugin-card">
+        <h4 class="card-header {color} lighten-4">{title}</h4>
+        <div class="card-body">
+            <h6>{author}</h6>
+            <p class="card-text">
+                {description}
+            </p>
+        </div>
+        <div class="rounded-bottom mdb-color lighten-5 text-right pt-3 pr-1">
+            <ul class="list-unstyled list-inline font-small">
+                {paper_footer}
+                {code_footer}
+                <li class="list-inline-item pr-2 black-text">
+                    <i class="far fa-clock pr-1"></i>{date}
+                </li>
+            </ul>
+        </div>
+    </div>
+"""
+
+PAPER_FOOTER = """<li class="list-inline-item pr-2">
+                    <a href="{paper}" class="black-text"><i class="fas fa-book"></i> Paper</a>
+                </li>
+"""
+
+CODE_FOOTER = """<li class="list-inline-item pr-2"><a href="{code}" class="black-text">
+                    <i class="fas fa-code-branch"></i></i> Code</a>
+                </li>
+"""
+
+
+class CommunityCardDirective(Directive):
+    """Create a community card."""
+
+    required_arguments = 0
+    optional_arguments = 2
+    option_spec = {
+        'title': directives.unchanged,
+        'author': directives.unchanged,
+        'paper': directives.unchanged,
+        'code': directives.unchanged,
+        'date': directives.unchanged,
+        'color': directives.unchanged,
+    }
+
+    final_argument_whitespace = False
+    has_content = True
+    add_index = False
+
+    def run(self):
+        description = [i if i != "" else "<br><br>" for i in self.content]
+        color = self.options.get("color", "teal")
+        code_footer = ""
+        paper_footer = ""
+
+        paper_url = self.options.get("paper", None)
+
+        if paper_url is not None:
+            paper_footer = PAPER_FOOTER.format(paper=paper_url)
+
+        code_url = self.options.get("code", None)
+
+        if code_url is not None:
+            code_footer = CODE_FOOTER.format(code=code_url)
+
+        card_rst = COMMUNITY_CARD_TEMPLATE.format(
+            title=self.options["title"],
+            author=self.options["author"],
+            description=" ".join(description),
+            date=self.options["date"],
+            paper_footer=paper_footer,
+            code_footer=code_footer,
+            color=color
+        )
+
+        thumbnail = StringList(card_rst.split('\n'))
+        thumb = nodes.paragraph()
+        self.state.nested_parse(thumbnail, self.content_offset, thumb)
+        return [thumb]

--- a/custom_directives.py
+++ b/custom_directives.py
@@ -190,30 +190,30 @@ COMMUNITY_CARD_TEMPLATE = """
         <h4 class="card-header {color} lighten-4">{title}</h4>
         <div class="card-body">
             <h6>{author}</h6>
-            <p class="card-text">
-                {description}
-            </p>
-        </div>
-        <div class="rounded-bottom mdb-color lighten-5 text-right pt-3 pr-1">
-            <ul class="list-unstyled list-inline font-small">
-                {paper_footer}
-                {code_footer}
-                <li class="list-inline-item pr-2 black-text">
-                    <i class="far fa-clock pr-1"></i>{date}
-                </li>
-            </ul>
+            <p class="font-small"><i class="far fa-clock pr-1"></i>{date}</p>
+            <div class="row d-flex align-items-center">
+                <div class="col-lg-8">
+                    <p class="card-text">
+                        {description}
+                    </p>
+                </div>
+                <div class="col-lg-4">
+                    {paper_footer}
+                    {code_footer}
+                </div>
+            </div>
         </div>
     </div>
 """
 
-PAPER_FOOTER = """<li class="list-inline-item pr-2">
-                    <a href="{paper}" class="black-text"><i class="fas fa-book"></i> Paper</a>
-                </li>
+PAPER_FOOTER = """<a href="{paper}" class="btn btn-info" style="box-shadow: unset; border-radius:5px; width:90%;">
+                <i class="fas fa-book"></i> Paper
+            </a>
 """
 
-CODE_FOOTER = """<li class="list-inline-item pr-2"><a href="{code}" class="black-text">
-                    <i class="fas fa-code-branch"></i></i> Code</a>
-                </li>
+CODE_FOOTER = """<a href="{code}" class="btn btn-default" style="box-shadow: unset; border-radius:5px; width:90%;">
+                <i class="fas fa-code-branch"></i></i> Code
+            </a>
 """
 
 
@@ -237,7 +237,7 @@ class CommunityCardDirective(Directive):
 
     def run(self):
         description = [i if i != "" else "<br><br>" for i in self.content]
-        color = self.options.get("color", "teal")
+        color = self.options.get("color", "heavy-rain-gradient")
         code_footer = ""
         paper_footer = ""
 

--- a/demos_community.rst
+++ b/demos_community.rst
@@ -44,9 +44,19 @@ Community
     <link href="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.8.10/css/mdb.min.css" rel="stylesheet">
 
     <hr>
+    <br>
 
 
-:html:`<div class="card-deck mt-5">`
+.. For two cards per row, create a new card deck every two cards.
+
+:html:`<div class="card-deck">`
+
+.. Community card required options:
+     - title
+     - author
+     - date
+   All remaining options (code, paper, color) are *optional*.
+   All fields, including the description can contain arbitrary HTML.
 
 .. community-card::
     :title: Characterizing the loss landscape of variational quantum circuits
@@ -59,6 +69,9 @@ Community
     Using PennyLane and complex PyTorch, we compute the Hessian of the loss function of VQCs and
     show how to characterize the loss landscape with it. We show how the Hessian can be used to
     escape flat regions of the loss landscape.
+
+.. If the final card deck only has a single card, we insert a 'hidden card'
+   so that the card does not become full-width.
 
 :html:`<div class="card hidden-card"></div></div>`
 

--- a/demos_community.rst
+++ b/demos_community.rst
@@ -46,37 +46,23 @@ Community
     <hr>
 
 
-    <div class="card-deck mt-5">
-        <div class="card plugin-card">
-            <h4 class="card-header teal lighten-4">Characterizing the loss landscape of variational quantum circuits</h4>
-            <div class="card-body">
-                <h6>Patrick Huembeli and Alexandre Dauphin</h6>
-                <p class="card-text">
-                    Using PennyLane and complex PyTorch, we compute the Hessian of the loss function of VQCs and show how to characterize the loss landscape with it. We show how the Hessian can be used to escape flat regions of the loss landscape.
-                </p>
-            </div>
-            <!-- Card footer -->
-            <div class="rounded-bottom mdb-color lighten-5 text-right pt-3 pr-1">
-                <ul class="list-unstyled list-inline font-small">
-                    <li class="list-inline-item pr-2">
-                        <a href="https://arxiv.org/abs/2008.02785" class="black-text"><i class="fas fa-book"></i> Paper</a>
-                    </li>
-                    <li class="list-inline-item pr-2"><a href="https://github.com/PatrickHuembeli/vqc_loss_landscapes" class="black-text">
-                        <i class="fas fa-code-branch"></i></i> Code</a>
-                    </li>
-                    <li class="list-inline-item pr-2 black-text">
-                        <i class="far fa-clock pr-1"></i>30/09/2020
-                    </li>
-                </ul>
-            </div>
-        </div>
-        <div class="card hidden-card"></div>
-    </div>
+:html:`<div class="card-deck mt-5">`
 
+.. community-card::
+    :title: Characterizing the loss landscape of variational quantum circuits
+    :author: Patrick Huembeli and Alexandre Dauphin
+    :date: 30/09/2020
+    :code: https://github.com/PatrickHuembeli/vqc_loss_landscapes
+    :paper: https://arxiv.org/abs/2008.02785
+    :color: teal
+
+    Using PennyLane and complex PyTorch, we compute the Hessian of the loss function of VQCs and
+    show how to characterize the loss landscape with it. We show how the Hessian can be used to
+    escape flat regions of the loss landscape.
+
+:html:`<div class="card hidden-card"></div></div>`
 
 .. toctree::
     :maxdepth: 2
     :hidden:
 
-
-.. <h3 class="card-title h3 my-4"><strong>Community demos</strong></h3>

--- a/demos_community.rst
+++ b/demos_community.rst
@@ -64,7 +64,7 @@ Community
     :date: 30/09/2020
     :code: https://github.com/PatrickHuembeli/vqc_loss_landscapes
     :paper: https://arxiv.org/abs/2008.02785
-    :color: teal
+    :color: heavy-rain-gradient
 
     Using PennyLane and complex PyTorch, we compute the Hessian of the loss function of VQCs and
     show how to characterize the loss landscape with it. We show how the Hessian can be used to


### PR DESCRIPTION
Provides a custom ReST directive for creating a community card:

```rest
.. community-card::
    :title: card title
    :author: author (or subtitle?)
    :date: 30/09/2020
    :code: https://github.com/username/repo/or/notebook
    :paper: https://arxiv.org/abs/1234568
    :color: teal

    The demo description goes here. This field can contain HTML if needed, for example images and links.
    Of the options above, only title, author, and date are required. Code, paper, and color are all optional.
```

This will help reduce the overhead of adding community demos.

Note that this PR should result in no front-facing webpage changes.