### PR TITLE
Fix qml.qnn import

### DIFF
--- a/demonstrations/tutorial_qnn_module_tf.py
+++ b/demonstrations/tutorial_qnn_module_tf.py
@@ -81,6 +81,7 @@ plt.show()
 # operations from the :doc:`templates <introduction/templates>` module.
 
 import pennylane as qml
+import pennylane.qnn
 
 n_qubits = 2
 dev = qml.device("default.qubit", wires=n_qubits)

--- a/demonstrations/tutorial_qnn_module_torch.py
+++ b/demonstrations/tutorial_qnn_module_torch.py
@@ -79,6 +79,7 @@ plt.show()
 # operations from the :doc:`templates <introduction/templates>` module.
 
 import pennylane as qml
+import pennylane.qnn
 
 n_qubits = 2
 dev = qml.device("default.qubit", wires=n_qubits)


### PR DESCRIPTION
Fixes demos due to PR https://github.com/PennyLaneAI/pennylane/pull/1162

Note that some [community demos](https://pennylane.ai/qml/demos_community.html) uses `KerasLayer` - what do we think about updating them? :thinking: This seems hard to maintain.