### PR TITLE
Sc 27275 view on GitHub links broken on qml demos

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -158,7 +158,8 @@ html_theme_options = {
     "toc_global": False,
     "toc_subset": False,
     "toc_hover": False,
-    "relations": False
+    "relations": False,
+    "github_repo":'PennyLaneAI/qml'
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/conf.py
+++ b/conf.py
@@ -159,7 +159,7 @@ html_theme_options = {
     "toc_subset": False,
     "toc_hover": False,
     "relations": False,
-    "github_repo":'PennyLaneAI/qml'
+    "github_repo": "PennyLaneAI/qml"
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/requirements-norun.txt
+++ b/requirements-norun.txt
@@ -12,3 +12,4 @@ Jinja2==3.0.3 # downgraded from 3.0.8
 pyyaml==6.0
 numpy==1.22.3
 yaml8==0.1.2
+pennylane-sphinx-theme


### PR DESCRIPTION
Adds `github_repo` variable from Xanadu Sphinx Theme in order to fid the "View on GitHub" links