### PR TITLE
Updated GitHub Actions workflow to update dev / prod QML sites on merge 

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -10,7 +10,7 @@ env:
   NUM_WORKERS: 15
 
 concurrency:
-  group: ${{ github.ref }}
+  group: build-docs-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -141,7 +141,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: demos
-          key: gallery-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}
+          key: gallery-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            gallery-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}-
 
       - name: Sphinx Cache
         uses: actions/cache@v3
@@ -181,7 +183,7 @@ jobs:
            --verbose
 
       - name: Upload Html
-        if: github.event_name == 'pull_request' && matrix.offset == 0
+        if: matrix.offset == 0
         uses: actions/upload-artifact@v3
         with:
           name: html-${{ matrix.offset }}.zip
@@ -194,7 +196,7 @@ jobs:
       # built artifact. This is done as a performance boost.
       # The step above this is executed by only one worker which uploads all static content.
       - name: Upload Demo Html
-        if: github.event_name == 'pull_request' && matrix.offset != 0
+        if: matrix.offset != 0
         uses: actions/upload-artifact@v3
         with:
           name: html-${{ matrix.offset }}.zip

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -56,7 +56,7 @@ jobs:
           PR_ID_NO_QUOTE="${PR_ID%\"}"
           PR_ID_NO_QUOTE="${PR_ID_NO_QUOTE#\"}"
           echo "::set-output name=pr_id::$PR_ID_NO_QUOTE"
-          echo "::set-output name=pr_site::https://${{ secrets.AWS_WEBSITE }}/${{ secrets.AWS_BUCKET_BUILD_DIR }}/$PR_ID_NO_QUOTE/index.html"
+          echo "::set-output name=pr_site::https://${{ secrets.AWS_WEBSITE }}/${{ secrets.AWS_PR_BUCKET_BUILD_DIR }}/$PR_ID_NO_QUOTE/index.html"
           
           PR_REF=$(echo '${{ steps.read_pr_info.outputs.result }}' | jq '.ref')
           PR_REF_NO_QUOTE="${PR_REF%\"}"

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -9,9 +9,10 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-20.04
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download PR Info
+        if: github.event.workflow_run.event == 'pull_request'
         uses: actions/github-script@v6
         with:
           script: |
