### PR TITLE
Revert "Fix qnn module tutorial for TorchLayer (#247)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,9 @@ jobs:
       - restore_cache:
           keys:
             # when lock file changes, use increasingly general patterns to restore cache
-            - pip-v24a-{{ .Branch }}-{{ checksum "requirements.txt" }}
-            - pip-v24a-{{ .Branch }}-
-            - pip-v24a-
+            - pip-v24b-{{ .Branch }}-{{ checksum "requirements.txt" }}
+            - pip-v24b-{{ .Branch }}-
+            - pip-v24b-
 
       - run:
           name: Install dependencies
@@ -35,7 +35,7 @@ jobs:
       - save_cache:
           paths:
             - venv
-          key: pip-v24a-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: pip-v24b-{{ .Branch }}-{{ checksum "requirements.txt" }}
 
       - restore_cache:
           keys:

--- a/demonstrations/tutorial_qnn_module_torch.py
+++ b/demonstrations/tutorial_qnn_module_torch.py
@@ -10,7 +10,7 @@ Turning quantum nodes into Torch Layers
 
    tutorial_qnn_module_tf Turning quantum nodes into Keras Layers
 
-*Author: PennyLane dev team. Posted: 2 Nov 2020. Last updated: 14 Apr 2021.*
+*Author: PennyLane dev team. Posted: 2 Nov 2020. Last updated: 28 Jan 2021.*
 
 Creating neural networks in `PyTorch <https://pytorch.org/>`__ is easy using the
 `nn module <https://pytorch.org/docs/stable/nn.html>`__. Models are constructed from elementary
@@ -85,15 +85,8 @@ dev = qml.device("default.qubit", wires=n_qubits)
 
 @qml.qnode(dev)
 def qnode(inputs, weights):
-    # Embedding
-    qml.RX(inputs[0], wires=0)
-    qml.RX(inputs[1], wires=1)
-
-    # Layers
-    for weights_layer in weights:
-        qml.RX(weights_layer[0], wires=0)
-        qml.RX(weights_layer[1], wires=1)
-        qml.CNOT(wires=[0, 1])
+    qml.templates.AngleEmbedding(inputs, wires=range(n_qubits))
+    qml.templates.BasicEntanglerLayers(weights, wires=range(n_qubits))
     return [qml.expval(qml.PauliZ(wires=i)) for i in range(n_qubits)]
 
 ###############################################################################
@@ -117,8 +110,8 @@ weight_shapes = {"weights": (n_layers, n_qubits)}
 
 ###############################################################################
 # In our example, the ``weights`` argument of the QNode is trainable and has shape given by
-# ``(n_layers, n_qubits)``. These weights determine the angles for blocks of rotation gates in the
-# circuit.
+# ``(n_layers, n_qubits)``, which is passed to
+# :func:`~pennylane.templates.layers.BasicEntanglerLayers`.
 #
 # Now that ``weight_shapes`` is defined, it is easy to then convert the QNode:
 


### PR DESCRIPTION
This reverts commit 1866e7e080d631d77c08f4f8f47d7b1b27cecf9a from PR https://github.com/PennyLaneAI/qml/pull/247.

We can revert this fix because the root bug has been squashed in https://github.com/PennyLaneAI/pennylane/pull/1223 (thanks @josh146!).