### PR TITLE
Resolve dependency conflicts.

### DIFF
--- a/requirements-norun.txt
+++ b/requirements-norun.txt
@@ -1,14 +1,14 @@
 pillow==9.1.0
 pip==22.0.4
 wheel==0.37.1
-docutils==0.18.1
+docutils==0.17
 markupsafe==2.1.1
 sphinx==4.5.0
 sphinx-sitemap==2.2.0
 pypandoc==1.7.5
 sphinx_gallery==0.10.1
 pyparsing==2.4.7
-Jinja2==3.0.8
+Jinja2==3.1.2
 pyyaml==6.0
-numpy==1.22.3
+numpy==1.21.6
 yaml8==0.1.2


### PR DESCRIPTION
**Title:**
Resolve dependency conflicts

**Summary:**
Jinja v3.0.8 was removed from PyPI and is no longer available. The `requirements-norun.txt` file has been updated such that all packages are compatible with other python dependencies, while retaining the original Jupyter notebook formatting generated by running the `make html-norun` command. This is desired since Natalie's script for fixing the notebook formatting (https://gist.github.com/nataliegirard/fb823d4daace12a0bcbd0f972d996d09) recognizes the old restructured text style.

**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**
