### PR TITLE
Use `cirq_pasqal`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,9 @@ jobs:
       - restore_cache:
           keys:
             # when lock file changes, use increasingly general patterns to restore cache
-            - pip-v32c-{{ .Branch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_no_deps.txt" }}
-            - pip-v32c-{{ .Branch }}-
-            - pip-v32c-
+            - pip-v33c-{{ .Branch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_no_deps.txt" }}
+            - pip-v33c-{{ .Branch }}-
+            - pip-v33c-
 
       - run:
           name: Install dependencies
@@ -31,13 +31,13 @@ jobs:
       - save_cache:
           paths:
             - venv
-          key: pip-v32c-{{ .Branch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_no_deps.txt" }}
+          key: pip-v33c-{{ .Branch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_no_deps.txt" }}
 
       - restore_cache:
           keys:
-            - gallery-v32a-{{ .Branch }}-{{ .Revision }}
-            - gallery-v32a-{{ .Branch }}-
-            - gallery-v32a-
+            - gallery-v33a-{{ .Branch }}-{{ .Revision }}
+            - gallery-v33a-{{ .Branch }}-
+            - gallery-v33a-
 
       - run:
           name: Build tutorials
@@ -53,7 +53,7 @@ jobs:
       - save_cache:
           paths:
             - ./demos
-          key: gallery-v32a-{{ .Branch }}-{{ .Revision }}
+          key: gallery-v33a-{{ .Branch }}-{{ .Revision }}
 
       - save_cache:
           paths:

--- a/demonstrations/tutorial_isingmodel_PyTorch.py
+++ b/demonstrations/tutorial_isingmodel_PyTorch.py
@@ -166,11 +166,14 @@ import matplotlib
 import matplotlib.pyplot as plt
 
 fig = plt.figure(figsize=(6, 4))
-plt.plot(x, cost_pt, label = 'global minimum')
-plt.xlabel("Optimization steps")
-plt.ylabel("Cost / Energy")
-plt.legend()
-plt.show()
+
+# Enable processing the Torch trainable tensors
+with torch.no_grad():
+    plt.plot(x, cost_pt, label = 'global minimum')
+    plt.xlabel("Optimization steps")
+    plt.ylabel("Cost / Energy")
+    plt.legend()
+    plt.show()
 
 ###############################################################################
 # Local minimum
@@ -218,11 +221,14 @@ for j in range(100):
 ###############################################################################
 
 fig = plt.figure(figsize=(6, 4))
-plt.plot(x, cost_pt_loc, 'r', label = 'local minimum')
-plt.xlabel("Optimization steps")
-plt.ylabel("Cost / Energy")
-plt.legend()
-plt.show()
+
+# Enable processing the Torch trainable tensors
+with torch.no_grad():
+    plt.plot(x, cost_pt_loc, 'r', label = 'local minimum')
+    plt.xlabel("Optimization steps")
+    plt.ylabel("Cost / Energy")
+    plt.legend()
+    plt.show()
 
 ###############################################################################
 # |

--- a/demonstrations/tutorial_pasqal.py
+++ b/demonstrations/tutorial_pasqal.py
@@ -131,7 +131,7 @@ plt.show();
 # one another more easily, we will artificially scale some dimensions
 # when placing the atoms.
 
-from cirq.pasqal import ThreeDQubit
+from cirq_pasqal import ThreeDQubit
 xy_scale = 1.5
 z_scale = 0.75
 qubits = [ThreeDQubit(xy_scale * x, xy_scale * y, z_scale * z)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 --find-links https://download.pytorch.org/whl/torch_stable.html
 appdirs==1.4.4
 autograd==1.3
-numpy~=1.22
+numpy~=1.21
 numba==0.53.1
 networkx==2.5.1
 nlopt==2.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 --find-links https://download.pytorch.org/whl/torch_stable.html
 appdirs==1.4.4
 autograd==1.3
-numpy==1.19.2
+numpy~=1.22
 numba==0.53.1
 networkx==2.5.1
 nlopt==2.6.2
@@ -28,8 +28,8 @@ sphinx-sitemap
 pypandoc==1.5
 sphinx_gallery==0.10.0
 seaborn==0.10.1
-keras==2.6.0
-tensorflow==2.6.0
+keras==2.8.0
+tensorflow==2.8.0
 toml==0.10.2
 torch==1.10.0+cpu
 torchvision==0.11.1+cpu

--- a/requirements_no_deps.txt
+++ b/requirements_no_deps.txt
@@ -1,2 +1,2 @@
-mitiq==0.11.0
+mitiq==0.13.0
 pyquil==2.21


### PR DESCRIPTION
Changes to using `cirq_pasqal` in the Pasqal demo as per the following deprecation warning:
```
tutorial_pasqal.py:134: DeprecationWarning: cirq.pasqal was used but is deprecated.
 it will be removed in cirq v0.14.
 Use cirq_pasqal instead.

  from cirq.pasqal import ThreeDQubit
```
----

Upgrading to Mitiq 0.13.0 raises an issue with NumPy 1.19.2:
```python
  File "/anaconda3/lib/python3.8/site-packages/mthree/__init__.py", line 31, in <module>
    from .mitigation import M3Mitigation
  File "/anaconda3/lib/python3.8/site-packages/mthree/mitigation.py", line 30, in <module>
    from mthree.matrix import _reduced_cal_matrix, sdd_check
  File "mthree/matrix.pyx", line 1, in init mthree.matrix
ValueError: numpy.ufunc size changed, may indicate binary incompatibility. Expected 232 from C header, got 216 from PyObject
```
Hence NumPy, TensorFlow, Keras and Mitiq are upgraded.

Closes https://github.com/PennyLaneAI/qml/issues/442.