### PR TITLE
Add note about `qsimcirq` warning

### DIFF
--- a/demonstrations/qsim_beyond_classical.py
+++ b/demonstrations/qsim_beyond_classical.py
@@ -393,6 +393,13 @@ def fidelity_xeb(samples, probs):
 # their correponding bitstrings, since we need the samples to be in the
 # computational basis.
 #
+# .. note::
+#
+#     Every time the previously defined circuit is run without any intermediate
+#     measurements, using the ``qsim`` device, a warning will be printed. More
+#     information about this warning can be found in the `Measurement sampling
+#     section of the qsimcirq guide <https://quantumai.google/qsim/tutorials/qsimcirq#measurement_sampling>`__.
+#
 
 seed = np.random.randint(0, 42424242)
 probs = circuit(seed=seed, return_probs=True)

--- a/demonstrations/qsim_beyond_classical.py
+++ b/demonstrations/qsim_beyond_classical.py
@@ -395,9 +395,9 @@ def fidelity_xeb(samples, probs):
 #
 # .. note::
 #
-#     Every time the previously defined circuit is run without any intermediate
-#     measurements, using the ``qsim`` device, a warning will be printed. More
-#     information about this warning can be found in the `Measurement sampling
+#     Every time the previously defined circuit is run using the ``qsim`` device, ``qsimcirq``
+#     will print a warning message because the circuit has no intermediate measurements.
+#     More information about this warning can be found in the `Measurement sampling
 #     section of the qsimcirq guide <https://quantumai.google/qsim/tutorials/qsimcirq#measurement_sampling>`__.
 #
 


### PR DESCRIPTION
Adds a note related to the `qsimcirq` warning printed in accordance with the getting-started guide [here](https://quantumai.google/qsim/tutorials/qsimcirq#measurement_sampling).

Note that it's not possible to filter out this warning in any straight-forward way, since it's simply a print statement in the source code. It would technically be possibly to bypass any prints made when calling the `run` method, as in the following example by wrapping it with a `stopPrint` function (found [here](https://stackoverflow.com/questions/42952623/stop-python-module-from-printing)), although this would probably be a slightly hacky solution.

```python
import sys
import os
def stopPrint(func, *args, **kwargs):
    with open(os.devnull,"w") as devNull:
        original = sys.stdout
        sys.stdout = devNull
        res = func(*args, **kwargs)
        sys.stdout = original
    return res
```