### PR TITLE
Corrects a typo in the definition of hafnian

### DIFF
--- a/demonstrations/tutorial_gbs.py
+++ b/demonstrations/tutorial_gbs.py
@@ -226,9 +226,9 @@ for i in measure_states:
 #
 #     The hafnian of a matrix is defined by
 #
-#     .. math:: \text{Haf}(A) = \sum_{\sigma \in S_{2N}}\prod_{i=1}^N A_{\sigma(2i-1)\sigma(2i)},
+#     .. math:: \text{Haf}(A) = \sum_{\sigma \in \text{PMP}_{2N}}\prod_{i=1}^N A_{\sigma(2i-1)\sigma(2i)},
 #
-#     where :math:`S_{2N}` is the set of all perfect matching permutations of :math:`2N` elements. In graph theory, the
+#     where :math:`\text{PMP}_{2N}` is the set of all perfect matching permutations of :math:`2N` elements. In graph theory, the
 #     hafnian calculates the number of perfect `matchings
 #     <https://en.wikipedia.org/wiki/Matching_(graph_theory)>`_ in a graph with
 #     adjacency matrix :math:`A`.

--- a/demonstrations/tutorial_gbs.py
+++ b/demonstrations/tutorial_gbs.py
@@ -226,7 +226,7 @@ for i in measure_states:
 #
 #     The hafnian of a matrix is defined by
 #
-#     .. math:: \text{Haf}(A) = \frac{1}{n!2^n}\sum_{\sigma=S_{2N}}\prod_{i=1}^N A_{\sigma(2i-1)\sigma(2i)},
+#     .. math:: \text{Haf}(A) = \sum_{\sigma \in S_{2N}}\prod_{i=1}^N A_{\sigma(2i-1)\sigma(2i)},
 #
 #     where :math:`S_{2N}` is the set of all perfect matching permutations of :math:`2N` elements. In graph theory, the
 #     hafnian calculates the number of perfect `matchings


### PR DESCRIPTION
Minor typo is fixed confusing perfect matching permutations with the set of all permutations.

The hafnian can be defined in two equivalent ways:

![image](https://user-images.githubusercontent.com/991946/101250899-b661a880-36eb-11eb-8dd4-bd1ca6b46e6e.png)


In the current version in `master` we are using the prefactor from the first definition but the summation from the second.