### PR TITLE
Bump sphinx req

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,10 +22,10 @@ qulacs==0.1.10.1
 pennylane-qulacs==0.16.0
 scikit-learn==0.23.2
 docutils==0.16
-sphinx==1.8.5
+sphinx==3.5.3
 sphinx-sitemap
 pypandoc==1.5
-sphinx_gallery==0.9.0
+sphinx_gallery==0.10.0
 seaborn==0.10.1
 keras==2.6.0
 tensorflow==2.6.0


### PR DESCRIPTION
The `ImportError: cannot import name 'soft_unicode' from 'markupsafe'` issue affects the Sphinx version that we're using, see here:
https://github.com/PennyLaneAI/qml/runs/5281725894?check_suite_focus=true#step:8:1371.