### PR TITLE
replaced pad --> pad_with

### DIFF
--- a/demonstrations/tutorial_multiclass_classification.py
+++ b/demonstrations/tutorial_multiclass_classification.py
@@ -106,7 +106,7 @@ def layer(W):
 
 
 def circuit(weights, feat=None):
-    qml.templates.embeddings.AmplitudeEmbedding(feat, range(num_qubits), pad=0.0, normalize=True)
+    qml.templates.embeddings.AmplitudeEmbedding(feat, range(num_qubits), pad_with=0.0, normalize=True)
     for W in weights:
         layer(W)
 


### PR DESCRIPTION
**Title: Update tutorials for upcoming breaking change** 

**Summary:**
replaced pad --> pad_with in this tutorial as it has now been deprecated

**Relevant references:**
https://github.com/PennyLaneAI/pennylane/pull/1805