### PR TITLE
Explicit `requires_grad` definitions

### DIFF
--- a/demonstrations/quantum_neural_net.py
+++ b/demonstrations/quantum_neural_net.py
@@ -150,7 +150,7 @@ plt.show()
 
 np.random.seed(0)
 num_layers = 4
-var_init = 0.05 * np.random.randn(num_layers, 5)
+var_init = 0.05 * np.random.randn(num_layers, 5, requires_grad=True)
 print(var_init)
 
 ##############################################################################
@@ -172,7 +172,7 @@ opt = AdamOptimizer(0.01, beta1=0.9, beta2=0.999)
 
 var = var_init
 for it in range(500):
-    var, _cost = opt.step_and_cost(lambda v: cost(v, X, Y), var)
+    (var, _, _), _cost = opt.step_and_cost(cost, var, X, Y)
     print("Iter: {:5d} | Cost: {:0.7f} ".format(it, _cost))
 
 

--- a/demonstrations/tutorial_backprop.py
+++ b/demonstrations/tutorial_backprop.py
@@ -83,7 +83,7 @@ def circuit(params):
 # Let's test the variational circuit evaluation with some parameter input:
 
 # initial parameters
-params = np.random.random([6])
+params = np.random.random([6], requires_grad=True)
 
 print("Parameters:", params)
 print("Expectation value:", circuit(params))
@@ -179,7 +179,7 @@ def circuit(params):
 
 # initialize circuit parameters
 param_shape = qml.templates.StronglyEntanglingLayers.shape(n_wires=4, n_layers=15)
-params = np.random.normal(scale=0.1, size=param_shape)
+params = np.random.normal(scale=0.1, size=param_shape, requires_grad=True)
 print(params.size)
 print(circuit(params))
 
@@ -277,8 +277,7 @@ def circuit(params):
 
 # initialize circuit parameters
 param_shape = qml.templates.StronglyEntanglingLayers.shape(n_wires=4, n_layers=15)
-params = np.random.normal(scale=0.1, size=param_shape)
-params = np.array(params, requires_grad=True)
+params = np.random.normal(scale=0.1, size=param_shape, requires_grad=True)
 print(circuit(params))
 
 ##############################################################################
@@ -337,9 +336,8 @@ gradient_backprop = []
 
 for depth in range(0, 21):
     param_shape = qml.templates.StronglyEntanglingLayers.shape(n_wires=4, n_layers=depth)
-    params = np.random.normal(scale=0.1, size=param_shape)
+    params = np.random.normal(scale=0.1, size=param_shape, requires_grad=True)
     num_params = params.size
-    params = np.array(params, requires_grad=True)
 
     # forward pass timing
     # ===================

--- a/demonstrations/tutorial_coherent_vqls.py
+++ b/demonstrations/tutorial_coherent_vqls.py
@@ -407,7 +407,7 @@ opt = qml.GradientDescentOptimizer(eta)
 # We initialize the variational weights with random parameters (with a fixed seed).
 
 np.random.seed(rng_seed)
-w = q_delta * np.random.randn(n_qubits)
+w = q_delta * np.random.randn(n_qubits, requires_grad=True)
 
 ##############################################################################
 # We are ready to perform the optimization loop.

--- a/demonstrations/tutorial_data_reuploading_classifier.py
+++ b/demonstrations/tutorial_data_reuploading_classifier.py
@@ -251,7 +251,7 @@ def density_matrix(state):
 
 label_0 = [[1], [0]]
 label_1 = [[0], [1]]
-state_labels = [label_0, label_1]
+state_labels = np.array([label_0, label_1], requires_grad=False)
 
 
 ##############################################################################
@@ -376,10 +376,10 @@ num_training = 200
 num_test = 2000
 
 Xdata, y_train = circle(num_training)
-X_train = np.hstack((Xdata, np.zeros((Xdata.shape[0], 1))))
+X_train = np.hstack((Xdata, np.zeros((Xdata.shape[0], 1), requires_grad=False)))
 
 Xtest, y_test = circle(num_test)
-X_test = np.hstack((Xtest, np.zeros((Xtest.shape[0], 1))))
+X_test = np.hstack((Xtest, np.zeros((Xtest.shape[0], 1), requires_grad=False)))
 
 
 # Train using Adam optimizer and evaluate the classifier
