### PR TITLE
Port QML Build to GitHub Actions with parallelisation 

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   # Generates a JSON list that is used by the strategy.matrix of the build job to spawn multiple workers
-  compute-build-matrix:
+  compute-build-strategy-matrix:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout PR
@@ -29,22 +29,22 @@ jobs:
           python-version: 3.7
 
       - name: Generate Build Matrix
-        id: compute-matrix
+        id: compute-strategy-matrix
         run: |
-          echo "::set-output name=build-matrix::$(python3 .github/workflows/github_job_scheduler.py \
-            build-matrix \
+          echo "::set-output name=strategy-matrix::$(python3 .github/workflows/github_job_scheduler.py \
+            build-strategy-matrix \
             ${{ github.workspace }} \
             --num-workers=${{ env.NUM_WORKERS }})"
     outputs:
-      build-matrix: ${{ steps.compute-matrix.outputs.build-matrix }}
+      strategy-matrix: ${{ steps.compute-strategy-matrix.outputs.strategy-matrix }}
 
   build:
     runs-on: ubuntu-20.04
     needs:
-      - compute-build-matrix
+      - compute-build-strategy-matrix
     strategy:
       matrix:
-        offset: ${{ fromJson(needs.compute-build-matrix.outputs.build-matrix) }}
+        offset: ${{ fromJson(needs.compute-build-strategy-matrix.outputs.strategy-matrix) }}
     steps:
       - name: Checkout PR
         uses: actions/checkout@v3
@@ -81,7 +81,7 @@ jobs:
           offset: ${{ matrix.offset }}
           EOL
           python3 .github/workflows/github_job_scheduler.py \
-           execute-matrix \
+           remove-executable-code \
            ${{ github.workspace }} \
            --num-workers=${{ env.NUM_WORKERS }} \
            --offset=${{ matrix.offset }} \
@@ -93,6 +93,8 @@ jobs:
 
       # Caches the python virtual environment. Once the caching issues outlined in actions/setup-python (described above)
       # are resolved, then this step can be removed
+      # (General) Info about GitHub caching:
+      # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
       - name: Python Cache
         id: python_cache
         uses: actions/cache@v3
@@ -114,7 +116,7 @@ jobs:
       - name: Execute Matrix offset
         run: |
           python3 .github/workflows/github_job_scheduler.py \
-           execute-matrix \
+           remove-executable-code \
            ${{ github.workspace }} \
            --num-workers=${{ env.NUM_WORKERS }} \
            --offset=${{ matrix.offset }} \
@@ -158,7 +160,7 @@ jobs:
         if: matrix.offset == 0
         run: |
           python3 .github/workflows/github_job_scheduler.py \
-           clean-html \
+           remove-html \
            ${{ github.workspace }} \
            --num-workers=${{ env.NUM_WORKERS }} \
            --offset=${{ matrix.offset }} \
@@ -169,7 +171,7 @@ jobs:
         if: matrix.offset != 0
         run: |
           python3 .github/workflows/github_job_scheduler.py \
-           clean-html \
+           remove-html \
            ${{ github.workspace }} \
            --num-workers=${{ env.NUM_WORKERS }} \
            --offset=${{ matrix.offset }} \

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -167,7 +167,7 @@ jobs:
       # Removes built html files that are not relevant to current node
       # See documentation in github_job_scheduler.py for more details.
       - name: Clean HTML Files
-        if: matrix.offset == 1
+        if: matrix.offset == 0
         run: |
           python3 .github/workflows/github_job_scheduler.py \
            clean-html \
@@ -178,7 +178,7 @@ jobs:
            --verbose
 
       - name: Clean HTML Files and Images
-        if: matrix.offset != 1
+        if: matrix.offset != 0
         run: |
           python3 .github/workflows/github_job_scheduler.py \
            clean-html \
@@ -188,7 +188,7 @@ jobs:
            --verbose
 
       - name: Upload Html
-        if: github.event_name == 'pull_request' && matrix.offset == 1
+        if: github.event_name == 'pull_request' && matrix.offset == 0
         uses: actions/upload-artifact@v3
         with:
           name: html-${{ matrix.offset }}.zip
@@ -198,7 +198,7 @@ jobs:
 
       # Only upload demos since all other html files are pushed as artifact from offset 1
       - name: Upload Demo Html
-        if: github.event_name == 'pull_request' && matrix.offset != 1
+        if: github.event_name == 'pull_request' && matrix.offset != 0
         uses: actions/upload-artifact@v3
         with:
           name: html-${{ matrix.offset }}.zip
@@ -216,7 +216,7 @@ jobs:
       # These two steps are required as the subsequent workflow_run will not have
       # the current context available to it.
       - name: Save PR Number
-        if: github.event_name == 'pull_request' && matrix.offset == 1
+        if: github.event_name == 'pull_request' && matrix.offset == 0
         run: |
           mkdir -p /tmp/pr
           cat >/tmp/pr/pr_info.json <<EOL
@@ -229,7 +229,7 @@ jobs:
           }
           EOL
       - name: Upload PR Number as Artifact
-        if: github.event_name == 'pull_request' && matrix.offset == 1
+        if: github.event_name == 'pull_request' && matrix.offset == 0
         uses: actions/upload-artifact@v3
         with:
           name: pr_info.zip

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -70,8 +70,11 @@ jobs:
           #   requirements.txt
           #   requirements_no_deps.txt
 
