### PR TITLE
Pin keras 2.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ sphinx-sitemap
 pypandoc==1.5
 sphinx_gallery==0.9.0
 seaborn==0.10.1
+keras==2.6.0
 tensorflow==2.6.0
 toml==0.10.2
 torch==1.10.0+cpu


### PR DESCRIPTION
Keras 2.7 was just released, however, it appears to be incompatible with TF 2.6.

This PR is meant to replicate https://github.com/PennyLaneAI/pennylane/pull/1846. TF 2.6 would by default pull in Keras 2.7, but there's a compatibility issue between the two.

See https://github.com/PennyLaneAI/qml/runs/4097045949?check_suite_focus=true#step:8:1430 for a log.