### PR TITLE
Bump SF and PL-SF versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numba==0.53.1
 networkx==2.5.1
 nlopt==2.6.2
 semantic_version==2.6
-strawberryfields==0.20
+strawberryfields==0.22
 sympy==1.6.2
 pillow==7.1.0
 pip==21.1
@@ -15,7 +15,7 @@ pyscf==1.7.6
 pennylane-lightning
 pennylane==0.22.0
 pennylane-qchem==0.21.0
-pennylane-sf==0.20.0
+pennylane-sf==0.20.1
 pennylane-cirq==0.22.0
 pennylane-qiskit==0.22.0
 qulacs==0.1.10.1


### PR DESCRIPTION
Updates the SF and PL-SF requirements as per the new [bug fix release of PennyLane-SF.](https://github.com/PennyLaneAI/pennylane-sf/releases/tag/v0.20.1)