### PR TITLE
Fix jax demo to work with the latest version of PennyLane

### DIFF
--- a/demonstrations/tutorial_jax_transformations.py
+++ b/demonstrations/tutorial_jax_transformations.py
@@ -272,7 +272,7 @@ def circuit(key, param):
     dev = qml.device("default.qubit.jax", wires=2, shots=10, prng_key=key)
 
     # Now we can create our qnode within the circuit function.
-    @qml.qnode(dev, interface="jax", diff_method=None)
+    @qml.qnode(dev, interface="jax", diff_method="backprop")
     def my_circuit():
         qml.RX(param, wires=0)
         qml.CNOT(wires=[0, 1])

--- a/demonstrations/tutorial_jax_transformations.py
+++ b/demonstrations/tutorial_jax_transformations.py
@@ -272,7 +272,7 @@ def circuit(key, param):
     dev = qml.device("default.qubit.jax", wires=2, shots=10, prng_key=key)
 
     # Now we can create our qnode within the circuit function.
-    @qml.qnode(dev, interface="jax", diff_method="backprop")
+    @qml.qnode(dev, interface="jax")
     def my_circuit():
         qml.RX(param, wires=0)
         qml.CNOT(wires=[0, 1])


### PR DESCRIPTION
The JAX demo uses `diff_method=None` with the JAX JIT, which is not supported on the latest version of PennyLane (setting `diff_method=None` will 'break' the JIT, as the QNode is not expecting backpropagation).

This is fixed by removing this keyword argument.