### PR TITLE
Update `tutorial_noisy_circuits.py`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,9 @@ jobs:
       - restore_cache:
           keys:
             # when lock file changes, use increasingly general patterns to restore cache
-            - pip-v27c-{{ .Branch }}-{{ checksum "requirements.txt" }}
-            - pip-v27c-{{ .Branch }}-
-            - pip-v27c-
+            - pip-v28c-{{ .Branch }}-{{ checksum "requirements.txt" }}
+            - pip-v28c-{{ .Branch }}-
+            - pip-v28c-
 
       - run:
           name: Install dependencies
@@ -36,13 +36,13 @@ jobs:
       - save_cache:
           paths:
             - venv
-          key: pip-v27c-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: pip-v28c-{{ .Branch }}-{{ checksum "requirements.txt" }}
 
       - restore_cache:
           keys:
-            - gallery-v27a-{{ .Branch }}-{{ .Revision }}
-            - gallery-v27a-{{ .Branch }}-
-            - gallery-v27a-
+            - gallery-v28a-{{ .Branch }}-{{ .Revision }}
+            - gallery-v28a-{{ .Branch }}-
+            - gallery-v28a-
 
       - run:
           name: Build tutorials
@@ -58,7 +58,7 @@ jobs:
       - save_cache:
           paths:
             - ./demos
-          key: gallery-v27a-{{ .Branch }}-{{ .Revision }}
+          key: gallery-v28a-{{ .Branch }}-{{ .Revision }}
 
       - save_cache:
           paths:

--- a/demonstrations/tutorial_noisy_circuits.py
+++ b/demonstrations/tutorial_noisy_circuits.py
@@ -248,7 +248,7 @@ def damping_circuit(x):
 
 
 def cost(x, target):
-    return (damping_circuit(x) - target[0])**2
+    return (damping_circuit(x) - target)**2
 
 ######################################################################
 # All that remains is to optimize the parameter. We use a straightforward gradient descent
@@ -265,7 +265,7 @@ for i in range(steps):
         print(f"Step: {i}    Cost: {cost_val}")
 
 print(f"QNode output after optimization = {damping_circuit(x):.4f}")
-print(f"Experimental expectation value = {ev[0]}")
+print(f"Experimental expectation value = {ev}")
 print(f"Optimized noise parameter p = {sigmoid(x.take(0)):.4f}")
 
 ######################################################################

--- a/demonstrations/tutorial_noisy_circuits.py
+++ b/demonstrations/tutorial_noisy_circuits.py
@@ -229,7 +229,7 @@ for p in ps:
 # ensure that the trainable parameters give rise to a valid channel parameter, i.e., a number
 # between 0 and 1.
 #
-ev = np.tensor([0.7781], requires_grad=False)  # observed expectation value
+ev = np.tensor(0.7781, requires_grad=False)  # observed expectation value
 
 def sigmoid(x):
     return 1/(1+np.exp(-x))
@@ -257,7 +257,7 @@ def cost(x, target):
 
 opt = qml.GradientDescentOptimizer(stepsize=10)
 steps = 35
-x = np.tensor([0.0], requires_grad=True)
+x = np.tensor(0.0, requires_grad=True)
 
 for i in range(steps):
     (x, ev), cost_val = opt.step_and_cost(cost, x, ev)


### PR DESCRIPTION
Updates the `tutorial_noisy_circuits.py` demonstration to use 0-dimensional PennyLane tensors instead of 1-dimensional ones.