### PR TITLE
Fix demo diffs with PennyLane release v0.20.0

### DIFF
--- a/demonstrations/tutorial_general_parshift.py
+++ b/demonstrations/tutorial_general_parshift.py
@@ -232,19 +232,19 @@ _ = axs[0].set_ylabel("$E$")
 #
 # .. note ::
 #
-#     The analysis tool :func:`~.pennylane.fourier.spectrum` makes use of the internal
+#     The analysis tool :func:`~.pennylane.fourier.qnode_spectrum` makes use of the internal
 #     structure of the :class:`~.pennylane.QNode` that encodes the cost function.
 #     As we used the ``jax.jit`` decorator when defining the cost function above, we
-#     here need to pass the wrapped function to ``spectrum``, which is stored in
+#     here need to pass the wrapped function to ``qnode_spectrum``, which is stored in
 #     ``cost_function.__wrapped__``.
 
 
-from pennylane.fourier import spectrum
+from pennylane.fourier import qnode_spectrum
 
 spectra = []
 for N, cost_function in zip(Ns, cost_functions):
     # Compute spectrum with respect to parameter x
-    spec = spectrum(cost_function.__wrapped__)(X[0])["x"]
+    spec = qnode_spectrum(cost_function.__wrapped__)(X[0])["x"][()]
     print(f"For {N} qubits the spectrum is {spec}.")
     # Store spectrum
     spectra.append([freq for freq in spec if freq>0.0])
@@ -718,8 +718,8 @@ grad_gen = lambda f, order: grad_gen(jax.grad(f), order - 1) if order > 0 else f
 for order, name in zip([1, 2, 4], ["First", "Second", "4th"]):
     recons = odd_reconstructions if order % 2 else even_reconstructions
     recon_name = "odd " if order % 2 else "even"
-    cost_grads = [grad_gen(orig, order)(0.0) for orig in cost_functions]
-    recon_grads = [grad_gen(recon, order)(0.0) for recon in recons]
+    cost_grads = np.array([grad_gen(orig, order)(0.0) for orig in cost_functions])
+    recon_grads = np.array([grad_gen(recon, order)(0.0) for recon in recons])
     all_equal = (
         "All entries match" if np.allclose(cost_grads, recon_grads) else "Some entries differ!"
     )

--- a/demonstrations/tutorial_quantum_analytic_descent.py
+++ b/demonstrations/tutorial_quantum_analytic_descent.py
@@ -103,7 +103,7 @@ np.random.seed(0)
 dev = qml.device("default.qubit", wires=2)
 
 # Define the variational form V and observable M and combine them into a QNode.
-@qml.qnode(dev, diff_method="parameter-shift")
+@qml.qnode(dev, diff_method="parameter-shift", max_diff=2)
 def circuit(parameters):
     qml.RX(parameters[0], wires=0)
     qml.RX(parameters[1], wires=1)

--- a/demonstrations/tutorial_quantum_metrology.py
+++ b/demonstrations/tutorial_quantum_metrology.py
@@ -181,7 +181,7 @@ def experiment(weights, phi, gamma=0.0):
     return qml.probs(wires=[0, 1, 2])
 
 # Draw the circuit at the given parameter values
-print(qml.draw(experiment)(
+print(qml.draw(experiment, expansion_strategy='device')(
     np.arange(NUM_ANSATZ_PARAMETERS + NUM_MEASUREMENT_PARAMETERS),
     np.zeros(3),
     gamma=0.2)

--- a/demonstrations/tutorial_quantum_natural_gradient.py
+++ b/demonstrations/tutorial_quantum_natural_gradient.py
@@ -405,7 +405,7 @@ print(np.round(g, 8))
 # PennyLane contains a built-in function for computing the Fubini-Study metric
 # tensor, :func:`~.pennylane.metric_tensor`, which
 # we can use to verify this result:
-print(np.round(qml.metric_tensor(circuit)(params), 8))
+print(np.round(qml.metric_tensor(circuit, approx="block-diag")(params), 8))
 
 ##############################################################################
 # As opposed to our manual computation, which required 6 different quantum


### PR DESCRIPTION
Fixes:
- new warning emitted by [Quantum natural gradient](https://pennylane.ai/qml/demos/tutorial_quantum_natural_gradient.html)
  ```
  UserWarning: The device does not have a wire that is not used by the tape. Reverting to the block-diagonal approximation. It will often be much more efficient to request the block-diagonal approximation directly!
  ```
- use `expansion_strategy='device'` to decompose templates before drawing (as before)
- correct Hessian calculation now requires `max_diff=2` parameter to QNode