### PR TITLE
[Prototype]: Add button to open demos in Xanadu Cloud

### DIFF
--- a/xanadu_theme/layout.html
+++ b/xanadu_theme/layout.html
@@ -300,6 +300,9 @@
     <!-- lightslider -->
     <script src="{{ pathto('_static/js/lightslider.min.js', 1) }}"></script>
 
+    <!-- XC button -->
+    <script src="{{ pathto('_static/js/xc.js', 1) }}"></script>
+
     <script type="text/javascript">
       $(window).scroll(function(){
           var windowHeight = window.innerHeight;

--- a/xanadu_theme/static/js/xc.js
+++ b/xanadu_theme/static/js/xc.js
@@ -1,0 +1,12 @@
+$(document).ready(function(){
+  const demo_name = window.location.pathname.split("/").pop().split(".").reverse().pop();
+  const xc_url = `https://pennylane.xanadu.ai/lab/tree/demo%3A${demo_name}.ipynb`;
+
+  const button = `
+  <button onclick="window.location.href='${xc_url}';">
+    Open demo in Xanadu Cloud
+  </button>
+  `;
+
+  $( button ).insertAfter($("h1").first());
+});

--- a/xanadu_theme/static/js/xc.js
+++ b/xanadu_theme/static/js/xc.js
@@ -8,7 +8,7 @@ $(document).ready(function(){
       const xc_url = `https://pennylane.xanadu.ai/lab/tree/demo%3A${demo_name}.ipynb`;
 
       const button = `
-      <a href="${xc_url}" class="button">Open demo in Xanadu Cloud</a>
+      <a href="${xc_url}" class="btn btn-primary">Open demo in Xanadu Cloud</a>
       `;
 
       $( button ).insertAfter($("h1").first());

--- a/xanadu_theme/static/js/xc.js
+++ b/xanadu_theme/static/js/xc.js
@@ -1,12 +1,16 @@
 $(document).ready(function(){
-  const demo_name = window.location.pathname.split("/").pop().split(".").reverse().pop();
-  const xc_url = `https://pennylane.xanadu.ai/lab/tree/demo%3A${demo_name}.ipynb`;
+  let url_split = window.location.pathname.split("/");
+  const page_name = url_split.pop();
+  const page_directory = url_split.pop();
 
-  const button = `
-  <button onclick="window.location.href='${xc_url}';">
-    Open demo in Xanadu Cloud
-  </button>
-  `;
+  if (page_directory === "demos") {
+      const demo_name = page_name.split(".").reverse().pop();
+      const xc_url = `https://pennylane.xanadu.ai/lab/tree/demo%3A${demo_name}.ipynb`;
 
-  $( button ).insertAfter($("h1").first());
+      const button = `
+      <a href="${xc_url}" class="button">Open demo in Xanadu Cloud</a>
+      `;
+
+      $( button ).insertAfter($("h1").first());
+  }
 });


### PR DESCRIPTION
This is a prototype PR to add a button at the top of each demo that links to the corresponding notebook version of the demo in Xanadu Cloud.