### PR TITLE
Check if repo can build with lightning included

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pennylane-sf==0.16.0
 pennylane-forest==0.17.0
 pennylane-cirq==0.17.0
 pennylane-qiskit==0.17.0
+pennylane-lightning==0.18.0
 qulacs==0.1.10.1
 pennylane-qulacs==0.16.0
 pyquil==2.21


### PR DESCRIPTION
This PR checks if the QML repo builds successfully when lightning.qubit is included as a dependency.

In 0.18.0 of PL, lightning.qubit will be already included transitively through pennylane and so we can close this PR. I.e., the purpose of this PR is to provide a quick check that tests pass before the 0.18 release.