### PR TITLE
feat: Added incremental backoff if error is raised while downloading artifact from GitHub

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -141,7 +141,16 @@ jobs:
             let htmlArtifacts = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name.startsWith('html-')
             });
-      
+            /*
+            Attempt to download the artifact one at a time and save them to disk.
+            In the event of an error, back-off (incrementally) and try again.
+
+            Each error increases the back-off delay by 1s, in other words:
+            > failure -> wait (1s) -> try-again -> failure -> wait (2s) -> try-again -> ...
+
+            This deals with network congestion and rate-limiting errors that occur if the artifact
+            download happens during a time of high load on GitHub Actions.
+            */
             for (const artifact of htmlArtifacts) {
               for (let i = 1; i < maxRetry + 1; i++) {
                  try {

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -119,6 +119,20 @@ jobs:
         with:
           script: |
             let fs = require('fs');
+            
+            const maxRetry = 15;
+            const backoffDelay = (retryCount) => new Promise(resolve => setTimeout(resolve, 1000 * retryCount));
+            
+            const downloadHtmlArtifact = async (artifact) => {
+              let download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: artifact.id,
+                archive_format: 'zip'
+              });
+              fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/${artifact.name}`, Buffer.from(download.data));
+            };
+            
             let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -127,14 +141,27 @@ jobs:
             let htmlArtifacts = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name.startsWith('html-')
             });
+      
             for (const artifact of htmlArtifacts) {
-              let download = await github.rest.actions.downloadArtifact({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                artifact_id: artifact.id,
-                archive_format: 'zip'
-              });
-              fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/${artifact.name}`, Buffer.from(download.data));
+              for (let i = 1; i < maxRetry + 1; i++) {
+                 try {
+                   console.log(`Attempting to download artifact: ${artifact.name}`);
+                   await downloadHtmlArtifact(artifact);
+                   console.log(`Successfully downloaded artifact: ${artifact.name}`);
+                   break;
+                 } catch (e) {
+                   console.log(`Error while trying to download artifact: ${artifact.name}, i: ${i}, error: ${e}`);
+                   ['message', 'status', 'request', 'response'].forEach((attr) => {
+                     if (e.hasOwnProperty(attr)) {
+                       console.log(`error_${attr}:`);
+                       console.log(e[attr]);
+                     }
+                   });
+                   if (i === maxRetry) throw new Error(e);
+                   console.log(`Retrying download of artifact: ${artifact.name}`);
+                   await backoffDelay(i);
+                 }
+              }
             }
 
       - name: Unpack HTML


### PR DESCRIPTION
**Title:** 
Introduce incremental backoff if error raised from GitHub API while attempting to download build artifacts

**Summary:**
The current deploy-pr fails if there are network issues while it attempts to download artifacts created during the build process.

The improvements introduced in this PR will *not* stop the workflow from failing if there is a widespread GitHub outage, however, in the case of network congestion or rate limiting. This will back off and then retry again.

The retry starts at 1s and increments by 1s on each failure (max: 15s).

**Relevant references:**
Build failures due to network issues:
- https://github.com/PennyLaneAI/qml/actions/runs/2353321155/attempts/1
- https://github.com/PennyLaneAI/qml/actions/runs/2353174352/attempts/1

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A