### PR TITLE
allow for arbitrary number of layers in qaoa example

### DIFF
--- a/demonstrations/tutorial_qaoa_maxcut.py
+++ b/demonstrations/tutorial_qaoa_maxcut.py
@@ -242,7 +242,7 @@ def qaoa_maxcut(n_layers=1):
     print("\np={:d}".format(n_layers))
 
     # initialize the parameters near zero
-    init_params = 0.01 * np.random.rand(2, 2)
+    init_params = 0.01 * np.random.rand(2, n_layers)
 
     # minimize the negative of the objective function
     def objective(params):


### PR DESCRIPTION
**Title:** Allow QAOA maxcut example to use more than 2 layers

**Summary:**

The initial parameters in the original example are defined as `init_params = 0.01 * np.random.rand(2, 2)` which has fixed size and only works for `p=1,2`. This PR replaces it with `init_params = 0.01 * np.random.rand(2, n_layers)`

**Relevant references:**

None

**Possible Drawbacks:**

None

**Related GitHub Issues:**

None
