### PR TITLE
Replace VQECost with ExpvalCost

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,9 @@ jobs:
       - restore_cache:
           keys:
             # when lock file changes, use increasingly general patterns to restore cache
-            - pip-v19-{{ .Branch }}-{{ checksum "requirements.txt" }}
-            - pip-v19-{{ .Branch }}-
-            - pip-v19-
+            - pip-v20-{{ .Branch }}-{{ checksum "requirements.txt" }}
+            - pip-v20-{{ .Branch }}-
+            - pip-v20-
 
       - run:
           name: Install dependencies
@@ -35,7 +35,7 @@ jobs:
       - save_cache:
           paths:
             - venv
-          key: pip-v19-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: pip-v20-{{ .Branch }}-{{ checksum "requirements.txt" }}
 
       - restore_cache:
           keys:

--- a/demonstrations/tutorial_qaoa_intro.py
+++ b/demonstrations/tutorial_qaoa_intro.py
@@ -312,7 +312,7 @@ def circuit(params, **kwargs):
 # step is PennyLane's specialty: optimizing the circuit parameters.
 #
 # The cost function is the expectation value of :math:`H_C`, which we want to minimize. The
-# function :func:`~.pennylane.VQECost` is designed for this purpose: it returns the
+# function :func:`~.pennylane.ExpvalCost` is designed for this purpose: it returns the
 # expectation value of an input Hamiltonian with respect to the circuit's output state.
 # We also define the device on which the simulation is
 # performed. We use the PennyLane-Qulacs plugin to
@@ -320,7 +320,7 @@ def circuit(params, **kwargs):
 #
 
 dev = qml.device("qulacs.simulator", wires=wires)
-cost_function = qml.VQECost(circuit, cost_h, dev)
+cost_function = qml.ExpvalCost(circuit, cost_h, dev)
 
 
 ######################################################################
@@ -438,7 +438,7 @@ def circuit(params, **kwargs):
         qml.Hadamard(wires=w)
     qml.layer(qaoa_layer, depth, params[0], params[1])
 
-cost_function = qml.VQECost(circuit, new_cost_h, dev)
+cost_function = qml.ExpvalCost(circuit, new_cost_h, dev)
 
 params = [[0.5, 0.5], [0.5, 0.5]]
 

--- a/demonstrations/tutorial_vqe.py
+++ b/demonstrations/tutorial_vqe.py
@@ -120,7 +120,7 @@ print('Hamiltonian is ', h)
 # Implementing the VQE algorithm
 # ------------------------------
 #
-# PennyLane contains the :class:`~.VQECost` class, specifically
+# PennyLane contains the :class:`~.ExpvalCost` class, specifically
 # built to implement the VQE algorithm. We begin by defining the device, in this case a simple
 # qubit simulator:
 
@@ -163,13 +163,13 @@ def circuit(params, wires):
 #     Hartree-Fock state of the hydrogen molecule described with a `minimal basis
 #     <https://en.wikipedia.org/wiki/Basis_set_(chemistry)#Minimal_basis_sets>`__.
 #
-# The cost function for optimizing the circuit can be created using the :class:`~.VQECost`
+# The cost function for optimizing the circuit can be created using the :class:`~.ExpvalCost`
 # class, which is tailored for VQE optimization. It requires specifying the
 # circuit, target Hamiltonian, and the device, and returns a cost function that can
 # be evaluated with the circuit parameters:
 
 
-cost_fn = qml.VQECost(circuit, h, dev)
+cost_fn = qml.ExpvalCost(circuit, h, dev)
 
 
 ##############################################################################

--- a/demonstrations/tutorial_vqe_parallel.py
+++ b/demonstrations/tutorial_vqe_parallel.py
@@ -171,15 +171,15 @@ params = np.load("vqe_parallel/RY_params.npy")
 
 ##############################################################################
 # Finally, the energies as functions of rotation angle can be given using
-# :class:`~.pennylane.VQECost`.
+# :class:`~.pennylane.ExpvalCost`.
 
-energies = [qml.VQECost(circuit, h, devs) for h in hamiltonians]
+energies = [qml.ExpvalCost(circuit, h, devs) for h in hamiltonians]
 
 ##############################################################################
 # Calculating the potential energy surface
 # ----------------------------------------
 #
