### PR TITLE
Add dev version of lightning as dependency to dev branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ git+https://github.com/PennyLaneAI/pennylane-sf.git
 git+https://github.com/PennyLaneAI/pennylane-forest.git
 git+https://github.com/PennyLaneAI/pennylane-cirq.git
 git+https://github.com/PennyLaneAI/pennylane-qiskit.git
-pennylane-lightning>=0.18
+git+https://github.com/PennyLaneAI/pennylane-lightning.git
 qulacs==0.1.10.1
 git+https://github.com/PennyLaneAI/pennylane-qulacs.git
 pyquil==2.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ git+https://github.com/PennyLaneAI/pennylane-sf.git
 git+https://github.com/PennyLaneAI/pennylane-forest.git
 git+https://github.com/PennyLaneAI/pennylane-cirq.git
 git+https://github.com/PennyLaneAI/pennylane-qiskit.git
+pennylane-lightning>=0.18
 qulacs==0.1.10.1
 git+https://github.com/PennyLaneAI/pennylane-qulacs.git
 pyquil==2.21


### PR DESCRIPTION
Adds the development branch of PL lightning as a dependency to the QML repo.

PL-lightning will be a dependency of the 0.18 version of PL, so we mirror the dependency here to confirm that no issues are caused in the QML repo demos.

See also https://github.com/PennyLaneAI/qml/pull/337 for the `master` branch version.