### PR TITLE
Specify `diff_method=None` when using `qml.sample` with `default.qubit.jax`

### DIFF
--- a/demonstrations/tutorial_jax_transformations.py
+++ b/demonstrations/tutorial_jax_transformations.py
@@ -272,7 +272,7 @@ def circuit(key, param):
     dev = qml.device("default.qubit.jax", wires=2, shots=10, prng_key=key)
 
     # Now we can create our qnode within the circuit function.
-    @qml.qnode(dev, interface="jax")
+    @qml.qnode(dev, interface="jax", diff_method=None)
     def my_circuit():
         qml.RX(param, wires=0)
         qml.CNOT(wires=[0, 1])


### PR DESCRIPTION
**Context**

One of the demonstrations is failing here:
https://github.com/PennyLaneAI/qml/runs/3609969727?check_suite_focus=true#step:8:2360.

**Solution**

The direct cause is addressed in the following PR: https://github.com/PennyLaneAI/pennylane/pull/1658.

However, even with those changes, an error would arise due to changes in https://github.com/PennyLaneAI/pennylane/pull/1588, an error is raised now when we use `qml.sample` with `default.qubit.jax` and the default diff method (`'best'`).

The simpler workaround, is to specify `diff_method=None`, which gives the instruction that no differentiation of the QNode will happen.