### PR TITLE
Pin `qiskit==0.32.0` temporarily

### DIFF
--- a/demonstrations/tutorial_ensemble_multi_qpu.py
+++ b/demonstrations/tutorial_ensemble_multi_qpu.py
@@ -62,7 +62,7 @@ y = data["target"]
 # We shuffle the data and then embed the four features into a two-dimensional space for ease of
 # plotting later on. The first two principal components of the data are used.
 
-np.random.seed(1967)
+np.random.seed(1968)
 x, y = zip(*np.random.permutation(list(zip(x, y))))
 
 pca = sklearn.decomposition.PCA(n_components=n_features)

--- a/demonstrations/tutorial_error_mitigation.py
+++ b/demonstrations/tutorial_error_mitigation.py
@@ -96,7 +96,7 @@ dev_noisy = qml.transforms.insert(noise_gate, noise_strength)(dev_ideal)
 from pennylane import numpy as np
 from pennylane.beta import QNode
 
-np.random.seed(1968)
+np.random.seed(1967)
 
 # Select template to use within circuit and generate parameters
 n_layers = 1
@@ -151,8 +151,8 @@ from mitiq.zne.scaling import fold_global
 from mitiq.zne.inference import RichardsonFactory
 from pennylane.transforms import mitigate_with_zne
 
-extrapolate = RichardsonFactory.extrapolate
 scale_factors = [1, 2, 3]
+extrapolate = RichardsonFactory.extrapolate
 
 mitigated_qnode = mitigate_with_zne(scale_factors, fold_global, extrapolate)(
     noisy_qnode

--- a/demonstrations/tutorial_error_mitigation.py
+++ b/demonstrations/tutorial_error_mitigation.py
@@ -96,7 +96,7 @@ dev_noisy = qml.transforms.insert(noise_gate, noise_strength)(dev_ideal)
 from pennylane import numpy as np
 from pennylane.beta import QNode
 
-np.random.seed(1967)
+np.random.seed(1968)
 
 # Select template to use within circuit and generate parameters
 n_layers = 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ pennylane-qchem==0.19.0
 pennylane-sf==0.19.0
 pennylane-forest==0.17.0
 pennylane-cirq==0.19.0
+qiskit==0.32.0
 pennylane-qiskit==0.18.0
 qulacs==0.1.10.1
 pennylane-qulacs==0.16.0


### PR DESCRIPTION
With the Qiskit 0.33.0 release, the `measure` functions has been removed, resulting in failures in the PennyLane-Qiskit plugin and when running the CI checks in this repo.

Multiple resolutions are on the way ([see here for discussion](https://github.com/PennyLaneAI/pennylane-qiskit/issues/164)), but to have the CI checks pass, this PR temporarily pins the version of Qiskit.