### PR TITLE
Match plot legend in benchmarking code to demo [adjoint differentiation]

### DIFF
--- a/demonstrations/adjoint_diff_benchmarking.py
+++ b/demonstrations/adjoint_diff_benchmarking.py
@@ -109,8 +109,8 @@ if __name__ == "__main__":
     fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
 
     ax1.plot(wires_list, adjoint_wires, '.-', label="adjoint")
-    ax1.plot(wires_list, backprop_wires, '.-', label="backprop")
     ax1.plot(wires_list, ps_wires, '.-', label="parameter-shift")
+    ax1.plot(wires_list, backprop_wires, '.-', label="backprop")
 
     ax1.legend()
 
@@ -121,8 +121,8 @@ if __name__ == "__main__":
     ax1.set_title("Scaling with wires")
 
     ax2.plot(layers_list, adjoint_layers, '.-', label="adjoint")
-    ax2.plot(layers_list, backprop_layers, '.-', label="backprop")
     ax2.plot(layers_list, ps_layers, '.-', label="parameter-shift")
+    ax2.plot(layers_list, backprop_layers, '.-', label="backprop")
 
     ax2.legend()
 


### PR DESCRIPTION
Match order of plot labels in the code to those currently displayed in the demo.
