### PR TITLE
Fix Soft 404 coverage issue for pennylane.ai/qml/search.html

### DIFF
--- a/_templates/search.html
+++ b/_templates/search.html
@@ -1,0 +1,3 @@
+<head>
+  <meta http-equiv="refresh" content="0; URL=https://pennylane.ai/qml" />
+</head>


### PR DESCRIPTION
Story details: https://app.shortcut.com/xanaduai/story/17645

The URL for the search page now redirects to the [QML homepage](https://pennylane.ai/qml/). Can test this by opening up the `search.html` file from the build folder in your browser.