### PR TITLE
[WIP] Add "start here" banner on main demo page

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -52,6 +52,7 @@ extensions = [
     "sphinx.ext.ifconfig",
     "sphinx_gallery.gen_gallery",
     "sphinx_sitemap",
+    "sphinx_togglebutton"
 ]
 
 

--- a/demonstrations.rst
+++ b/demonstrations.rst
@@ -1,3 +1,4 @@
+
 .. raw:: html
 
     <style>
@@ -21,6 +22,14 @@ Demos
         <!-- Section: Features v.1 -->
             <p class="lead grey-text text-center mx-auto mb-5">
             Take a deeper dive into quantum machine learning by exploring cutting-edge algorithms using PennyLane and near-term quantum hardware.</p>
+
+	    <div class="toggle dropdown admonition border rounded">
+	        <p class="admonition-title">New to PennyLane and quantum machine learning?</p>
+                <p> <a href="https://pennylane.ai/install.html" target="_blank" > Install </a> PennyLane, then start by training a quantum circuit to
+	        <a href="../demos/tutorial_qubit_rotation" target="_blank"> rotate a qubit </a>, or
+	        <a href="../demos/tutorial_gaussian_transformation" target="_blank"> tune a beamsplitter</a>!
+		</p>
+	    </div>
 
         <section class="my-5">
             <div class="row justify-content-center" id="main-cards">

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ scipy==1.4.1
 sphinx==1.8.5
 sphinx-sitemap
 sphinx_gallery==0.7
+sphinx-togglebutton
 seaborn==0.10.1
 tensorflow==2.3.1
 toml

--- a/xanadu_theme/static/xanadu.css_t
+++ b/xanadu_theme/static/xanadu.css_t
@@ -1143,6 +1143,15 @@ div.topic.contents > ul > li {
   font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
+.admonition.dropdown {
+ /* margin: 20px 0;*/
+  padding: 20px;
+  background-color: #fff6ea;
+  /*border: 1px solid #eee;*/
+  border-left-width: 0px;
+  border-radius: 3px;
+}
+
 .admonition.danger,
 .admonition.error {
   border-left-color: #d9534f;


### PR DESCRIPTION
**Title:** Add "start here" banner on main demo page

**Summary:** A simple implementation using a dropdown admonition that suggests a starting point for new users. 

**Relevant references:** None

**Possible Drawbacks:** Not as relevant after categorization during the re-design, but still nice to have for people who land on the demo page for the first time. Also we'll need to tweak the CSS if we decide to keep this. 

**Related GitHub Issues:** #83 