@@ -33,11 +34,13 @@ jobs:
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_info.zip`, Buffer.from(download.data));
 
       - name: Unpack PR Info
+        if: github.event.workflow_run.event == 'pull_request'
         run: |
           unzip pr_info.zip
 
       - name: Read PR Info
         id: read_pr_info
+        if: github.event.workflow_run.event == 'pull_request'
         uses: actions/github-script@v6
         with:
           script: |
@@ -47,6 +50,7 @@ jobs:
 
       - name: Parse PR Info
         id: pr_info
+        if: github.event.workflow_run.event == 'pull_request'
         run: |
           PR_ID=$(echo '${{ steps.read_pr_info.outputs.result }}' | jq '.id')
           PR_ID_NO_QUOTE="${PR_ID%\"}"
@@ -66,6 +70,7 @@ jobs:
 
       - name: Get Build IDs
         id: build_ids
+        if: github.event.workflow_run.event == 'pull_request'
         uses: actions/github-script@v6
         with:
           script: |
@@ -82,8 +87,17 @@ jobs:
             });
             return buildIds
 
+      - name: Get Branch name (on Push)
+        id: push_branch_info
+        if: github.event.workflow_run.event == 'push'
+        run: |
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          echo "${BRANCH_NAME^^}"
+          echo "::set-output name=branch_name::${BRANCH_NAME^^}"
+
       - name: Create Deployment
         id: deployment
+        if: github.event.workflow_run.event == 'pull_request'
         uses: actions/github-script@v6
         with:
           result-encoding: string
@@ -180,15 +194,38 @@ jobs:
             unzip -o -d website $f
           done
 
-      - name: Upload HTML
+      - name: Upload HTML (Pull Request)
+        if: github.event.workflow_run.event == 'pull_request'
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run:
-          aws s3 sync website s3://${{ secrets.AWS_BUCKET_ID }}/${{ secrets.AWS_BUCKET_BUILD_DIR }}/${{ steps.pr_info.outputs.pr_id }}/ --delete
+          aws s3 sync website s3://${{ secrets.AWS_PR_S3_BUCKET_ID }}/${{ secrets.AWS_PR_BUCKET_BUILD_DIR }}/${{ steps.pr_info.outputs.pr_id }}/ --delete
+
+      - name: Upload HTML (Push to master / dev)
+        if: github.event.workflow_run.event == 'push'
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          BUCKET_ACTIONS_ID: ${{ format('AWS_ENV_S3_BUCKET_{0}', steps.push_branch_info.outputs.branch_name) }}
+        run: |
+          echo "Got actions Bucket ID: ${{ env.BUCKET_ACTIONS_ID }}"
+          AWS_BUCKET_NAME=${{ secrets[env.BUCKET_ACTIONS_ID] }}
+          aws s3 sync website s3://$AWS_BUCKET_NAME/qml/ --delete
+
+      - name: Invalidate Cloudfront cache (Prod)
+        if: github.event.workflow_run.event == 'push' && steps.push_branch_info.outputs.branch_name == 'master'
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths /qml/*
 
       - name: Comment on PR
+        if: github.event.workflow_run.event == 'pull_request'
         uses: actions/github-script@v6
         with:
           script: |
@@ -238,7 +275,7 @@ jobs:
             }
 
       - name: Update Deployment (success)
-        if: success()
+        if: success() && github.event.workflow_run.event == 'pull_request'
         uses: actions/github-script@v6
         env:
           DEPLOYMENT_STAGE: success
@@ -259,7 +296,7 @@ jobs:
             });
 
       - name: Update Deployment (failure)
-        if: failure()
+        if: failure() && github.event.workflow_run.event == 'pull_request'
         uses: actions/github-script@v6
         env:
           DEPLOYMENT_STAGE: failure

--- a/.github/workflows/teardown-pr.yml
+++ b/.github/workflows/teardown-pr.yml
@@ -16,13 +16,13 @@ jobs:
       - name: Check if deployment exists
         id: check_deployment
         run: |
-          num_obj=$(aws s3 ls s3://${{ secrets.AWS_BUCKET_ID }}/${{ secrets.AWS_BUCKET_BUILD_DIR }}/${{ github.event.pull_request.number }}/index.html --summarize | grep "Total Objects: " | sed 's/[^0-9]*//g')
+          num_obj=$(aws s3 ls s3://${{ secrets.AWS_PR_S3_BUCKET_ID }}/${{ secrets.AWS_PR_BUCKET_BUILD_DIR }}/${{ github.event.pull_request.number }}/index.html --summarize | grep "Total Objects: " | sed 's/[^0-9]*//g')
           echo "::set-output name=exists::$num_obj"
 
       - name: Teardown
         if: steps.check_deployment.outputs.exists != '0'
         run: |
-          aws s3 rm s3://${{ secrets.AWS_BUCKET_ID }}/${{ secrets.AWS_BUCKET_BUILD_DIR }}/${{ github.event.pull_request.number }} --recursive
+          aws s3 rm s3://${{ secrets.AWS_PR_S3_BUCKET_ID }}/${{ secrets.AWS_PR_BUCKET_BUILD_DIR }}/${{ github.event.pull_request.number }} --recursive
 
       - name: Deactivate Deployment
         uses: actions/github-script@v6


### PR DESCRIPTION
**Title:** Updated GitHub Actions workflow to update dev / prod QML sites on merge 

**Summary:**
This PR introduces the changes missed in the previous iteration of the actions docs build workflow. On merge to either `master`/`dev`, the built docs will now be pushed to the appropriate S3 bucket.

Note: There is a terraform change that needs to be applied before this PR can be merged.

**Relevant references:**
sc-20104

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A