### PR TITLE
Fix QML pipeline bug to push changes to appropriate environment site

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -18,7 +18,7 @@ jobs:
   compute-build-strategy-matrix:
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout PR
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
@@ -48,7 +48,7 @@ jobs:
     env:
       ignore_cache: ${{ contains(github.event.pull_request.labels.*.name, 'ignore-qml-cache') }}
     steps:
-      - name: Checkout PR
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
@@ -228,23 +228,41 @@ jobs:
 
       # These two steps are required as the subsequent workflow_run will not have
       # the current context available to it.
-      - name: Save PR Number
+      # Will run to create an artifact containing key pull_request event information
+      - name: Save Pull Request Event Context
         if: github.event_name == 'pull_request' && matrix.offset == 0
         run: |
           mkdir -p /tmp/pr
-          cat >/tmp/pr/pr_info.json <<EOL
+          cat >/tmp/pr/info.json <<EOL
           {
             "id": "${{ github.event.pull_request.number }}",
-            "title": "${{ github.event.pull_request.title }}",
-            "author": "${{ github.event.pull_request.user.login }}",
             "ref": "${{ github.event.pull_request.head.sha }}",
             "ref_name": "${{ github.event.pull_request.head.ref }}"
           }
           EOL
-      - name: Upload PR Number as Artifact
+      - name: Upload Pull Request Event Context as Artifact
         if: github.event_name == 'pull_request' && matrix.offset == 0
         uses: actions/upload-artifact@v3
         with:
           name: pr_info.zip
           path: /tmp/pr
+          retention-days: 30
+
+      # Will run to create an artifact containing key push event information
+      - name: Save Push Event Context
+        if: github.event_name == 'push' && matrix.offset == 0
+        run: |
+          mkdir -p /tmp/push
+          cat >/tmp/push/info.json <<EOL
+          {
+            "ref": "${{ github.sha }}",
+            "ref_name": "${{ github.ref_name }}"
+          }
+          EOL
+      - name: Upload Push Event Context as Artifact
+        if: github.event_name == 'push' && matrix.offset == 0
+        uses: actions/upload-artifact@v3
+        with:
+          name: push_info.zip
+          path: /tmp/push
           retention-days: 30

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -233,7 +233,7 @@ jobs:
         if: github.event_name == 'pull_request' && matrix.offset == 0
         run: |
           mkdir -p /tmp/pr
-          cat >/tmp/pr/info.json <<EOL
+          cat >/tmp/pr/pr_info.json <<EOL
           {
             "id": "${{ github.event.pull_request.number }}",
             "ref": "${{ github.event.pull_request.head.sha }}",
@@ -253,7 +253,7 @@ jobs:
         if: github.event_name == 'push' && matrix.offset == 0
         run: |
           mkdir -p /tmp/push
-          cat >/tmp/push/info.json <<EOL
+          cat >/tmp/push/push_info.json <<EOL
           {
             "ref": "${{ github.sha }}",
             "ref_name": "${{ github.ref_name }}"

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -11,14 +11,23 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event.workflow_run.conclusion == 'success'
     steps:
+      - name: Set Build Context File Prefix
+        id: build_context_file_prefix
+        run: |
+          if [[ "${{ github.event.workflow_run.event }}" == "pull_request" ]]; then
+            echo "build_context_prefix=pr" >> $GITHUB_ENV
+          elif [[ "${{ github.event.workflow_run.event }}" == "push" ]]; then
+            echo "build_context_prefix=push" >> $GITHUB_ENV
+          fi
+
       - name: Download Build Context
         id: build_context
         uses: actions/github-script@v6
         with:
           result-encoding: string
           script: |
-            const workflowRunEventType = "${{ github.event.workflow_run.event }}"
-            const workflowContextFileName = workflowRunEventType === "pull_request" ? "pr_info.zip" : "push_info.zip"
+            const workflowContextFilePrefix = process.env.build_context_prefix;
+            const workflowContextFileName = `${workflowContextFilePrefix}_info.zip`;
             let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -47,7 +56,8 @@ jobs:
         with:
           script: |
             let fs = require('fs');
-            const buildData = fs.readFileSync('info.json');
+            const workflowContextFilePrefix = process.env.build_context_prefix;
+            const buildData = fs.readFileSync(`${workflowContextFilePrefix}_info.json`);
             return JSON.parse(buildData);
 
       - name: Parse Pull Request Event Information

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -11,18 +11,21 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event.workflow_run.conclusion == 'success'
     steps:
-      - name: Download PR Info
-        if: github.event.workflow_run.event == 'pull_request'
+      - name: Download Build Context
+        id: build_context
         uses: actions/github-script@v6
         with:
+          result-encoding: string
           script: |
+            const workflowRunEventType = "${{ github.event.workflow_run.event }}"
+            const workflowContextFileName = workflowRunEventType === "pull_request" ? "pr_info.zip" : "push_info.zip"
             let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
               run_id: context.payload.workflow_run.id
             });
             let prArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == 'pr_info.zip'
