### PR TITLE
Fix array indexing in the multiclass classification demonstration

### DIFF
--- a/demonstrations/tutorial_multiclass_classification.py
+++ b/demonstrations/tutorial_multiclass_classification.py
@@ -44,7 +44,7 @@ of size 4.
 
 import pennylane as qml
 import torch
-from pennylane import numpy as np
+import numpy as np
 from torch.autograd import Variable
 import torch.optim as optim
 


### PR DESCRIPTION
**Summary:**
With the latest PennyLane version and changes to the `pennylane.numpy.tensor` class (indexing logic), the following errors arise when running the multiclass classification demonstration:

```python
Traceback (most recent call last):
  File "tutorial_multiclass_classification.py", line 285, in <module>
    costs, train_acc, test_acc = training(features, Y)
  File "tutorial_multiclass_classification.py", line 254, in training
    feat_vecs_train_batch = feat_vecs_train[indices]
IndexError: too many indices for tensor of dimension 2
```

The error comes down to indexing into `torch.Tensor` objects with one-element `pennylane.numpy.tensor` objects.

**Suggested solution**

The proposed solution is to simply change to using the original NumPy functions instead of PennyLane's patched version. (Unless the patched version of NumPy would have to be used for the demonstration.)

**Alternative solution**

An alternative solution would be including a logic for unwrapping the related tensor objects:
```python
        batch_index = np.random.randint(0, num_train, (batch_size,))
        indices = [ind.unwrap() for ind in batch_index] 
        feat_vecs_train_batch = feat_vecs_train[indices]
        Y_train_batch = Y_train[indices]
```
This might, however, add complexity to understanding the code.

**Relevant references:**
N/A

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A