### PR TITLE
Fixed typos in qubit rotation tutorial

### DIFF
--- a/demonstrations/tutorial_qubit_rotation.py
+++ b/demonstrations/tutorial_qubit_rotation.py
@@ -117,7 +117,7 @@ from pennylane import numpy as np
 # .. admonition:: Definition
 #     :class: defn
 #
-#     Any computational object that can apply quantum operations, and return an measurement value
+#     Any computational object that can apply quantum operations and return a measurement value
 #     is called a quantum **device**.
 #
 #     In PennyLane, a device could be a hardware device (such as the IBM QX4, via the


### PR DESCRIPTION
**Title:** Fixed typos in qubit rotation tutorial

**Summary:**
1. 'a measurement' instead of 'an measurement'
2. a compound predicate should not have a separating comma

**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**
