### PR TITLE
Update networkx version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,9 @@ jobs:
       - restore_cache:
           keys:
             # when lock file changes, use increasingly general patterns to restore cache
-            - pip-v22f-{{ .Branch }}-{{ checksum "requirements.txt" }}
-            - pip-v22f-{{ .Branch }}-
-            - pip-v22f-
+            - pip-v23a-{{ .Branch }}-{{ checksum "requirements.txt" }}
+            - pip-v23a-{{ .Branch }}-
+            - pip-v23a-
 
       - run:
           name: Install dependencies
@@ -35,13 +35,13 @@ jobs:
       - save_cache:
           paths:
             - venv
-          key: pip-v22f-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: pip-v23a-{{ .Branch }}-{{ checksum "requirements.txt" }}
 
       - restore_cache:
           keys:
-            - gallery-v14-{{ .Branch }}-{{ .Revision }}
-            - gallery-v14-{{ .Branch }}-
-            - gallery-v14-
+            - gallery-v23a-{{ .Branch }}-{{ .Revision }}
+            - gallery-v23a-{{ .Branch }}-
+            - gallery-v23a-
 
       - run:
           name: Build tutorials
@@ -57,7 +57,7 @@ jobs:
       - save_cache:
           paths:
             - ./demos
-          key: gallery-v14-{{ .Branch }}-{{ .Revision }}
+          key: gallery-v23a-{{ .Branch }}-{{ .Revision }}
 
       - save_cache:
           paths:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 appdirs==1.4.4
 autograd==1.3
 numpy==1.18.5
-networkx==2.4
+networkx==2.5.1
 nlopt==2.6.2
 semantic_version==2.6
 strawberryfields==0.15


### PR DESCRIPTION
The build pipeline on the `dev` branch is currently failing for some demos due to  the error 
```
networkx.exception.NetworkXError: random_state_index is incorrect
```

It looks like this was a known issue in a recent release and has been fixed in version `2.5.1` (see [here](https://github.com/networkx/networkx/issues/4722) and [here](https://github.com/networkx/networkx/issues/4718)). The `qml` repo specifies `networkx==2.4` so we can try updating this to see if it helps (and hopefully it will not cause other issues in the meantime).