### PR TITLE
QSP: remove comment about reverse order

### DIFF
--- a/demonstrations/function_fitting_qsp.py
+++ b/demonstrations/function_fitting_qsp.py
@@ -191,11 +191,11 @@ def QSP_circ(phi, W):
     representation of the final unitary are polynomials!
     """
     qml.Hadamard(wires=0)  # set initial state |+>
-    for i in range(len(phi) - 1):  # iterate through rotations in reverse order
-        qml.RZ(phi[i], wires=0)
+    for angle in phi[1:].flip(0):  # iterate through rotations in reverse order
+        qml.RZ(angle, wires=0)
         qml.QubitUnitary(W, wires=0)
 
-    qml.RZ(phi[-1], wires=0)  # final rotation
+    qml.RZ(phi[0], wires=0)  # final rotation
     qml.Hadamard(wires=0)  # change of basis |+> , |->
     return
 

--- a/demonstrations/function_fitting_qsp.py
+++ b/demonstrations/function_fitting_qsp.py
@@ -191,11 +191,11 @@ def QSP_circ(phi, W):
     representation of the final unitary are polynomials!
     """
     qml.Hadamard(wires=0)  # set initial state |+>
-    for angle in phi[1:].flip(0):  # iterate through rotations in reverse order
-        qml.RZ(angle, wires=0)
+    for i in range(len(phi) - 1):  # iterate through rotations in reverse order
+        qml.RZ(phi[i], wires=0)
         qml.QubitUnitary(W, wires=0)
 
-    qml.RZ(phi[0], wires=0)  # final rotation
+    qml.RZ(phi[-1], wires=0)  # final rotation
     qml.Hadamard(wires=0)  # change of basis |+> , |->
     return
 

--- a/demonstrations/function_fitting_qsp.py
+++ b/demonstrations/function_fitting_qsp.py
@@ -191,8 +191,8 @@ def QSP_circ(phi, W):
     representation of the final unitary are polynomials!
     """
     qml.Hadamard(wires=0)  # set initial state |+>
-    for i in range(len(phi) - 1):  # iterate through rotations in reverse order
-        qml.RZ(phi[i], wires=0)
+    for angle in phi[:-1]:
+        qml.RZ(angle, wires=0)
         qml.QubitUnitary(W, wires=0)
 
     qml.RZ(phi[-1], wires=0)  # final rotation


### PR DESCRIPTION
~It doesn't truly make a difference, but we should apply the angles in reverse order.~
EDIT: don't wanna update values (below comment aged poorly) so I'm just removing the comment.

My Mac couldn't run the whole demo, but it only froze many lines after the change so we good. Also TIL `torch.tensor` can't have a negative step (I tried `phi[:0:-1]` and it failed 😢)