### PR TITLE
Added a note to Quantum Volume Demo

### DIFF
--- a/demonstrations/quantum_volume.py
+++ b/demonstrations/quantum_volume.py
@@ -539,9 +539,6 @@ print(f"Heavy outputs are {heavy_outputs}")
 #    In the time since the original release of this demo, the Ourense device is
 #    no longer available from IBM Q. However, we leave the original results for
 #    expository purposes, and note that the methods are applicable in general.
-#
-# .. note::
-#
 #    Users can get a list of available IBM Q backends by importing IBM Q,
 #    specifying their provider and then calling: ``provider.backends()``
 #

--- a/demonstrations/quantum_volume.py
+++ b/demonstrations/quantum_volume.py
@@ -540,6 +540,11 @@ print(f"Heavy outputs are {heavy_outputs}")
 #    no longer available from IBM Q. However, we leave the original results for
 #    expository purposes, and note that the methods are applicable in general.
 #
+# .. note::
+#
+#    Users can get a list of available IBM Q backends by importing IBM Q,
+#    specifying their provider and then calling: ``provider.backends()``
+#
 dev_ourense = qml.device("qiskit.ibmq", wires=5, backend="ibmq_ourense")
 
 ##############################################################################


### PR DESCRIPTION
Added a note to teach users how to query a list of available IBM Q backends 

Links: 
https://pennylane.ai/qml/demos/quantum_volume.html