-      # Creates a temp file with current matrix information.
-      # The hash of this file is used to as portion of the key in subsequent caching steps.
+      # Creates a temp file with current matrix information, which includes:
+      #  - Current offset
+      #  - Total Workers
+      #  - The name of files that will be executed by this worker
+      # The hash of this file is used as portion of the key in subsequent caching steps.
       # This ensures that if the number of worker / tutorials change,
       # it will invalidate the previous cache and build fresh.
       - name: Set Matrix offset file

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       - cancel
-      - matrix
+      - compute-build-matrix
     strategy:
       matrix:
         offset: ${{ fromJson(needs.compute-build-matrix.outputs.matrix) }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -103,15 +103,8 @@ jobs:
       - name: Create venv
         if: steps.python_cache.outputs.cache-hit != 'true'
         run: |
-          if [ ! -f venv/bin/python3 ]; then
-            rm -rf venv
-            python3 -m venv venv
-          fi
-
-      # Once the caching issues outlined in actions/setup-python (described above)
-      # Then the `venv/bin/` prefix can be removed here.
-      - name: Install pip dependencies
-        run: |
+          if [ -d "venv" ]; then rm -rf venv; fi
+          python3 -m venv venv
           venv/bin/python3 -m pip install pip setuptools cmake --upgrade
           venv/bin/python3 -m pip install -r requirements.txt
           venv/bin/python3 -m pip install --no-deps -r requirements_no_deps.txt

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -196,7 +196,10 @@ jobs:
           retention-days: 1
           path: _build/html
 
-      # Only upload demos since all other html files are pushed as artifact from offset 1
+      # Only upload demos since all other html files are pushed as artifact from offset 0
+      # This step excludes static files (files that are the same across all workers) from being included in the
+      # built artifact. This is done as a performance boost.
+      # The step above this is executed by only one worker which uploads all static content.
       - name: Upload Demo Html
         if: github.event_name == 'pull_request' && matrix.offset != 0
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,223 @@
+name: Build Website
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - dev
+
+env:
+  NUM_WORKERS: 15
+
+jobs:
+  cancel:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
+  matrix:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: Setup Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.7
+
+      - name: Generate Build Matrix
+        id: matrix
+        run: |
+          echo "::set-output name=matrix::$(python3 .github/workflows/github_job_scheduler.py \
+            build-matrix \
+            ${{ github.workspace }} \
+            --num-workers=${{ env.NUM_WORKERS }})"
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+
+  build:
+    runs-on: ubuntu-20.04
+    needs:
+      - cancel
+      - matrix
+    strategy:
+      matrix:
+        offset: ${{ fromJson(needs.matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        id: setup_python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.7
+          # Caching pip packages using setup-python is the recommended route by GitHub.
+          # However, it is currently quite slow since it only caches the downloaded form of the packages,
+          # not the installed version. Caching a venv in that sense is much faster.
+          # However, caching the venv may cause broken symlinks sporadically when restored.
+          # Once the following issues are resolved, the action version should be updated to provider a performance boost
+          # Ref:
+          # - https://github.com/actions/setup-python/issues/276
+          # - https://github.com/actions/setup-python/issues/330
+          # ---
+          # cache: pip
+          # cache-dependency-path: |
+          #   requirements.txt
+          #   requirements_no_deps.txt
+
+      - name: Set Matrix offset file
+        run: |
+          cat >matrix_info.txt <<EOL
+          workers: ${{ env.NUM_WORKERS }}
+          offset: ${{ matrix.offset }}
+          EOL
+          python3 .github/workflows/github_job_scheduler.py \
+           execute-matrix \
+           ${{ github.workspace }} \
+           --num-workers=${{ env.NUM_WORKERS }} \
+           --offset=${{ matrix.offset }} \
+           --dry-run | tee -a matrix_info.txt
+
+      - name: Install OS build dependencies
+        run: |
+          sudo apt-get install -y pandoc -qq
+
+      - name: Python Cache
+        id: python_cache
+        uses: actions/cache@v3
+        with:
+          path: venv
+          key: pip-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements_no_deps.txt') }}
+
+      - name: Create venv
+        if: steps.python_cache.outputs.cache-hit != 'true'
+        run: |
+          if [ ! -f venv/bin/python3 ]; then
+            rm -rf venv
+            python3 -m venv venv
+          fi
+
+      - name: Install pip dependencies
+        run: |
+          venv/bin/python3 -m pip install pip setuptools cmake --upgrade
+          venv/bin/python3 -m pip install -r requirements.txt
+          venv/bin/python3 -m pip install --no-deps -r requirements_no_deps.txt
+
+      - name: Execute Matrix offset
+        run: |
+          python3 .github/workflows/github_job_scheduler.py \
+           execute-matrix \
+           ${{ github.workspace }} \
+           --num-workers=${{ env.NUM_WORKERS }} \
+           --offset=${{ matrix.offset }} \
+           --verbose
+
+      - name: Gallery Cache (on Pull Request)
+        if: github.event_name == 'pull_request'
+        uses: actions/cache@v3
+        with:
+          path: demos
+          key: gallery-v34a-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            gallery-v34a-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}-
+            gallery-v34a-${{ hashFiles('matrix_info.txt') }}-
+
+      - name: Gallery Cache (on Push to default branches)
+        if: github.event_name == 'push'
+        uses: actions/cache@v3
+        with:
+          path: demos
+          key: gallery-v34a-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}
+
+      - name: Sphinx Cache
+        uses: actions/cache@v3
+        with:
+          path: sphinx_cache-${{ hashFiles('matrix_info.txt') }}
+          key: sphinx-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            sphinx-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}-
+            sphinx-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('matrix_info.txt') }}-
+
+      - name: Build Tutorials
+        run: |
+          make download
+          make SPHINXBUILD="venv/bin/sphinx-build" SPHINXOPTS="-d sphinx_cache-${{ hashFiles('matrix_info.txt') }}" html
+
+      - name: Clean HTML Files
+        if: matrix.offset == 1
+        run: |
+          python3 .github/workflows/github_job_scheduler.py \
+           clean-html \
+           ${{ github.workspace }} \
+           --num-workers=${{ env.NUM_WORKERS }} \
+           --offset=${{ matrix.offset }} \
+           --preserve-non-sphinx-images \
+           --verbose
+
+      - name: Clean HTML Files and Images
+        if: matrix.offset != 1
+        run: |
+          python3 .github/workflows/github_job_scheduler.py \
+           clean-html \
+           ${{ github.workspace }} \
+           --num-workers=${{ env.NUM_WORKERS }} \
+           --offset=${{ matrix.offset }} \
+           --verbose
+
+      - name: Upload Html
+        if: github.event_name == 'pull_request' && matrix.offset == 1
+        uses: actions/upload-artifact@v3
+        with:
+          name: html-${{ matrix.offset }}.zip
+          path: _build/html
+          if-no-files-found: error
+          retention-days: 1
+
+      # Only upload demos since all other html files are pushed as artifact from offset 1
+      - name: Upload Demo Html
+        if: github.event_name == 'pull_request' && matrix.offset != 1
+        uses: actions/upload-artifact@v3
+        with:
+          name: html-${{ matrix.offset }}.zip
+          if-no-files-found: error
+          retention-days: 1
+          path: |
+            _build/html
+            !_build/html/*.html
+            !_build/html/*.js
+            !_build/html/*.xml
+            !_build/html/_static
+            !_build/html/glossary
+            
+
+      # These two steps are required as the subsequent workflow_run will not have
+      #  the current context available to it.
+      - name: Save PR Number
+        if: github.event_name == 'pull_request' && matrix.offset == 1
+        run: |
+          mkdir -p /tmp/pr
+          cat >/tmp/pr/pr_info.json <<EOL
+          {
+            "id": "${{ github.event.pull_request.number }}",
+            "title": "${{ github.event.pull_request.title }}",
+            "author": "${{ github.event.pull_request.user.login }}",
+            "ref": "${{ github.event.pull_request.head.sha }}",
+            "ref_name": "${{ github.event.pull_request.head.ref }}"
+          }
+          EOL
+      - name: Upload PR Number as Artifact
+        if: github.event_name == 'pull_request' && matrix.offset == 1
+        uses: actions/upload-artifact@v3
+        with:
+          name: pr_info.zip
+          path: /tmp/pr
+          retention-days: 30

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -19,7 +19,7 @@ jobs:
           access_token: ${{ github.token }}
 
   # Generates a JSON list that is used by the strategy.matrix of the build job to spawn multiple workers
-  matrix:
+  compute-build-matrix:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout PR
@@ -49,7 +49,7 @@ jobs:
       - matrix
     strategy:
       matrix:
-        offset: ${{ fromJson(needs.matrix.outputs.matrix) }}
+        offset: ${{ fromJson(needs.compute-build-matrix.outputs.matrix) }}
     steps:
       - name: Checkout PR
         uses: actions/checkout@v3
@@ -137,7 +137,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: demos
-          key: gallery-v34a-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}-${{ github.sha }}
+          key: gallery-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
             gallery-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}-
             gallery-${{ hashFiles('matrix_info.txt') }}-
@@ -192,9 +192,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: html-${{ matrix.offset }}.zip
-          path: _build/html
           if-no-files-found: error
           retention-days: 1
+          path: _build/html
 
       # Only upload demos since all other html files are pushed as artifact from offset 1
       - name: Upload Demo Html

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
+  # Generates a JSON list that is used by the strategy.matrix of the build job to spawn multiple workers
   matrix:
     runs-on: ubuntu-20.04
     steps:
@@ -64,7 +65,7 @@ jobs:
           # However, it is currently quite slow since it only caches the downloaded form of the packages,
           # not the installed version. Caching a venv in that sense is much faster.
           # However, caching the venv may cause broken symlinks sporadically when restored.
-          # Once the following issues are resolved, the action version should be updated to provider a performance boost
+          # Once the following issues are resolved, the action version should be updated to provide a performance boost
           # Ref:
           # - https://github.com/actions/setup-python/issues/276
           # - https://github.com/actions/setup-python/issues/330
@@ -74,6 +75,10 @@ jobs:
           #   requirements.txt
           #   requirements_no_deps.txt
 
+      # Creates a temp file with current matrix information.
+      # The hash of this file is used to as portion of the key in subsequent caching steps.
+      # This ensures that if the number of worker / tutorials change,
+      # it will invalidate the previous cache and build fresh.
       - name: Set Matrix offset file
         run: |
           cat >matrix_info.txt <<EOL
@@ -91,6 +96,8 @@ jobs:
         run: |
           sudo apt-get install -y pandoc -qq
 
+      # Caches the python virtual environment. Once the caching issues outlined in actions/setup-python (described above)
+      # are resolved, then this step can be removed
       - name: Python Cache
         id: python_cache
         uses: actions/cache@v3
@@ -106,12 +113,16 @@ jobs:
             python3 -m venv venv
           fi
 
+      # Once the caching issues outlined in actions/setup-python (described above)
+      # Then the `venv/bin/` prefix can be removed here.
       - name: Install pip dependencies
         run: |
           venv/bin/python3 -m pip install pip setuptools cmake --upgrade
           venv/bin/python3 -m pip install -r requirements.txt
           venv/bin/python3 -m pip install --no-deps -r requirements_no_deps.txt
 
+      # Removes executable code from tutorials that are not relevant to current node
+      # See documentation in github_job_scheduler.py for more details.
       - name: Execute Matrix offset
         run: |
           python3 .github/workflows/github_job_scheduler.py \
@@ -128,15 +139,16 @@ jobs:
           path: demos
           key: gallery-v34a-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
-            gallery-v34a-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}-
-            gallery-v34a-${{ hashFiles('matrix_info.txt') }}-
+            gallery-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}-
+            gallery-${{ hashFiles('matrix_info.txt') }}-
 
+      # Refreshes cache on 'push' event as that run on 'master' or 'dev'
       - name: Gallery Cache (on Push to default branches)
         if: github.event_name == 'push'
         uses: actions/cache@v3
         with:
           path: demos
-          key: gallery-v34a-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}
+          key: gallery-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}
 
       - name: Sphinx Cache
         uses: actions/cache@v3
@@ -152,6 +164,8 @@ jobs:
           make download
           make SPHINXBUILD="venv/bin/sphinx-build" SPHINXOPTS="-d sphinx_cache-${{ hashFiles('matrix_info.txt') }}" html
 
+      # Removes built html files that are not relevant to current node
+      # See documentation in github_job_scheduler.py for more details.
       - name: Clean HTML Files
         if: matrix.offset == 1
         run: |
@@ -200,7 +214,7 @@ jobs:
             
 
       # These two steps are required as the subsequent workflow_run will not have
-      #  the current context available to it.
+      # the current context available to it.
       - name: Save PR Number
         if: github.event_name == 'pull_request' && matrix.offset == 1
         run: |

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -33,14 +33,14 @@ jobs:
           python-version: 3.7
 
       - name: Generate Build Matrix
-        id: matrix
+        id: compute-matrix
         run: |
-          echo "::set-output name=matrix::$(python3 .github/workflows/github_job_scheduler.py \
+          echo "::set-output name=build-matrix::$(python3 .github/workflows/github_job_scheduler.py \
             build-matrix \
             ${{ github.workspace }} \
             --num-workers=${{ env.NUM_WORKERS }})"
     outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
+      build-matrix: ${{ steps.compute-matrix.outputs.build-matrix }}
 
   build:
     runs-on: ubuntu-20.04
@@ -49,7 +49,7 @@ jobs:
       - compute-build-matrix
     strategy:
       matrix:
-        offset: ${{ fromJson(needs.compute-build-matrix.outputs.matrix) }}
+        offset: ${{ fromJson(needs.compute-build-matrix.outputs.build-matrix) }}
     steps:
       - name: Checkout PR
         uses: actions/checkout@v3

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -116,7 +116,7 @@ jobs:
 
       # Removes executable code from tutorials that are not relevant to current node
       # See documentation in github_job_scheduler.py for more details.
-      - name: Execute Matrix offset
+      - name: Remove extraneous executable code from demos
         run: |
           python3 .github/workflows/github_job_scheduler.py \
            remove-executable-code \

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -9,15 +9,11 @@ on:
 env:
   NUM_WORKERS: 15
 
-jobs:
-  cancel:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.1
-        with:
-          access_token: ${{ github.token }}
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   # Generates a JSON list that is used by the strategy.matrix of the build job to spawn multiple workers
   compute-build-matrix:
     runs-on: ubuntu-20.04
@@ -45,7 +41,6 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     needs:
-      - cancel
       - compute-build-matrix
     strategy:
       matrix:

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -1,0 +1,223 @@
+name: Deploy Website
+on:
+  workflow_run:
+    workflows:
+      - Build Website
+    types:
+      - completed
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download PR Info
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id
+            });
+            let prArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == 'pr_info.zip'
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: prArtifact.id,
+              archive_format: 'zip'
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_info.zip`, Buffer.from(download.data));
+
+      - name: Unpack PR Info
+        run: |
+          unzip pr_info.zip
+
+      - name: Read PR Info
+        id: read_pr_info
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let fs = require('fs');
+            const prData = fs.readFileSync('pr_info.json');
+            return JSON.parse(prData);
+
+      - name: Parse PR Info
+        id: pr_info
+        run: |
+          PR_ID=$(echo '${{ steps.read_pr_info.outputs.result }}' | jq '.id')
+          PR_ID_NO_QUOTE="${PR_ID%\"}"
+          PR_ID_NO_QUOTE="${PR_ID_NO_QUOTE#\"}"
+          echo "::set-output name=pr_id::$PR_ID_NO_QUOTE"
+          echo "::set-output name=pr_site::https://${{ secrets.AWS_WEBSITE }}/${{ secrets.AWS_BUCKET_BUILD_DIR }}/$PR_ID_NO_QUOTE/index.html"
+          
+          PR_REF=$(echo '${{ steps.read_pr_info.outputs.result }}' | jq '.ref')
+          PR_REF_NO_QUOTE="${PR_REF%\"}"
+          PR_REF_NO_QUOTE="${PR_REF_NO_QUOTE#\"}"
+          echo "::set-output name=pr_ref::$PR_REF_NO_QUOTE"
+          
+          PR_REF_NAME=$(echo '${{ steps.read_pr_info.outputs.result }}' | jq '.ref_name')
+          PR_REF_NAME_NO_QUOTE="${PR_REF_NAME%\"}"
+          PR_REF_NAME_NO_QUOTE="${PR_REF_NAME_NO_QUOTE#\"}"
+          echo "::set-output name=pr_ref_name::$PR_REF_NAME_NO_QUOTE"
+          
+
+      - name: Create Deployment
+        id: deployment
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const deploymentStage = 'in_progress';
+            
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: '${{ steps.pr_info.outputs.pr_ref }}',
+              environment: 'preview',
+              task: 'deploy:pr-${{ steps.pr_info.outputs.pr_id }}',
+              transient_environment: true,
+              auto_merge: false,
+              description: `QML doc deployment from pull request ${{ steps.pr_info.outputs.pr_id }}`
+            });
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.data.id,
+              state: deploymentStage,
+              log_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
+              environment_url: '${{ steps.pr_info.outputs.pr_site }}'
+            });
+            return deployment.data.id
+
+      - name: Download HTML
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let fs = require('fs');
+            let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id
+            });
+            let htmlArtifacts = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name.startsWith('html-')
+            });
+            for (const artifact of htmlArtifacts) {
+              let download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: artifact.id,
+                archive_format: 'zip'
+              });
+              fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/${artifact.name}`, Buffer.from(download.data));
+            }
+
+      - name: Unpack HTML
+        run: |
+          mkdir -p website/demos
+          for f in html-*.zip; do
+            unzip -o -d website $f
+          done
+
+      - name: Upload HTML
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run:
+          aws s3 sync website s3://${{ secrets.AWS_BUCKET_ID }}/${{ secrets.AWS_BUCKET_BUILD_DIR }}/${{ steps.pr_info.outputs.pr_id }}/ --delete
+
+      - name: Comment on PR
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const actionsBotUserId = 41898282;
+            const prNumber = ${{ steps.pr_info.outputs.pr_id }};
+            const commentHeader = '**Thank you for opening this pull request.**'
+            const commentBody = `   
+            You can find the built site [at this link](${{ steps.pr_info.outputs.pr_site }}).
+            
+            **Deployment Info:**
+            - Pull Request ID: \`${{ steps.pr_info.outputs.pr_id }}\`
+            - Deployment SHA: \`${{ steps.pr_info.outputs.pr_ref }}\`
+            (The \`Deployment SHA\` refers to the latest commit hash the docs were built from)
+            
+            **Note:** It may take several minutes for updates to this pull request to be reflected on the deployed site.
+            `;
+            const commentText = `
+            ${commentHeader}
+            
+            ${commentBody}
+            `;
+            
+            // Get the existing comments.
+            const {data: comments} = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+            
+            // Find any comment already made by the bot.                                                                                                    
+            const botComment = comments.find(comment => comment.user.id === actionsBotUserId && comment.body.trim().startsWith(commentHeader));
+            
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: commentText
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: commentText
+              });
+            }
+
+      - name: Update Deployment (success)
+        if: success()
+        uses: actions/github-script@v6
+        env:
+          DEPLOYMENT_STAGE: success
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.result }}
+        with:
+          script: |
+            const deploymentId = process.env.DEPLOYMENT_ID
+            const deploymentEnv = process.env.DEPLOYMENT_ENV;
+            const deploymentStage = process.env.DEPLOYMENT_STAGE;
+            
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deploymentId,
+              state: deploymentStage,
+              log_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
+              environment_url: '${{ steps.pr_info.outputs.pr_site }}'
+            });
+
+      - name: Update Deployment (failure)
+        if: failure()
+        uses: actions/github-script@v6
+        env:
+          DEPLOYMENT_STAGE: failure
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.result }}
+        with:
+          script: |
+            const deploymentId = process.env.DEPLOYMENT_ID
+            const deploymentEnv = process.env.DEPLOYMENT_ENV;
+            const deploymentStage = process.env.DEPLOYMENT_STAGE;
+            
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deploymentId,
+              state: deploymentStage,
+              log_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
+              environment_url: '${{ steps.pr_info.outputs.pr_site }}'
+            });

--- a/.github/workflows/github_job_scheduler.py
+++ b/.github/workflows/github_job_scheduler.py
@@ -1,5 +1,89 @@
 #!/usr/bin/env python3
 
+"""
+This script can be invoked by GitHub Actions workflow to generate the strategy.matrix that the workflow will use
+in order to spawn worker nodes to build the QML docs.
+
+This script determines the subset of tutorial a worker will build during the sphinx-build process.
+Please refer to the doc strings of each function to see how this is done. Summary is provided below.
+
+Summary of workflow:
+
+1) Call `build-matrix` function
+```
+python3 github_job_scheduler.py build-matrix {PATH_TO_REPO} --num-workers={TOTAL WORKERS TO SPAWN}
+```
+This simply calculates how many tutorials are there in total, then divides that by the total number of workers
+to get  the 'jobs per worker' count. It then outputs a JSON list of 'offset' which basically means where in the
+tutorial list should the worker start executing jobs.
+
+So if there are four tutorials
+[
+  "a.py",
+  "b.py",
+  "c.py",
+  "d.py"
+]
+And two workers, then the output would be:
+[0, 2]
+
+This information is then used by the workers to determine as such:
+[
+  "a.py", <-- Worker 0 starts at index '0' (stops at 1)
+  "b.py",
+  "c.py", <-- Worker 1 starts at index '2' (stops at 3)
+  "d.py"
+]
+
+
+2) Call 'execute-matrix' function
+```
+python3 github_job_scheduler.py build-matrix {PATH_TO_REPO} --num-workers={TOTAL WORKERS TO SPAWN} \
+ --offset={CURRENT WORKER MATRIX OFFSET FROM 'build-matrix'}
+```
+
+There is no option to actually build 'partial gallery' in sphinx. It is also not possible to simply delete tutorials
+that are not relevant as that would break table of contents, thumbnails and other index pages.
+
+To achieve parallelisation, the workers remove executable code from tutorials that are not relevant to them.
+
+Example:
+If worker 1 from above example called 'execute-matrix', then the following would happen to "a.py" tutorial.
+
+Contents of a.py (before execute-matrix):
+```
+# This is a tutorial file
+
+print("Starting a loop")
+for i in range(10):
+  print(i)
+
+# Conclusion
+```
+
+Contents of a.py (after execute-matrix):
+```
+# This is a tutorial file
+
+
+# Conclusion
+# %%%%%%RUNNABLE_CODE_REMOVED%%%%%%
+```
+
+This allows all workers to build all tutorials, but only the tutorials relevant to each worker will have appropriate
+executable code preserved. This also preserves proper indexing, and table of contents.
+
+
+2) Call 'clean-html' function
+```
+python3 github_job_scheduler.py build-matrix {PATH_TO_REPO} --num-workers={TOTAL WORKERS TO SPAWN} \
+ --offset={CURRENT WORKER MATRIX OFFSET FROM 'build-matrix'}
+```
+Once the sphinx-build process has completed, the html files that were generated which are not relevant to the current
+worker are deleted. This ensures that when all the html files are aggregated, the proper executed html files is present
+from each worker.
+"""
+
 import re
 import json
 import math
@@ -17,6 +101,47 @@ class State(IntEnum):
 
 
 def _remove_executable_from_doc(input_file_path: PosixPath, output_file_path: PosixPath) -> None:
+    """
+    Given a python file to read, this function will remove all executable code from the file but retain all comments.
+
+    Sample python file:
+    ```
+    #!/usr/bin/env python3
+
+    # This is a python script
+
+    import requests
+
+    print("Hello World")
+
+    # Send HTTP Request
+    resp = requests.get("https://example.com")
+    print(resp.status_code)
+    ```
+
+    This function would update that file to following:
+    ```
+    #!/usr/bin/env python3
+
+    # This is a python script
+
+
+
+
+
+    # Send HTTP Request
+
+
+    # %%%%%%RUNNABLE_CODE_REMOVED%%%%%%
+    ```
+
+    Args:
+        input_file_path: PosixPath of python file to read in
+        output_file_path: PosixPath of where to save python file with all executable code removed
+
+    Returns:
+        None
+    """
     lines = []
     current_state = State.NORMAL
     with input_file_path.open() as fh:
@@ -60,32 +185,111 @@ def _remove_executable_from_doc(input_file_path: PosixPath, output_file_path: Po
 def build_matrix(num_workers: int,
                  build_directory: PosixPath,
                  parser_namespace: argparse.Namespace) -> List[str]:
+    """
+    Generates a JSON list of "offsets" that indicate where each node should start building tutorials from.
+    This function calculates how many files should be allocated per worker, then generates a list indicating the index
+    each worker should start executing tutorials at.
+
+    Example:
+        If you have 15 tutorials (files are globbed using pathlib):
+        [
+          "0.py",  # File names in this case are their respective indexes in this list (illustrative purpose)
+          "1.py",
+          "2.py",
+          "3.py",
+          "4.py",
+          "5.py",
+          "6.py",
+          "7.py",
+          "8.py",
+          "9.py",
+          "10.py",
+          "11.py",
+          "12.py",
+          "13.py",
+          "14.py"
+        ]
+        And you have 3 workers, then the files to be excuted per worker is:
+        math.ceil(15 / 3) = 5
+
+        The above list is then broken into chunks of 5
+        [
+          "0.py",  <-- Worker 1 start point
+          "1.py",
+          "2.py",
+          "3.py",
+          "4.py",
+          "5.py",  <-- Worker 2 start point
+          "6.py",
+          "7.py",
+          "8.py",
+          "9.py",
+          "10.py", <-- Worker 3 start point
+          "11.py",
+          "12.py",
+          "13.py",
+          "14.py"
+        ]
+
+        Keeping the above in mind, the output of the function for the above case would be:
+
+        -> [0, 5, 10]
+        This when fed into GitHub's strategy.matrix will tell the workflow to spawn 3 nodes.
+
+        Each node will have access to it's own offset from this list. It will recalculate the total files to execute
+        and determine the files relevant to it.
+    Args:
+        num_workers: The total number of nodes that needs to be spawned
+        build_directory: The directory where all the demonstrations reside
+        parser_namespace: The argparse object containing input from cli
+
+    Returns:
+        List[str]. JSON list of integers indicating the offset of each node to execute tutorials.
+    """
     glob_pattern = parser_namespace.glob_pattern
     file_count = len(list(build_directory.glob(glob_pattern)))
     files_per_worker = math.ceil(file_count / num_workers)
 
-    return list(range(1, file_count + 1, files_per_worker))
+    return list(range(0, file_count, files_per_worker))
 
 
 def execute_matrix(num_workers: int,
                    build_directory: PosixPath,
                    parser_namespace: argparse.Namespace) -> Optional[List[str]]:
+    """
+    Deletes executable to code from all tutorials that are not relevant to the current node calling this function.
+
+    The files that are relevant is determined as such:
+      -> Glob all tutorial files (sorted order)
+      -> Re-calculate the number of files this worker needs to execute `math.ceil(TOTAL_FILES / TOTAL_WORKERS)`
+      -> Start the the current matrix offset and add the total files from previous step
+      -> All other files will have executable code removed
+
+    Args:
+        num_workers: The total number of workers that are in the workflow
+        build_directory: The directory where all the demonstrations reside
+        parser_namespace: The argparse object containing input from cli
+
+    Returns:
+        By default, return `None`. If dry_run flag is set from cli, then returns a list of file names that will
+        have executable code retained.
+    """
     glob_pattern = parser_namespace.glob_pattern
     offset = parser_namespace.offset
     dry_run = parser_namespace.dry_run
     verbose = parser_namespace.verbose
 
-    assert offset and offset > 0, f"Invalid value for offset. Expected int greater than 0; Got: {offset}"
+    assert offset >= 0, f"Invalid value for offset. Expected positive int; Got: {offset}"
 
     files = sorted(build_directory.glob(glob_pattern))
     files_per_worker = math.ceil(len(files) / num_workers)
 
-    files_to_retain = files[offset - 1:offset + files_per_worker - 1]
+    files_to_retain = files[offset:offset + files_per_worker]
     if dry_run:
         return list(map(lambda x: x.name, files_to_retain))
 
-    files_to_delete_1 = files[:offset - 1]
-    files_to_delete_2 = files[offset + files_per_worker - 1:]
+    files_to_delete_1 = files[:offset]
+    files_to_delete_2 = files[offset + files_per_worker:]
 
     for file in chain(files_to_delete_1, files_to_delete_2):
         _remove_executable_from_doc(file, file)
@@ -98,6 +302,25 @@ def clean_html(num_workers: int,
                root_directory: PosixPath,
                build_directory: PosixPath,
                parser_namespace: argparse.Namespace) -> Optional[List[str]]:
+    """
+    Deletes all html files after sphinx-build that are not relevant to the current node.
+
+    The `execute_matrix` function is called to get the list of relevant files.
+    And since the html and py file names are the same, it is possible to determine which html files will be deleted.
+
+    The same goes for images. Sphinx generated images (graphs etc) have the prefix of 'sphx_glr_{file name}.png'.
+    That can be used to determine which images are relevant to this node and the remaining images are deleted.
+
+    Args:
+        num_workers: The total number of workers that are in the workflow
+        root_directory: The directory where the QML repo resides.
+        build_directory: The directory where all the demonstrations reside
+        parser_namespace: The argparse object containing input from cli
+
+    Returns:
+        By default, return `None`. If dry_run flag is set from cli, then returns a list of file names that will
+        be deleted.
+    """
     current_dry_run = parser_namespace.dry_run
     verbose = parser_namespace.verbose
     parser_namespace.dry_run = True
@@ -204,9 +427,10 @@ if __name__ == "__main__":
     if parser_results.action == "clean-html":
         output = clean_html(worker_count, directory_qml, directory_examples, parser_results)
     else:
-        output = {
+        action_dict = {
             "build-matrix": build_matrix,
             "execute-matrix": execute_matrix
-        }[parser_results.action](worker_count, directory_examples, parser_results)
+        }
+        output = action_dict[parser_results.action](worker_count, directory_examples, parser_results)
 
     print(json.dumps(output) if output else "")

--- a/.github/workflows/github_job_scheduler.py
+++ b/.github/workflows/github_job_scheduler.py
@@ -38,7 +38,7 @@ This information is then used by the workers to determine as such:
 
 2) Call 'execute-matrix' function
 ```
-python3 github_job_scheduler.py build-matrix {PATH_TO_REPO} --num-workers={TOTAL WORKERS TO SPAWN} \
+python3 github_job_scheduler.py execute-matrix {PATH_TO_REPO} --num-workers={TOTAL WORKERS TO SPAWN} \
  --offset={CURRENT WORKER MATRIX OFFSET FROM 'build-matrix'}
 ```
 
@@ -74,9 +74,9 @@ This allows all workers to build all tutorials, but only the tutorials relevant 
 executable code preserved. This also preserves proper indexing, and table of contents.
 
 
-2) Call 'clean-html' function
+3) Call 'clean-html' function
 ```
-python3 github_job_scheduler.py build-matrix {PATH_TO_REPO} --num-workers={TOTAL WORKERS TO SPAWN} \
+python3 github_job_scheduler.py clean-html {PATH_TO_REPO} --num-workers={TOTAL WORKERS TO SPAWN} \
  --offset={CURRENT WORKER MATRIX OFFSET FROM 'build-matrix'}
 ```
 Once the sphinx-build process has completed, the html files that were generated which are not relevant to the current

--- a/.github/workflows/github_job_scheduler.py
+++ b/.github/workflows/github_job_scheduler.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+
+import re
+import json
+import math
+import argparse
+from enum import IntEnum
+from itertools import chain
+from pathlib import PosixPath
+from typing import List, Optional
+
+
+class State(IntEnum):
+    NORMAL = 0
+    BLOCK_SINGLE_QUOTE = 1
+    BLOCK_DOUBLE_QUOTE = 2
+
+
+def _remove_executable_from_doc(input_file_path: PosixPath, output_file_path: PosixPath) -> None:
+    lines = []
+    current_state = State.NORMAL
+    with input_file_path.open() as fh:
+        for line in fh:
+            if current_state == State.NORMAL:
+                if line.startswith("#"):
+                    lines.append(line)
+                    current_state = State.NORMAL
+                elif line.startswith(('"""', 'r"""')) and line.endswith(('"""', '"""\n')) and len(line) > 6:
+                    lines.append(line)
+                    current_state = State.NORMAL
+                elif line.startswith(('"""', '"""\n', 'r"""', 'r"""\n')):
+                    lines.append(line)
+                    current_state = State.BLOCK_DOUBLE_QUOTE
+                elif line.startswith(("'''", "r'''")) and line.endswith(("'''", "'''\n")) and len(line) > 6:
+                    lines.append(line)
+                    current_state = State.NORMAL
+                elif line.startswith(("'''", "'''\n", "r'''", "r'''\n")):
+                    lines.append(line)
+                    current_state = State.BLOCK_SINGLE_QUOTE
+                else:
+                    lines.append("\n")
+                    current_state = State.NORMAL
+            elif current_state == State.BLOCK_DOUBLE_QUOTE:
+                lines.append(line)
+                current_state = State.NORMAL if line.startswith(('"""', '"""\n')) or line.endswith(('"""', '"""\n')) \
+                    else State.BLOCK_DOUBLE_QUOTE
+            elif current_state == State.BLOCK_SINGLE_QUOTE:
+                lines.append(line)
+                current_state = State.NORMAL if line.startswith(("'''", "'''\n")) or line.endswith(("'''", "'''\n")) \
+                    else State.BLOCK_SINGLE_QUOTE
+    lines.append("\n# %%%%%%RUNNABLE_CODE_REMOVED%%%%%%")
+
+    with output_file_path.open("w", encoding="utf-8") as fh:
+        for line in lines:  # More space efficient in this case than using str.join
+            fh.write(line)
+
+    return None
+
+
+def build_matrix(num_workers: int,
+                 build_directory: PosixPath,
+                 parser_namespace: argparse.Namespace) -> List[str]:
+    glob_pattern = parser_namespace.glob_pattern
+    file_count = len(list(build_directory.glob(glob_pattern)))
+    files_per_worker = math.ceil(file_count / num_workers)
+
+    return list(range(1, file_count + 1, files_per_worker))
+
+
+def execute_matrix(num_workers: int,
+                   build_directory: PosixPath,
+                   parser_namespace: argparse.Namespace) -> Optional[List[str]]:
+    glob_pattern = parser_namespace.glob_pattern
+    offset = parser_namespace.offset
+    dry_run = parser_namespace.dry_run
+    verbose = parser_namespace.verbose
+
+    assert offset and offset > 0, f"Invalid value for offset. Expected int greater than 0; Got: {offset}"
+
+    files = sorted(build_directory.glob(glob_pattern))
+    files_per_worker = math.ceil(len(files) / num_workers)
+
+    files_to_retain = files[offset - 1:offset + files_per_worker - 1]
+    if dry_run:
+        return list(map(lambda x: x.name, files_to_retain))
+
+    files_to_delete_1 = files[:offset - 1]
+    files_to_delete_2 = files[offset + files_per_worker - 1:]
+
+    for file in chain(files_to_delete_1, files_to_delete_2):
+        _remove_executable_from_doc(file, file)
+        if verbose:
+            print("Removing executable code from", file.name)
+    return None
+
+
+def clean_html(num_workers: int,
+               root_directory: PosixPath,
+               build_directory: PosixPath,
+               parser_namespace: argparse.Namespace) -> Optional[List[str]]:
+    current_dry_run = parser_namespace.dry_run
+    verbose = parser_namespace.verbose
+    parser_namespace.dry_run = True
+    files_to_retain = execute_matrix(num_workers, build_directory, parser_namespace)
+    files_to_retain = list(map(lambda f: "".join(f.split(".")[:-1]), files_to_retain))
+
+    image_files = (root_directory / "_build" / "html" / "_images").glob("*")
+    html_files = (root_directory / "_build" / "html" / "demos").glob("*.html")
+
+    dry_run = []
+    for file in html_files:
+        file_stem = file.stem
+
+        if file_stem == "index":
+            continue
+        file_name = f"html/{file.name}"
+        if file_stem not in files_to_retain:
+            if current_dry_run:
+                dry_run.append(file_name)
+            else:
+                file.unlink()
+            if verbose:
+                print("Deleted", file_name)
+
+    image_file_possible_prefixes = [
+        f"sphx_glr_{file_name}"
+        for file_name in files_to_retain
+    ]
+    image_file_regex_pattern = f"^({'|'.join(image_file_possible_prefixes)}).*"
+    image_file_regex = re.compile(image_file_regex_pattern, re.IGNORECASE)
+    for file in image_files:
+        file_stem = file.stem
+        file_name = f"_images/{file.name}"
+
+        if parser_namespace.preserve_non_sphinx_images and not file_stem.startswith("sphx_glr"):
+            continue
+
+        if not image_file_regex.match(file_stem):
+            if current_dry_run:
+                dry_run.append(file_name)
+            else:
+                file.unlink()
+            if verbose:
+                print("Deleted", file_name)
+
+    if current_dry_run:
+        return dry_run
+    return None
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="QML Build Scheduler",
+        description="This Python script aids in splitting the build process of the QML docs across multiple nodes"
+    )
+    parser.add_argument("action",
+                        help="build-matrix -> Build strategy.matrix that will be used to schedule jobs dynamically. "
+                             "execute-matrix -> Remove executable code from non-relevant files in current offset. "
+                             "clean-html -> Delete html files built that are not relevant for current matrix offset.",
+                        choices=["build-matrix", "execute-matrix", "clean-html"],
+                        type=str)
+    parser.add_argument("directory",
+                        help="The path to the qml directory",
+                        type=str)
+    parser.add_argument("--examples-dir",
+                        help="The directory where sphinx documents exists. Similar to Sphinx examples-dir."
+                             "Default: 'demonstrations'",
+                        default="demonstrations")
+    parser.add_argument("--num-workers",
+                        help="The total number of jobs the build should be split across",
+                        type=int,
+                        required=True)
+    parser.add_argument("--glob-pattern",
+                        help="The pattern to use to search for files in the examples-dir."
+                             "Default: '*.py'",
+                        type=str,
+                        default="*.py")
+    parser_build = parser.add_argument_group("Build Matrix")
+
+    parser_execute = parser.add_argument_group("Execute Matrix / Clean")
+    parser_execute.add_argument("--offset",
+                                help="The current matrix output to retain files from",
+                                type=int)
+    parser_execute.add_argument("--dry-run",
+                                help="Will not delete files but list what will be deleted",
+                                action="store_true")
+    parser_execute.add_argument("--preserve-non-sphinx-images",
+                                help="Do not delete static images in the gallery _images directory",
+                                action="store_true")
+    parser_execute.add_argument("--verbose",
+                                help="Print name of files that are being cleaned up for current offset",
+                                action="store_true")
+
+    parser_results = parser.parse_args()
+
+    directory_qml = PosixPath(parser_results.directory)
+    directory_examples = directory_qml / parser_results.examples_dir
+    assert directory_examples.exists(), f"Could not find {parser_results.examples_dir!r} folder " \
+                                        f"under {parser_results.directory!r}"
+
+    worker_count = parser_results.num_workers
+    assert worker_count > 0, "Total number of workers has to be greater than 1"
+
+    if parser_results.action == "clean-html":
+        output = clean_html(worker_count, directory_qml, directory_examples, parser_results)
+    else:
+        output = {
+            "build-matrix": build_matrix,
+            "execute-matrix": execute_matrix
+        }[parser_results.action](worker_count, directory_examples, parser_results)
+
+    print(json.dumps(output) if output else "")

--- a/.github/workflows/github_job_scheduler.py
+++ b/.github/workflows/github_job_scheduler.py
@@ -208,7 +208,7 @@ def build_matrix(num_workers: int,
           "13.py",
           "14.py"
         ]
-        And you have 3 workers, then the files to be excuted per worker is:
+        And you have 3 workers, then the files to be executed per worker is:
         math.ceil(15 / 3) = 5
 
         The above list is then broken into chunks of 5

--- a/.github/workflows/github_job_scheduler.py
+++ b/.github/workflows/github_job_scheduler.py
@@ -160,7 +160,7 @@ def _remove_executable_from_doc(
     with input_file_path.open(encoding=encoding) as fh:
         for line in fh:
             original_line = line
-            line = line.strip()
+            line = line.rstrip()
             if current_read_state == FileReadState.NORMAL:
                 if line.startswith(CommentType.SINGLE_LINE.value):
                     output_lines.append(original_line)

--- a/.github/workflows/teardown-pr.yml
+++ b/.github/workflows/teardown-pr.yml
@@ -1,0 +1,53 @@
+name: Teardown Website
+on:
+  pull_request_target:
+    types:
+      - closed
+
+env:
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+jobs:
+  teardown:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check if deployment exists
+        id: check_deployment
+        run: |
+          num_obj=$(aws s3 ls s3://${{ secrets.AWS_BUCKET_ID }}/${{ secrets.AWS_BUCKET_BUILD_DIR }}/${{ github.event.pull_request.number }}/index.html --summarize | grep "Total Objects: " | sed 's/[^0-9]*//g')
+          echo "::set-output name=exists::$num_obj"
+
+      - name: Teardown
+        if: steps.check_deployment.outputs.exists != '0'
+        run: |
+          aws s3 rm s3://${{ secrets.AWS_BUCKET_ID }}/${{ secrets.AWS_BUCKET_BUILD_DIR }}/${{ github.event.pull_request.number }} --recursive
+
+      - name: Deactivate Deployment
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const deployments = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment: 'preview',
+              task: 'deploy:pr-${{ github.event.pull_request.number }}'
+            });
+            
+            const numDeployments = deployments.data.length;
+            if (numDeployments > 0) {
+              for (const deployment of deployments.data) {
+                await github.rest.repos.createDeploymentStatus({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  deployment_id: deployment.id,
+                  state: 'inactive'
+                });
+                await github.rest.repos.deleteDeployment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  deployment_id: deployment.id
+                });
+              }
+            }


### PR DESCRIPTION
**Title:** Port QML Docs pull request build process to GitHub Actions

**Summary:**
This pull request adds GitHub Actions workflows to build the QML docs for pull request and deploy them as static sites to S3.

Each pull request will get their own site under the URL prefix of: 

```
https://qml-build-previews.pennylane.ai/pull_request_build_preview/${pull_request_id}/index.html
```

The build workflow also implements parallelisation similar to pytorch/tutorials. Multiple workers are spawned each of which build a subsection of tutorials. 

In order for this to work with forked pull request, the build and deploy workflows were separated and only the deploy workflow will get access to secrets.

Note: The setting up of workflow secrets and all AWS infrastructure has been setup with [terraform](https://github.com/PennyLaneAI/pennylane-cloud-provisioning/pull/4)

**Relevant references:**
- sc-16868

**Possible Drawbacks:**
Depending on the volume of active pull request, we may hit an upper limit of workers available to the repository at a time. This will not cause any jobs to fail, it will queue the job until a runner is available.

**Related GitHub Issues:**
N/A