-# :class:`~.pennylane.VQECost` returns a :class:`~.pennylane.QNodeCollection` which can be
+# :class:`~.pennylane.ExpvalCost` returns a :class:`~.pennylane.QNodeCollection` which can be
 # evaluated using the input parameters to the ansatz circuit. The
 # :class:`~.pennylane.QNodeCollection` can be evaluated asynchronously by passing the keyword
 # argument ``parallel=True``. When ``parallel=False`` (the default behaviour), the QNodes are

--- a/demonstrations/tutorial_vqe_qng.py
+++ b/demonstrations/tutorial_vqe_qng.py
@@ -55,7 +55,7 @@ def circuit(params, wires=0):
 
 
 ##############################################################################
-# We then define our cost function using the ``VQECost`` class, which supports the computation of
+# We then define our cost function using the ``ExpvalCost`` class, which supports the computation of
 # block-diagonal or diagonal approximations to the Fubini-Study metric tensor :ref:`[1]`. This tensor is a
 # crucial component for optimizing with quantum natural gradients.
 
@@ -63,7 +63,7 @@ coeffs = [1, 1]
 obs = [qml.PauliX(0), qml.PauliZ(0)]
 
 H = qml.Hamiltonian(coeffs, obs)
-cost_fn = qml.VQECost(circuit, H, dev)
+cost_fn = qml.ExpvalCost(circuit, H, dev)
 
 ##############################################################################
 # To analyze the performance of quantum natural gradient on VQE calculations,
@@ -295,9 +295,9 @@ def ansatz(params, wires=[0, 1, 2, 3]):
 ##############################################################################
 # Note that the qubit register has been initialized to |1100⟩, which encodes for
 # the Hartree-Fock state of the hydrogen molecule described in the minimal basis.
-# Again, we define the cost function using the ``VQECost`` class.
+# Again, we define the cost function using the ``ExpvalCost`` class.
 
-cost = qml.VQECost(ansatz, hamiltonian, dev)
+cost = qml.ExpvalCost(ansatz, hamiltonian, dev)
 
 ##############################################################################
 # For this problem, we can compute the exact value of the

--- a/demonstrations/tutorial_vqe_uccsd_obs.py
+++ b/demonstrations/tutorial_vqe_uccsd_obs.py
@@ -144,7 +144,7 @@ print(S2)
 # Implementing VQE with the UCCSD ansatz
 # --------------------------------------
 #
-# PennyLane contains the :class:`~.pennylane.VQECost` class to implement the VQE algorithm.
+# PennyLane contains the :class:`~.pennylane.ExpvalCost` class to implement the VQE algorithm.
 # We begin by defining the device, in this case a qubit simulator:
 
 dev = qml.device("default.qubit", wires=qubits)
@@ -244,17 +244,17 @@ print(hf_state)
 ansatz = partial(UCCSD, init_state=hf_state, s_wires=s_wires, d_wires=d_wires)
 
 ##############################################################################
-# Next, we use the PennyLane class :class:`~.pennylane.VQECost` to define the cost function.
+# Next, we use the PennyLane class :class:`~.pennylane.ExpvalCost` to define the cost function.
 # This requires specifying the circuit, target Hamiltonian, and the device. It returns
 # a cost function that can be evaluated with the circuit parameters:
 
-cost_fn = qml.VQECost(ansatz, H, dev)
+cost_fn = qml.ExpvalCost(ansatz, H, dev)
 
 ##############################################################################
 # As a reminder, we also built the total spin operator :math:`\hat{S}^2` for which
 # we can now define a function to compute its expectation value:
 
-S2_exp_value = qml.VQECost(ansatz, S2, dev)
+S2_exp_value = qml.ExpvalCost(ansatz, S2, dev)
 
 ##############################################################################
 # The total spin :math:`S` of the trial state can be obtained from the
@@ -343,8 +343,8 @@ hf_state = qchem.hf_state(electrons, qubits)
 
 ansatz = partial(UCCSD, init_state=hf_state, s_wires=s_wires, d_wires=d_wires)
 
-cost_fn = qml.VQECost(ansatz, H, dev)
-S2_exp_value = qml.VQECost(ansatz, S2, dev)
+cost_fn = qml.ExpvalCost(ansatz, H, dev)
+S2_exp_value = qml.ExpvalCost(ansatz, S2, dev)
 
 ##############################################################################
 # Then, we generate the new set of initial parameters, and proceed with the VQE algorithm to


### PR DESCRIPTION
Based upon https://github.com/PennyLaneAI/pennylane/pull/913, this PR renames `VQECost` to `ExpvalCost`.