### PR TITLE
[On hold] Change matrix to matrix() once op-refactor is merged

### DIFF
--- a/demonstrations/tutorial_classical_shadows.py
+++ b/demonstrations/tutorial_classical_shadows.py
@@ -301,8 +301,8 @@ def snapshot_state(b_list, obs_list):
 
     # local qubit unitaries
     phase_z = np.array([[1, 0], [0, -1j]], dtype=complex)
-    hadamard = qml.Hadamard(0).matrix
-    identity = qml.Identity(0).matrix
+    hadamard = qml.Hadamard(0).matrix()
+    identity = qml.Identity(0).matrix()
 
     # undo the rotations that were added implicitly to the circuit for the Pauli measurements
     unitaries = [hadamard, hadamard @ phase_z, identity]
@@ -621,7 +621,7 @@ list_of_observables = (
 # for all :math:`1\leq i \leq M`.
 
 shadow_size_bound, k = shadow_bound(
-    error=2e-1, observables=[o.matrix for o in list_of_observables]
+    error=2e-1, observables=[o.matrix() for o in list_of_observables]
 )
 shadow_size_bound
 
@@ -638,7 +638,7 @@ estimates = []
 for error in epsilon_grid:
     # get the number of samples needed so that the absolute error < epsilon.
     shadow_size_bound, k = shadow_bound(
-        error=error, observables=[o.matrix for o in list_of_observables]
+        error=error, observables=[o.matrix() for o in list_of_observables]
     )
     shadow_sizes.append(shadow_size_bound)
     print(f"{shadow_size_bound} samples required ")

--- a/demonstrations/tutorial_qgrnn.py
+++ b/demonstrations/tutorial_qgrnn.py
@@ -277,7 +277,7 @@ def create_hamiltonian_matrix(n_qubits, graph, weights, bias):
         interaction_term = 1
         for qubit in range(0, n_qubits):
             if qubit in edge:
-                interaction_term = np.kron(interaction_term, qml.PauliZ.matrix)
+                interaction_term = np.kron(interaction_term, qml.PauliZ.matrix())
             else:
                 interaction_term = np.kron(interaction_term, np.identity(2))
         full_matrix += weights[i] * interaction_term
@@ -287,8 +287,8 @@ def create_hamiltonian_matrix(n_qubits, graph, weights, bias):
         z_term = x_term = 1
         for j in range(0, n_qubits):
             if j == i:
-                z_term = np.kron(z_term, qml.PauliZ.matrix)
-                x_term = np.kron(x_term, qml.PauliX.matrix)
+                z_term = np.kron(z_term, qml.PauliZ.matrix())
+                x_term = np.kron(x_term, qml.PauliX.matrix())
             else:
                 z_term = np.kron(z_term, np.identity(2))
                 x_term = np.kron(x_term, np.identity(2))

--- a/demonstrations/tutorial_vqt.py
+++ b/demonstrations/tutorial_vqt.py
@@ -149,9 +149,9 @@ def create_hamiltonian_matrix(n, graph):
         x = y = z = 1
         for j in range(0, n):
             if j == i[0] or j == i[1]:
-                x = np.kron(x, qml.PauliX.matrix)
-                y = np.kron(y, qml.PauliY.matrix)
-                z = np.kron(z, qml.PauliZ.matrix)
+                x = np.kron(x, qml.PauliX.matrix())
+                y = np.kron(y, qml.PauliY.matrix())
+                z = np.kron(z, qml.PauliZ.matrix())
             else:
                 x = np.kron(x, np.identity(2))
                 y = np.kron(y, np.identity(2))


### PR DESCRIPTION
**Summary:**

These changes should make the demos compatible with the `op-refactor` branch in PennyLane, and should be merged at the same time.

**Changes:**

Luckily we only had to change a few instances of `op.matrix` to `op.matrix()`