### PR TITLE
Updates README with demo categorization instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,10 @@ quantum machine learning paper/result.
   where `<demo name>` is a sub-directory with the name of
   your demo.
 
-* When complete, create a gallery link to your demo, by adding the
-  following to `demonstrations.rst`:
-
+* When complete, create a gallery link to your demo. This can be done by adding the
+  snippet below to `demos_basic.rst` for introductory demos, or `demos_research.rst`
+  for more advanced topics, such as those based on research papers. 
+  
   ```rest
   .. customgalleryitem::
       :tooltip: An extended description of the demo
@@ -90,7 +91,10 @@ quantum machine learning paper/result.
   ```
 
   You should also add a link to your demo to the table of contents, by adding to the
-  end of the `.. toctree::`.
+  end of the `.. toctree::` in the appropriate file.
+
+  If you're unsure which file to put your demo in, choose the one you think is  best,
+  and we will work together to sort it during the review process.
 
 * Finally, run your script through the [Black Python formatter](https://github.com/psf/black),
 


### PR DESCRIPTION
**Title:** Update README

**Summary:** After the webpage redesign, the demos were split into basic and research categories, but the contribution instructions in the README have not yet been updated. This PR provides updated instructions for users to add new demos.  

**Relevant references:** None

**Possible Drawbacks:** None

**Related GitHub Issues:** #151 
