### PR TITLE
Update Braket parallel demo to measure all qubits

### DIFF
--- a/demonstrations/braket-parallel-gradients.py
+++ b/demonstrations/braket-parallel-gradients.py
@@ -140,7 +140,10 @@ def circuit(params):
         qml.RX(params[i], wires=i)
     for i in range(n_wires):
         qml.CNOT(wires=[i, (i + 1) % n_wires])
-    return qml.expval(qml.PauliZ(n_wires - 1))
+
+    main_obs = qml.PauliZ(n_wires - 1)
+    identities = [qml.Identity(i) for i in range(n_wires - 1)]
+    return qml.expval(qml.operation.Tensor(main_pauliz + identities))
 
 
 ##############################################################################

--- a/demonstrations/braket-parallel-gradients.py
+++ b/demonstrations/braket-parallel-gradients.py
@@ -141,9 +141,9 @@ def circuit(params):
     for i in range(n_wires):
         qml.CNOT(wires=[i, (i + 1) % n_wires])
 
-    main_obs = qml.PauliZ(n_wires - 1)
-    identities = [qml.Identity(i) for i in range(n_wires - 1)]
-    return qml.expval(qml.operation.Tensor(main_pauliz + identities))
+    # Measure all qubits to make sure all's good with Braket
+    observables = [qml.PauliZ(n_wires - 1)] + [qml.Identity(i) for i in range(n_wires - 1)]
+    return qml.expval(qml.operation.Tensor(*observables))
 
 
 ##############################################################################


### PR DESCRIPTION
**Context**

Braket may raise the following error:
```
botocore.errorfactory.ValidationException: An error occurred (ValidationException) when calling the CreateQuantumTask operation: Device requires all qubits in the program to be measured. This may be caused by declaring non-contiguous qubits or measuring partial qubits
```

This is being resolved in Braket. To make the related demo future proof, updates the demonstration to measure all qubits.