### PR TITLE
Made sure to keep track of running best_cost

### DIFF
--- a/demonstrations/tutorial_state_preparation.py
+++ b/demonstrations/tutorial_state_preparation.py
@@ -179,6 +179,7 @@ for n in range(steps):
 
     # keeps track of best parameters
     if loss < best_cost:
+        best_cost = loss
         best_params = params
 
     # Keep track of progress every 10 steps


### PR DESCRIPTION
**Title:** Made sure to keep track of running best_cost (the current code forgets to update it)

**Summary:**

This ensures that our computed output_bloch_v is truly the best one encountered in gradient descent, instead of one computed by just any parameters that result in a cost less than our very first initial cost.

**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**
