### PR TITLE
Update mitiq demo drawing

### DIFF
--- a/demonstrations/tutorial_error_mitigation.py
+++ b/demonstrations/tutorial_error_mitigation.py
@@ -212,7 +212,7 @@ folded_circuits = [fold_global(circuit, scale_factor=s) for s in scale_factors]
 
 for s, c in zip(scale_factors, folded_circuits):
     print(f"Globally-folded circuit with a scale factor of {s}:")
-    print(c.draw())
+    print(qml.drawer.tape_text(c, decimals=2))
 
 ##############################################################################
 # Although these circuits are a bit deep, if you look carefully, you might be able to convince
@@ -377,7 +377,7 @@ mitigated_qnode(w1, w2)
 # circuits are all folded with a scale factor of :math:`s=1.1`:
 
 for _ in range(3):
-    print(folding(circuit, scale_factor=1.1).draw())
+    print(qml.drawer.tape_text(folding(circuit, scale_factor=1.1), decimals=2))
 
 ##############################################################################
 # To accommodate for this randomness, we can perform multiple repetitions of random folding for a


### PR DESCRIPTION
Updates the Mitiq demo such that the parameters are shown to 2 decimals and the `tape_text` function is used.

*Before*
```
0: ──RY─╭C──RY──RY────────────────╭C──RY─┤
1: ──RY─╰Z──RY─╭C───RY──RY─╭C──RY─╰Z──RY─┤
2: ──RY─╭C──RY─╰Z───RY──RY─╰Z──RY─╭C──RY─┤
3: ──RY─╰Z──RY──RY────────────────╰Z──RY─┤
0: ──RY─╭C──RY──RY────────────────╭C──RY──RY─╭C───────────────────────────────╭C──RY─┤
1: ──RY─╰Z──RY─╭C───RY──RY─╭C──RY─╰Z──RY──RY─╰Z──RY─╭C──RY──RY──RY──RY─╭C──RY─╰Z──RY─┤
2: ──RY─╭C──RY─╰Z───RY──RY─╰Z──RY─╭C──RY──RY─╭C──RY─╰Z──RY──RY──RY──RY─╰Z──RY─╭C──RY─┤
3: ──RY─╰Z──RY──RY────────────────╰Z──RY──RY─╰Z───────────────────────────────╰Z──RY─┤
```
*After*
```
0: ──RY(4.56)─╭C──RY(5.93)──RY(-5.93)────────────────────────────────────╭C──RY(-4.56)─┤  
1: ──RY(3.60)─╰Z──RY(5.90)─╭C──────────RY(5.18)──RY(-5.18)─╭C──RY(-5.90)─╰Z──RY(-3.60)─┤  
2: ──RY(4.05)─╭C──RY(3.32)─╰Z──────────RY(1.07)──RY(-1.07)─╰Z──RY(-3.32)─╭C──RY(-4.05)─┤  
3: ──RY(3.51)─╰Z──RY(3.66)──RY(-3.66)────────────────────────────────────╰Z──RY(-3.51)─┤  
0: ──RY(4.56)─╭C──RY(5.93)──RY(-5.93)────────────────────────────────────╭C──RY(-4.56)──RY(4.56)─╭C
1: ──RY(3.60)─╰Z──RY(5.90)─╭C──────────RY(5.18)──RY(-5.18)─╭C──RY(-5.90)─╰Z──RY(-3.60)──RY(3.60)─╰Z
2: ──RY(4.05)─╭C──RY(3.32)─╰Z──────────RY(1.07)──RY(-1.07)─╰Z──RY(-3.32)─╭C──RY(-4.05)──RY(4.05)─╭C
3: ──RY(3.51)─╰Z──RY(3.66)──RY(-3.66)────────────────────────────────────╰Z──RY(-3.51)──RY(3.51)─╰Z

````