### PR TITLE
Use `approx='block-diag'` instead of `diag_approx=False`

### DIFF
--- a/demonstrations/tutorial_vqe_qng.py
+++ b/demonstrations/tutorial_vqe_qng.py
@@ -127,7 +127,7 @@ print("Number of iterations = ", n)
 ##############################################################################
 # We then repeat the process for the optimizer employing quantum natural gradients:
 
-opt = qml.QNGOptimizer(stepsize=step_size, diag_approx=False)
+opt = qml.QNGOptimizer(stepsize=step_size, approx="block-diag")
 
 params = init_params
 
@@ -359,7 +359,7 @@ print("Final circuit parameters = \n", params)
 
 ##############################################################################
 # Next, we run the optimizer employing quantum natural gradients.
-opt = qml.QNGOptimizer(step_size, lam=0.001, diag_approx=False)
+opt = qml.QNGOptimizer(step_size, lam=0.001, approx="block-diag")
 
 params = init_params
 prev_energy = cost(params)


### PR DESCRIPTION
Updates the `demonstrations/tutorial_vqe_qng.py` as per the [`QNGOptimizer` deprecation in the development version of PennyLane](https://github.com/PennyLaneAI/pennylane/pull/1834).