### PR TITLE
Pin `numba` and increase cache number

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,9 @@ jobs:
       - restore_cache:
           keys:
             # when lock file changes, use increasingly general patterns to restore cache
-            - pip-v28c-{{ .Branch }}-{{ checksum "requirements.txt" }}
-            - pip-v28c-{{ .Branch }}-
-            - pip-v28c-
+            - pip-v29c-{{ .Branch }}-{{ checksum "requirements.txt" }}
+            - pip-v29c-{{ .Branch }}-
+            - pip-v29c-
 
       - run:
           name: Install dependencies
@@ -36,13 +36,13 @@ jobs:
       - save_cache:
           paths:
             - venv
-          key: pip-v28c-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: pip-v29c-{{ .Branch }}-{{ checksum "requirements.txt" }}
 
       - restore_cache:
           keys:
-            - gallery-v28a-{{ .Branch }}-{{ .Revision }}
-            - gallery-v28a-{{ .Branch }}-
-            - gallery-v28a-
+            - gallery-v29a-{{ .Branch }}-{{ .Revision }}
+            - gallery-v29a-{{ .Branch }}-
+            - gallery-v29a-
 
       - run:
           name: Build tutorials
@@ -58,7 +58,7 @@ jobs:
       - save_cache:
           paths:
             - ./demos
-          key: gallery-v28a-{{ .Branch }}-{{ .Revision }}
+          key: gallery-v29a-{{ .Branch }}-{{ .Revision }}
 
       - save_cache:
           paths:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 --find-links https://download.pytorch.org/whl/torch_stable.html
 appdirs==1.4.4
 autograd==1.3
-numpy==1.20
+numpy==1.18.5
+numba==0.53.1
 networkx==2.5.1
 nlopt==2.6.2
 semantic_version==2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 --find-links https://download.pytorch.org/whl/torch_stable.html
 appdirs==1.4.4
 autograd==1.3
-numpy==1.18.5
+numpy==1.20
 networkx==2.5.1
 nlopt==2.6.2
 semantic_version==2.6


### PR DESCRIPTION
The check [when merging into `master` failed on the dependencies](https://github.com/PennyLaneAI/qml/commit/54722c5f22246454ca13d2a22cf47dba3cb21e4f). This PR increases the cache number such that dependencies are installed fresh.

The newest version of `numba` seems to cause import issues:
https://app.circleci.com/pipelines/github/PennyLaneAI/qml/3854/workflows/36affa59-2f4d-4ec3-9208-40dd64abe63d/jobs/4087/steps?invite=true#step-106-1478

Therefore, numba is pinned.