### PR TITLE
Added required_context to deployment creation to stop it from failing if unrelated workflows fail

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -63,7 +63,24 @@ jobs:
           PR_REF_NAME_NO_QUOTE="${PR_REF_NAME%\"}"
           PR_REF_NAME_NO_QUOTE="${PR_REF_NAME_NO_QUOTE#\"}"
           echo "::set-output name=pr_ref_name::$PR_REF_NAME_NO_QUOTE"
-          
+
+      - name: Get Build IDs
+        id: build_ids
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id
+            });
+            let htmlArtifacts = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name.startsWith('html-')
+            });
+            let buildIds = htmlArtifacts.map((artifact) => {
+              return artifact.name.split('.')[0].split('-')[1];
+            });
+            return buildIds
 
       - name: Create Deployment
         id: deployment
@@ -72,13 +89,17 @@ jobs:
           result-encoding: string
           script: |
             const deploymentStage = 'in_progress';
-            
+            const buildIds = JSON.parse('${{ steps.build_ids.outputs.result }}')
+            const requiredContexts = buildIds.map((buildId) => {
+              return `build (${buildId})`;
+            });
             const deployment = await github.rest.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: '${{ steps.pr_info.outputs.pr_ref }}',
               environment: 'preview',
               task: 'deploy:pr-${{ steps.pr_info.outputs.pr_id }}',
+              required_contexts: requiredContexts,
               transient_environment: true,
               auto_merge: false,
               description: `QML doc deployment from pull request ${{ steps.pr_info.outputs.pr_id }}`


### PR DESCRIPTION
**Title:** Added required_context to deployment creation to stop it from failing if unrelated workflows fail

**Summary:**
This pull request resolves the error in deploy-pr where workflows extraneous to build-pr failing caused the deployment creation to fail. This is due to the reason that by default if the `required_context` is empty, GitHub will check to ensure all status checks pass before creating the deployment.

Previous failure:
- [deploy-pr](https://github.com/PennyLaneAI/qml/actions/runs/2346363675)

**Relevant references:**
- [Octokit docs](https://octokit.github.io/rest.js/v18#repos-create-deployment)
- [Commit statuses](https://docs.github.com/en/rest/commits/statuses)

**Possible Drawbacks:**
If any build related to the the deploy (in other words, any builds in `build-pr` workflow) fails, then the docs will not be deployed. This is as expected since we need sphinx-build to pass successfully before the docs can be fully deployed.

**Related GitHub Issues:**
N/A