### PR TITLE
Use adjoint method in kernels demo

### DIFF
--- a/demonstrations/tutorial_kernel_based_training.py
+++ b/demonstrations/tutorial_kernel_based_training.py
@@ -258,7 +258,7 @@ projector[0, 0] = 1
 def kernel(x1, x2):
     """The quantum kernel."""
     AngleEmbedding(x1, wires=range(n_qubits))
-    qml.inv(AngleEmbedding(x2, wires=range(n_qubits)))
+    qml.adjoint(AngleEmbedding)(x2, wires=range(n_qubits))
     return qml.expval(qml.Hermitian(projector, wires=range(n_qubits)))
 
 


### PR DESCRIPTION
**Summary:**

Since we are moving to the `adjoint` method to invert an operation, this PR implements the change in the kernels demo, which may be an important reference for users of how to implement kernels in PennyLane.

The PR is made against master, since it uses functionality of the latest release.