### PR TITLE
Pin `pyparsing` (`master` branch)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ torch==1.9.0+cpu
 torchvision==0.10.0+cpu
 dask[delayed]==2.10.1
 scikit-learn==0.23.2
+pyparsing==2.4.7
 matplotlib==3.3.3
 noisyopt==0.2.2
 Jinja2==2.11.3


### PR DESCRIPTION
**Context**

Certain Latex symbols raise an error when rendered using Matplotlib. This seems to be related to a dependency, `pyparsing`:

```python
import matplotlib.pyplot as plt

plt.ylabel(r"$\langle O_i$")
plt.legend()
plt.show()
```

The issue affects the demonstration on classical shadows and makes both the [`build-master`](https://github.com/PennyLaneAI/qml/runs/3998201143?check_suite_focus=true#step:8:2386) and [`build-dev`](https://github.com/PennyLaneAI/qml/runs/3986428998?check_suite_focus=true#step:8:2398) CI checks to fail.

**Solutions**

* Pinning to `pyparsing==2.4.7` (from [latest working run](https://github.com/PennyLaneAI/qml/runs/3916347221?check_suite_focus=true) of the checks)
* Enclosing the problematic expressions with `{}` (thanks to Luke for finding this!):
```python
import matplotlib.pyplot as plt

plt.ylabel(r"${\langle} O_i$")
plt.legend()
plt.show()
```

**Changes**

This PR implements pinning of `pyparsing` in case similar issues would arise with the package for other/further demonstrations.

**Long term fixes**

Long term fixes include a fix to the relevant [issue open in the `pyparsing` repository](https://github.com/pyparsing/pyparsing/issues/318) or a fix in `matplotlib` (see [relevant PR](https://github.com/matplotlib/matplotlib/pull/21454) here).

Once one of them is live, we should revisit the pinning of `pyparsing`/`matplotlib`.