### PR TITLE
Update semantic-version package requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ numpy~=1.21
 numba==0.53.1
 networkx==2.5.1
 nlopt==2.6.2
-semantic_version==2.6
+semantic_version==2.10
 strawberryfields==0.22
 sympy==1.6.2
 pillow==9.0.1


### PR DESCRIPTION
PennyLane has been updated to use the new semantic-version API requiring a version number >=2.7

See PennyLaneAI/pennylane#2744