### PR TITLE
Upgrades the Python Docker image used as per the steps in the deprecation warning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/python:3.7.12
+      - image: cimg/python:3.7.13
 
     steps:
       - checkout
@@ -22,7 +22,7 @@ jobs:
           name: Install dependencies
           command: |
             sudo apt-get update && sudo apt-get install -y pandoc
-            python3 -m venv venv
+            python -m venv venv
             . venv/bin/activate
             pip install pip setuptools cmake --upgrade
             pip install -r requirements.txt
@@ -80,7 +80,7 @@ jobs:
 
   build_dev:
     docker:
-      - image: cimg/python:3.7.12
+      - image: cimg/python:3.7.13
 
     steps:
       - checkout
@@ -88,7 +88,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            python3 -m venv venv
+            python -m venv venv
             . venv/bin/activate
             pip install pip setuptools cmake --upgrade
             pip install -r requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,15 +14,9 @@ jobs:
       - restore_cache:
           keys:
             # when lock file changes, use increasingly general patterns to restore cache
-            - pip-v34c-{{ .Branch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_no_deps.txt" }}
-            - pip-v34c-{{ .Branch }}-
-            - pip-v34c-
-
-      - run:
-          name: Where's Python
-          command: |
-            python --version
-            python -m site --user-site
+            - pip-v35c-{{ .Branch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_no_deps.txt" }}
+            - pip-v35c-{{ .Branch }}-
+            - pip-v35c-
 
       - run:
           name: Install dependencies
@@ -37,13 +31,13 @@ jobs:
       - save_cache:
           paths:
             - venv
-          key: pip-v34c-{{ .Branch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_no_deps.txt" }}
+          key: pip-v35c-{{ .Branch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_no_deps.txt" }}
 
       - restore_cache:
           keys:
-            - gallery-v34a-{{ .Branch }}-{{ .Revision }}
-            - gallery-v34a-{{ .Branch }}-
-            - gallery-v34a-
+            - gallery-v35a-{{ .Branch }}-{{ .Revision }}
+            - gallery-v35a-{{ .Branch }}-
+            - gallery-v35a-
 
       - run:
           name: Build tutorials
@@ -59,7 +53,7 @@ jobs:
       - save_cache:
           paths:
             - ./demos
-          key: gallery-v34a-{{ .Branch }}-{{ .Revision }}
+          key: gallery-v35a-{{ .Branch }}-{{ .Revision }}
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,9 @@ jobs:
       - restore_cache:
           keys:
             # when lock file changes, use increasingly general patterns to restore cache
-            - pip-v35c-{{ .Branch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_no_deps.txt" }}
-            - pip-v35c-{{ .Branch }}-
-            - pip-v35c-
+            - pip-v36c-{{ .Branch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_no_deps.txt" }}
+            - pip-v36c-{{ .Branch }}-
+            - pip-v36c-
 
       - run:
           name: Install dependencies
@@ -31,13 +31,13 @@ jobs:
       - save_cache:
           paths:
             - venv
-          key: pip-v35c-{{ .Branch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_no_deps.txt" }}
+          key: pip-v36c-{{ .Branch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_no_deps.txt" }}
 
       - restore_cache:
           keys:
-            - gallery-v35a-{{ .Branch }}-{{ .Revision }}
-            - gallery-v35a-{{ .Branch }}-
-            - gallery-v35a-
+            - gallery-v36a-{{ .Branch }}-{{ .Revision }}
+            - gallery-v36a-{{ .Branch }}-
+            - gallery-v36a-
 
       - run:
           name: Build tutorials
@@ -53,7 +53,7 @@ jobs:
       - save_cache:
           paths:
             - ./demos
-          key: gallery-v35a-{{ .Branch }}-{{ .Revision }}
+          key: gallery-v36a-{{ .Branch }}-{{ .Revision }}
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/python:3.7.12
+      - image: cimg/python:3.7.12
 
     steps:
       - checkout
@@ -80,7 +80,7 @@ jobs:
 
   build_dev:
     docker:
-      - image: circleci/python:3.7.12
+      - image: cimg/python:3.7.12
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            sudo apt install pandoc -qq
+            sudo apt-get update && sudo apt-get install -y pandoc
             python3 -m venv venv
             . venv/bin/activate
             pip install pip setuptools cmake --upgrade

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,12 @@ jobs:
             - pip-v34c-
 
       - run:
+          name: Where's Python
+          command: |
+            python --version
+            python -m site --user-site
+
+      - run:
           name: Install dependencies
           command: |
             sudo apt-get update && sudo apt-get install -y pandoc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/python:3.7.13
+      - image: cimg/python:3.7.12
 
     steps:
       - checkout
@@ -22,7 +22,7 @@ jobs:
           name: Install dependencies
           command: |
             sudo apt-get update && sudo apt-get install -y pandoc
-            python -m venv venv
+            python3 -m venv venv
             . venv/bin/activate
             pip install pip setuptools cmake --upgrade
             pip install -r requirements.txt
@@ -80,7 +80,7 @@ jobs:
 
   build_dev:
     docker:
-      - image: cimg/python:3.7.13
+      - image: cimg/python:3.7.12
 
     steps:
       - checkout
@@ -88,7 +88,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            python -m venv venv
+            python3 -m venv venv
             . venv/bin/activate
             pip install pip setuptools cmake --upgrade
             pip install -r requirements.txt


### PR DESCRIPTION
**Context**

Upgrades the Python Docker image as the current one is deprecated.

**Changes**

Follows the [steps to take](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) and changes to the `cimg/python:3.7.12` image.

**More details**

The warning appears on the demo build page:
![image](https://user-images.githubusercontent.com/24476053/163856826-62e1b010-c812-430d-a38c-1a626f0a6aa5.png)

---------
Note: the [AWS-CLI action](https://circleci.com/developer/orbs/orb/circleci/aws-cli) seems to still be on the CircleCI provider.