### PR TITLE
Fix text rendering error in multiclass demo

### DIFF
--- a/demonstrations/tutorial_multiclass_classification.py
+++ b/demonstrations/tutorial_multiclass_classification.py
@@ -98,10 +98,11 @@ def layer(W):
 # sample belongs to class 1 or not, and so on. The circuit architecture for all
 # nodes are the same. We use the PyTorch interface for the QNodes.
 # Data is embedded in each circuit using amplitude embedding.
+#
 # .. note::
 #     For demonstration purposes we are using a very simple circuit here. 
 #     You may find that other choices, for example more 
-#     elaborate measurements, increase  the power of the classifier.      
+#     elaborate measurements, increase the power of the classifier.      
 
 
 def circuit(weights, feat=None):


### PR DESCRIPTION
A "note" box wasn't rendering correctly

Before:
![image](https://user-images.githubusercontent.com/7213358/112541059-50c42580-8d89-11eb-8c9d-40eebbdf7fe9.png)

After:
![image](https://user-images.githubusercontent.com/7213358/112543548-4a837880-8d8c-11eb-92f4-a62dc130f107.png)
