### PR TITLE
Use PennyLane-Qchem 0.13.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,9 @@ jobs:
       - restore_cache:
           keys:
             # when lock file changes, use increasingly general patterns to restore cache
-            - pip-v21-{{ .Branch }}-{{ checksum "requirements.txt" }}
-            - pip-v21-{{ .Branch }}-
-            - pip-v21-
+            - pip-v20-{{ .Branch }}-{{ checksum "requirements.txt" }}
+            - pip-v20-{{ .Branch }}-
+            - pip-v20-
 
       - run:
           name: Install dependencies
@@ -35,13 +35,13 @@ jobs:
       - save_cache:
           paths:
             - venv
-          key: pip-v21-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: pip-v20-{{ .Branch }}-{{ checksum "requirements.txt" }}
 
       - restore_cache:
           keys:
-            - gallery-v13-{{ .Branch }}-{{ .Revision }}
-            - gallery-v13-{{ .Branch }}-
-            - gallery-v13-
+            - gallery-v12-{{ .Branch }}-{{ .Revision }}
+            - gallery-v12-{{ .Branch }}-
+            - gallery-v12-
 
       - run:
           name: Build tutorials
@@ -57,7 +57,7 @@ jobs:
       - save_cache:
           paths:
             - ./demos
-          key: gallery-v13-{{ .Branch }}-{{ .Revision }}
+          key: gallery-v12-{{ .Branch }}-{{ .Revision }}
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,9 @@ jobs:
       - restore_cache:
           keys:
             # when lock file changes, use increasingly general patterns to restore cache
-            - pip-v20-{{ .Branch }}-{{ checksum "requirements.txt" }}
-            - pip-v20-{{ .Branch }}-
-            - pip-v20-
+            - pip-v21-{{ .Branch }}-{{ checksum "requirements.txt" }}
+            - pip-v21-{{ .Branch }}-
+            - pip-v21-
 
       - run:
           name: Install dependencies
@@ -35,13 +35,13 @@ jobs:
       - save_cache:
           paths:
             - venv
-          key: pip-v20-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: pip-v21-{{ .Branch }}-{{ checksum "requirements.txt" }}
 
       - restore_cache:
           keys:
-            - gallery-v12-{{ .Branch }}-{{ .Revision }}
-            - gallery-v12-{{ .Branch }}-
-            - gallery-v12-
+            - gallery-v13-{{ .Branch }}-{{ .Revision }}
+            - gallery-v13-{{ .Branch }}-
+            - gallery-v13-
 
       - run:
           name: Build tutorials
@@ -57,7 +57,7 @@ jobs:
       - save_cache:
           paths:
             - ./demos
-          key: gallery-v12-{{ .Branch }}-{{ .Revision }}
+          key: gallery-v13-{{ .Branch }}-{{ .Revision }}
 
       - save_cache:
           paths:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pillow==7.1.0
 pip==20.1
 pyscf==1.7.2
 pennylane==0.13
-pennylane-qchem==0.13
+pennylane-qchem==0.13.1
 pennylane-sf==0.12
 pennylane-forest==0.12
 pennylane-cirq==0.13


### PR DESCRIPTION
**Context**

When re-generating demonstrations, several errors are raised when importing PennyLane-Qchem (see [CI logs](https://app.circleci.com/pipelines/github/PennyLaneAI/qml/2183/workflows/54b92d67-c430-4fe9-ae41-1a6bc7ea458d/jobs/2286/tests) for #196).

**Reason**

The CI environment pulls **OpenFermion 1.0** with **PennyLane-Qchem 0.13.0**. As PennyLane-Qchem 0.13.0 is only compatible with OpenFermion version <1.0, several imports fail.

**Change**

Update to use PennyLane-Qchem 0.13.1 on `master`.