### PR TITLE
Pin docutils to version v0.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 appdirs==1.4.4
 autograd==1.3
 numpy==1.18.5
-networkx==2.4
+networkx==2.5.1
 nlopt==2.6.2
 semantic_version==2.6
 strawberryfields==0.15
@@ -20,6 +20,7 @@ qulacs==0.1.10.1
 pennylane-qulacs==0.14.0
 pyquil==2.21
 scikit-learn==0.23.2
+docutils==0.16
 sphinx==1.8.5
 sphinx-sitemap
 sphinx_gallery==0.7


### PR DESCRIPTION
[Docutils version 0.17](https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-17-2021-04-03), released on April 3rd, contains a new HTML5 writer that uses HTML5 semantic tags (`<main>`, `<section>`, `<header>`, `<footer>`, `<aside>`, `<figure>`, and `<figcaption>`) rather than `<div>`. This breaks the CSS on the website.

This PR pins docutils to version 0.16.