### PR TITLE
Replaced Hermitian call with PauliZ in expval

### DIFF
--- a/demonstrations/tutorial_qaoa_maxcut.py
+++ b/demonstrations/tutorial_qaoa_maxcut.py
@@ -200,9 +200,6 @@ dev = qml.device("default.qubit", wires=n_wires, shots=1)
 # if executed with the ``edge`` keyword set to ``None``. Additionally, we specify the number of layers
 # (repeated applications of :math:`U_BU_C`) using the keyword ``n_layers``.
 
-pauli_z = [[1, 0], [0, -1]]
-pauli_z_2 = np.kron(pauli_z, pauli_z, requires_grad=False)
-
 
 @qml.qnode(dev)
 def circuit(gammas, betas, edge=None, n_layers=1):

--- a/demonstrations/tutorial_qaoa_maxcut.py
+++ b/demonstrations/tutorial_qaoa_maxcut.py
@@ -218,7 +218,8 @@ def circuit(gammas, betas, edge=None, n_layers=1):
         return qml.sample()
     # during the optimization phase we are evaluating a term
     # in the objective using expval
-    return qml.expval(qml.Hermitian(pauli_z_2, wires=edge))
+    H = qml.PauliZ(edge[0]) @ qml.PauliZ(edge[1])
+    return qml.expval(H)
 
 
 ##############################################################################


### PR DESCRIPTION
**Title:**Replaced Hermitian call with PauliZ in expval

**Summary:** The Hamiltonian construction in the circuit uses the old Hermitian() call which makes it difficult to JIT the QAOA circuit in JAX. Additionally, the new Hamiltonian/PauliZ class could possibly be more efficient than the Hamiltonian construction from a matrix. It is a simple update.

@josh146 