@@ -391,7 +391,7 @@ batch_size = 32
 opt = AdamOptimizer(learning_rate, beta1=0.9, beta2=0.999)
 
 # initialize random weights
-params = np.random.uniform(size=(num_layers, 3))
+params = np.random.uniform(size=(num_layers, 3), requires_grad=True)
 
 predicted_train, fidel_train = test(params, X_train, y_train, state_labels)
 accuracy_train = accuracy_score(y_train, predicted_train)
@@ -412,7 +412,7 @@ print(
 
 for it in range(epochs):
     for Xbatch, ybatch in iterate_minibatches(X_train, y_train, batch_size=batch_size):
-        params = opt.step(lambda v: cost(v, Xbatch, ybatch, state_labels), params)
+        params, _, _, _ = opt.step(cost, params, Xbatch, ybatch, state_labels)
 
     predicted_train, fidel_train = test(params, X_train, y_train, state_labels)
     accuracy_train = accuracy_score(y_train, predicted_train)

--- a/demonstrations/tutorial_doubly_stochastic.py
+++ b/demonstrations/tutorial_doubly_stochastic.py
@@ -155,7 +155,7 @@ qnode_analytic = qml.QNode(circuit, dev_analytic)
 qnode_stochastic = qml.QNode(circuit, dev_stochastic)
 
 param_shape = StronglyEntanglingLayers.shape(n_layers=num_layers, n_wires=num_wires)
-init_params = np.random.uniform(low=0, high=2*np.pi, size=param_shape)
+init_params = np.random.uniform(low=0, high=2*np.pi, size=param_shape, requires_grad=True)
 
 # Optimizing using exact gradient descent
 

--- a/demonstrations/tutorial_expressivity_fourier_series.py
+++ b/demonstrations/tutorial_expressivity_fourier_series.py
@@ -216,7 +216,7 @@ def target_function(x):
 # 
 
 x = np.linspace(-6, 6, 70, requires_grad=False)
-target_y = np.array([target_function(x_) for x_ in x])
+target_y = np.array([target_function(x_) for x_ in x], requires_grad=False)
 
 plt.plot(x, target_y, c='black')
 plt.scatter(x, target_y, facecolor='white', edgecolor='black')
@@ -365,7 +365,7 @@ for step in range(max_steps):
     y_batch = target_y[batch_index]
 
     # Update the weights by one optimizer step
-    weights = opt.step(lambda w: cost(w, x_batch, y_batch), weights)
+    weights, _, _ = opt.step(cost, weights, x_batch, y_batch)
 
     # Save, and possibly print, the current cost
     c = cost(weights, x, target_y)
@@ -573,7 +573,7 @@ for step in range(max_steps):
     y_batch = target_y[batch_index]
 
     # update the weights by one optimizer step
-    weights = opt.step(lambda w: cost(w, x_batch, y_batch), weights)
+    weights, _, _ = opt.step(cost, weights, x_batch, y_batch)
     
     # save, and possibly print, the current cost
     c = cost(weights, x, target_y)

--- a/demonstrations/tutorial_expressivity_fourier_series.py
+++ b/demonstrations/tutorial_expressivity_fourier_series.py
@@ -303,7 +303,7 @@ def serial_quantum_model(weights, x):
 # 
 
 r = 1 # number of times the encoding gets repeated (here equal to the number of layers)
-weights = 2 * np.pi * np.random.random(size=(r+1, 3)) # some random initial weights
+weights = 2 * np.pi * np.random.random(size=(r+1, 3), requires_grad=True) # some random initial weights
 
 x = np.linspace(-6, 6, 70, requires_grad=False)
 random_quantum_model_y = [serial_quantum_model(weights, x_) for x_ in x]
@@ -532,7 +532,7 @@ def parallel_quantum_model(weights, x):
 # 
 
 trainable_block_layers = 3
-weights = 2 * np.pi * np.random.random(size=(2, trainable_block_layers, r, 3))
+weights = 2 * np.pi * np.random.random(size=(2, trainable_block_layers, r, 3), requires_grad=True)
 
 x = np.linspace(-6, 6, 70, requires_grad=False)
 random_quantum_model_y = [parallel_quantum_model(weights, x_) for x_ in x]

--- a/demonstrations/tutorial_kernels_module.py
+++ b/demonstrations/tutorial_kernels_module.py
@@ -274,7 +274,7 @@ adjoint_ansatz = qml.adjoint(ansatz)
 
 def random_params(num_wires, num_layers):
     """Generate random variational parameters in the shape for the ansatz."""
-    return np.random.uniform(0, 2 * np.pi, (num_layers, 2, num_wires))
+    return np.random.uniform(0, 2 * np.pi, (num_layers, 2, num_wires), requires_grad=True)
 
 
 ##############################################################################
@@ -323,7 +323,7 @@ def kernel(x1, x2, params):
 # variational parameters. At this point we fix the number of layers in the
 # ansatz circuit to :math:`6`.
 
-init_params = random_params(num_wires=5, num_layers=6, requires_grad=True)
+init_params = random_params(num_wires=5, num_layers=6)
 
 ##############################################################################
 # Now we can have a look at the kernel value between the first and the

--- a/demonstrations/tutorial_kernels_module.py
+++ b/demonstrations/tutorial_kernels_module.py
@@ -323,7 +323,7 @@ def kernel(x1, x2, params):
 # variational parameters. At this point we fix the number of layers in the
 # ansatz circuit to :math:`6`.
 
-init_params = random_params(num_wires=5, num_layers=6)
+init_params = random_params(num_wires=5, num_layers=6, requires_grad=True)
 
 ##############################################################################
 # Now we can have a look at the kernel value between the first and the

--- a/demonstrations/tutorial_noisy_circuit_optimization.py
+++ b/demonstrations/tutorial_noisy_circuit_optimization.py
@@ -315,7 +315,7 @@ opt = qml.GradientDescentOptimizer(stepsize=0.4)
 # set the number of steps
 steps = 100
 # set the initial parameter values
-init_params = np.array([0.011, 0.055])
+init_params = np.array([0.011, 0.055], requires_grad=True)
 noisy_circuit_params = init_params
 params = init_params
 

--- a/demonstrations/tutorial_plugins_hybrid.py
+++ b/demonstrations/tutorial_plugins_hybrid.py
@@ -192,7 +192,7 @@ def cost(params):
 # To begin our optimization, let's choose the following small initial values of
 # :math:`\theta` and :math:`\phi`:
 
-init_params = np.array([0.01, 0.01])
+init_params = np.array([0.01, 0.01], requires_grad=True)
 print(cost(init_params))
 
 ##############################################################################

--- a/demonstrations/tutorial_plugins_hybrid.py
+++ b/demonstrations/tutorial_plugins_hybrid.py
@@ -331,7 +331,7 @@ opt = qml.GradientDescentOptimizer(stepsize=0.4)
 # set the number of steps
 steps = 100
 # set the initial parameter values
-params = np.array([0.01, 0.01])
+params = np.array([0.01, 0.01], requires_grad=True)
 
 for i in range(steps):
     # update the circuit parameters

--- a/demonstrations/tutorial_qaoa_maxcut.py
+++ b/demonstrations/tutorial_qaoa_maxcut.py
@@ -239,7 +239,7 @@ def qaoa_maxcut(n_layers=1):
     print("\np={:d}".format(n_layers))
 
     # initialize the parameters near zero
-    init_params = 0.01 * np.random.rand(2, n_layers)
+    init_params = 0.01 * np.random.rand(2, n_layers, requires_grad=True)
 
     # minimize the negative of the objective function
     def objective(params):

--- a/demonstrations/tutorial_quantum_analytic_descent.py
+++ b/demonstrations/tutorial_quantum_analytic_descent.py
@@ -582,7 +582,7 @@ for iter_outer in range(N_iter_outer):
     opt = qml.AdamOptimizer(0.05)
     # Recall that the parameters of the model are relative coordinates.
     # Correspondingly, we initialize at 0, not at parameters.
-    relative_parameters = np.zeros_like(parameters)
+    relative_parameters = np.zeros_like(parameters, requires_grad=True)
     model_log = [mapped_model(relative_parameters)]
     print(f"-Iteration {iter_outer+1}-")
 

--- a/demonstrations/tutorial_quantum_analytic_descent.py
+++ b/demonstrations/tutorial_quantum_analytic_descent.py
@@ -118,7 +118,7 @@ def circuit(parameters):
 num_samples = 50
 
 # Fix a parameter position.
-parameters = np.array([3.3, 0.5])
+parameters = np.array([3.3, 0.5], requires_grad=True)
 
 theta_func = np.linspace(0, 2 * np.pi, num_samples)
 C1 = [circuit(np.array([theta, parameters[1]])) for theta in theta_func]
@@ -327,7 +327,7 @@ def get_model_data(fun, params):
 ###############################################################################
 # Let's test our brand-new function for the circuit from above, at a random parameter position:
 
-parameters = np.random.random(2) * 2 * np.pi
+parameters = np.random.random(2, requires_grad=True) * 2 * np.pi
 print(f"Random parameters (params): {parameters}")
 coeffs = get_model_data(circuit, parameters)
 print(
@@ -494,7 +494,7 @@ def plot_cost_and_model(f, model, params, shift_radius=5 * np.pi / 8, num_points
 
 
 # Get some fresh random parameters and the model coefficients
-parameters = np.random.random(2) * 2 * np.pi
+parameters = np.random.random(2, requires_grad=True) * 2 * np.pi
 coeffs = get_model_data(circuit, parameters)
 
 # Define a mapped model that has the model coefficients fixed.

--- a/demonstrations/tutorial_quantum_metrology.py
+++ b/demonstrations/tutorial_quantum_metrology.py
@@ -279,7 +279,7 @@ def opt_cost(weights, phi=phi, gamma=gamma, J=J, W=W):
 # Seed for reproducible results
 np.random.seed(395)
 weights = np.random.uniform(
-    0, 2 * np.pi, NUM_ANSATZ_PARAMETERS + NUM_MEASUREMENT_PARAMETERS
+    0, 2 * np.pi, NUM_ANSATZ_PARAMETERS + NUM_MEASUREMENT_PARAMETERS, requires_grad=True
 )
 
 opt = qml.AdagradOptimizer(stepsize=0.1)

--- a/demonstrations/tutorial_qubit_rotation.py
+++ b/demonstrations/tutorial_qubit_rotation.py
@@ -334,7 +334,7 @@ def cost(x):
 ################################################################################
 # To begin our optimization, let's choose small initial values of :math:`\phi_1` and :math:`\phi_2`:
 
-init_params = np.array([0.011, 0.012])
+init_params = np.array([0.011, 0.012], requires_grad=True)
 print(cost(init_params))
 
 ################################################################################

--- a/demonstrations/tutorial_vqe_parallel.py
+++ b/demonstrations/tutorial_vqe_parallel.py
@@ -29,7 +29,6 @@ We begin by importing the prerequisite libraries:
 import time
 
 import matplotlib.pyplot as plt
-import numpy as np
 from pennylane import numpy as np
 import pennylane as qml
 from pennylane import qchem

--- a/demonstrations/tutorial_vqe_qng.py
+++ b/demonstrations/tutorial_vqe_qng.py
@@ -77,7 +77,7 @@ def cost_fn(params):
 #
 # To perform a fair comparison, we fix the initial parameters for the two optimizers.
 
-init_params = np.array([3.97507603, 3.00854038])
+init_params = np.array([3.97507603, 3.00854038], requires_grad=True)
 
 
 ##############################################################################
@@ -313,7 +313,7 @@ exact_value = -1.136189454088
 # We now set up our optimizations runs.
 
 np.random.seed(0)
-init_params = np.random.uniform(low=0, high=2 * np.pi, size=12)
+init_params = np.random.uniform(low=0, high=2 * np.pi, size=12, requires_grad=True)
 max_iterations = 500
 step_size = 0.5
 conv_tol = 1e-06

--- a/demonstrations/tutorial_vqls.py
+++ b/demonstrations/tutorial_vqls.py
@@ -380,7 +380,7 @@ def cost_loc(weights):
 # We first initialize the variational weights with random parameters (with a fixed seed).
 
 np.random.seed(rng_seed)
-w = q_delta * np.random.randn(n_qubits)
+w = q_delta * np.random.randn(n_qubits, requires_grad=True)
 
 ##############################################################################
 # To minimize the cost function we use the gradient-descent optimizer.


### PR DESCRIPTION
When creating an array using the NumPy version of PennyLane, currently `requires_grad=True` is set as a default.

Multiple demonstrations make use of this implicit setting. However, using the default implicitly comes with its drawbacks:

* It may hide that trainable parameters need to be marked using the Autograd interface (either by setting the `requires_grad` attribute or by passing the `argnum` argument to `qml.grad`/`qml.jacobian`);
* The `requires_grad=True` default is planned to be changed to `requires_grad=False` in a future release.

This PR updates demonstrations that implicitly depend on marking parameters as trainable.