+              return artifact.name == workflowContextFileName
             })[0];
             let download = await github.rest.actions.downloadArtifact({
               owner: context.repo.owner,
@@ -31,42 +34,65 @@ jobs:
               archive_format: 'zip'
             });
             let fs = require('fs');
-            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_info.zip`, Buffer.from(download.data));
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/${workflowContextFileName}`, Buffer.from(download.data));
+            return workflowContextFileName;
 
-      - name: Unpack PR Info
-        if: github.event.workflow_run.event == 'pull_request'
+      - name: Unpack Build Information
         run: |
-          unzip pr_info.zip
+          unzip ${{ steps.build_context.outputs.result }}
 
-      - name: Read PR Info
-        id: read_pr_info
-        if: github.event.workflow_run.event == 'pull_request'
+      - name: Read Build Information
+        id: read_build_info
         uses: actions/github-script@v6
         with:
           script: |
             let fs = require('fs');
-            const prData = fs.readFileSync('pr_info.json');
-            return JSON.parse(prData);
+            const buildData = fs.readFileSync('info.json');
+            return JSON.parse(buildData);
 
-      - name: Parse PR Info
+      - name: Parse Pull Request Event Information
         id: pr_info
         if: github.event.workflow_run.event == 'pull_request'
         run: |
-          PR_ID=$(echo '${{ steps.read_pr_info.outputs.result }}' | jq '.id')
+          PR_ID=$(echo '${{ steps.read_build_info.outputs.result }}' | jq '.id')
           PR_ID_NO_QUOTE="${PR_ID%\"}"
           PR_ID_NO_QUOTE="${PR_ID_NO_QUOTE#\"}"
+          echo "pr_id => $PR_ID_NO_QUOTE"
           echo "::set-output name=pr_id::$PR_ID_NO_QUOTE"
           echo "::set-output name=pr_site::https://${{ secrets.AWS_WEBSITE }}/${{ secrets.AWS_PR_BUCKET_BUILD_DIR }}/$PR_ID_NO_QUOTE/index.html"
           
-          PR_REF=$(echo '${{ steps.read_pr_info.outputs.result }}' | jq '.ref')
+          PR_REF=$(echo '${{ steps.read_build_info.outputs.result }}' | jq '.ref')
           PR_REF_NO_QUOTE="${PR_REF%\"}"
           PR_REF_NO_QUOTE="${PR_REF_NO_QUOTE#\"}"
+          echo "pr_ref => $PR_REF_NO_QUOTE"
           echo "::set-output name=pr_ref::$PR_REF_NO_QUOTE"
           
-          PR_REF_NAME=$(echo '${{ steps.read_pr_info.outputs.result }}' | jq '.ref_name')
+          PR_REF_NAME=$(echo '${{ steps.read_build_info.outputs.result }}' | jq '.ref_name')
           PR_REF_NAME_NO_QUOTE="${PR_REF_NAME%\"}"
           PR_REF_NAME_NO_QUOTE="${PR_REF_NAME_NO_QUOTE#\"}"
+          echo "pr_ref_name => $PR_REF_NAME_NO_QUOTE"
           echo "::set-output name=pr_ref_name::$PR_REF_NAME_NO_QUOTE"
+
+      - name: Parse Push Event Information
+        id: push_info
+        if: github.event.workflow_run.event == 'push'
+        run: |
+          PUSH_REF=$(echo '${{ steps.read_build_info.outputs.result }}' | jq '.ref')
+          PUSH_REF_NO_QUOTE="${PUSH_REF%\"}"
+          PUSH_REF_NO_QUOTE="${PUSH_REF_NO_QUOTE#\"}"
+          echo "push_ref => $PUSH_REF_NO_QUOTE"
+          echo "::set-output name=push_ref::$PUSH_REF_NO_QUOTE"
+
+          PUSH_REF_NAME=$(echo '${{ steps.read_build_info.outputs.result }}' | jq '.ref_name')
+          PUSH_REF_NAME_NO_QUOTE="${PUSH_REF_NAME%\"}"
+          PUSH_REF_NAME_NO_QUOTE="${PUSH_REF_NAME_NO_QUOTE#\"}"
+          echo "push_ref_name_raw => $PUSH_REF_NAME_NO_QUOTE"
+          echo "::set-output name=push_ref_name_raw::$PUSH_REF_NAME_NO_QUOTE"
+
+          BRANCH_NAME=${PUSH_REF_NAME_NO_QUOTE#refs/heads/}
+          BRANCH_NAME_FORMATTED=${BRANCH_NAME^^}
+          echo "push_ref_name => $BRANCH_NAME_FORMATTED"
+          echo "::set-output name=push_ref_name::$BRANCH_NAME_FORMATTED"
 
       - name: Get Build IDs
         id: build_ids
@@ -86,14 +112,6 @@ jobs:
               return artifact.name.split('.')[0].split('-')[1];
             });
             return buildIds
-
-      - name: Get Branch name (on Push)
-        id: push_branch_info
-        if: github.event.workflow_run.event == 'push'
-        run: |
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          echo "${BRANCH_NAME^^}"
-          echo "::set-output name=branch_name::${BRANCH_NAME^^}"
 
       - name: Create Deployment
         id: deployment
@@ -209,14 +227,14 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          BUCKET_ACTIONS_ID: ${{ format('AWS_ENV_S3_BUCKET_{0}', steps.push_branch_info.outputs.branch_name) }}
+          BUCKET_ACTIONS_ID: ${{ format('AWS_ENV_S3_BUCKET_{0}', steps.push_info.outputs.push_ref_name) }}
         run: |
           echo "Got actions Bucket ID: ${{ env.BUCKET_ACTIONS_ID }}"
           AWS_BUCKET_NAME=${{ secrets[env.BUCKET_ACTIONS_ID] }}
           aws s3 sync website s3://$AWS_BUCKET_NAME/qml/ --delete
 
       - name: Invalidate Cloudfront cache (Prod)
-        if: github.event.workflow_run.event == 'push' && steps.push_branch_info.outputs.branch_name == 'master'
+        if: github.event.workflow_run.event == 'push' && steps.push_info.outputs.push_ref_name == 'master'
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
**Title:** Update QML Build pipeline to fix bug where PR merge to either master or dev branch would always push changes to Prod S3 bucket

**Summary and RCA of bug**
The current QML pipeline attempts to push the changes from a sphinx build to either the QML Prod or Dev sites based on branch. Determination of that logic was done at [this step](https://github.com/PennyLaneAI/qml/blob/23977d59e29f1095fc264405231548014d395a86/.github/workflows/deploy-pr.yml#L90-L96). The `GITHUB_REF` variable generally contains the branch that the update was pushed for, however, in this case the `deploy-pr` workflow is not triggered directly from a push; `build-pr` is triggered from a push and `deploy-pr` runs from a [workflow_run call](https://github.com/PennyLaneAI/qml/blob/23977d59e29f1095fc264405231548014d395a86/.github/workflows/deploy-pr.yml#L2-L7).

In other words, the push context (information regarding which branch was updated) is not available to `deploy-pr`, it runs from the default branch. This is why the step referring to `GITHUB_REF` always resolved to master, and all changes were pushed to Prod.

This pull request resolves this issue by adding a new step to the `build-pr` workflow, it creates an artifact with the required information from the push context. That artifact is then downloaded by `deploy-pr` and parsed. 

**Relevant references:**
- sc-24324

**Possible Drawbacks:**
The master branch may need to be merged to dev afterwards.

**Related GitHub Issues:**
None.
