### PR TITLE
[sc-26860]: Update QML cache strategy to allow for refreshing of cache

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   # Generates a JSON list that is used by the strategy.matrix of the build job to spawn multiple workers
   compute-build-strategy-matrix:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -24,22 +24,22 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
       - name: Generate Build Matrix
         id: compute-strategy-matrix
         run: |
-          echo "::set-output name=strategy-matrix::$(python3 .github/workflows/github_job_scheduler.py \
+          echo "strategy-matrix=$(python3 .github/workflows/github_job_scheduler.py \
             build-strategy-matrix \
             ${{ github.workspace }} \
-            --num-workers=${{ env.NUM_WORKERS }})"
+            --num-workers=${{ env.NUM_WORKERS }})" >> $GITHUB_OUTPUT
     outputs:
       strategy-matrix: ${{ steps.compute-strategy-matrix.outputs.strategy-matrix }}
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - compute-build-strategy-matrix
     strategy:
@@ -55,35 +55,33 @@ jobs:
 
       - name: Set up Python
         id: setup_python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
-          # Caching pip packages using setup-python is the recommended route by GitHub.
-          # However, it is currently quite slow since it only caches the downloaded form of the packages,
-          # not the installed version. Caching a venv in that sense is much faster.
-          # However, caching the venv may cause broken symlinks sporadically when restored.
-          # Once the following issues are resolved, the action version should be updated to provide a performance boost
-          # Ref:
-          # - https://github.com/actions/setup-python/issues/276
-          # - https://github.com/actions/setup-python/issues/330
-          # ---
-          # cache: pip
-          # cache-dependency-path: |
-          #   requirements.txt
-          #   requirements_no_deps.txt
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install --no-deps -r requirements_no_deps.txt
+          pip install --upgrade pip setuptools cmake
 
       # Creates a temp file with current matrix information, which includes:
       #  - Current offset
       #  - Total Workers
+      #  - Metadata regarding the Python version and dependencies
       #  - The name of files that will be executed by this worker
       # The hash of this file is used as portion of the key in subsequent caching steps.
-      # This ensures that if the number of worker / tutorials change,
+      # This ensures that if the number of worker, tutorials, or python evironment details change,
       # it will invalidate the previous cache and build fresh.
       - name: Set Matrix offset file
         run: |
           cat >matrix_info.txt <<EOL
           workers: ${{ env.NUM_WORKERS }}
           offset: ${{ matrix.offset }}
+          ---
+          python_version: ${{ steps.setup_python.outputs.python-version }}
+          requirements: ${{ hashFiles('requirements.txt') }}
+          requirements_no_deps: ${{ hashFiles('requirements_no_deps.txt') }}
           EOL
           python3 .github/workflows/github_job_scheduler.py \
            remove-executable-code \
@@ -91,31 +89,11 @@ jobs:
            --num-workers=${{ env.NUM_WORKERS }} \
            --offset=${{ matrix.offset }} \
            --dry-run | tee -a matrix_info.txt
+          cat matrix_info.txt
 
       - name: Install OS build dependencies
         run: |
           sudo apt-get install -y pandoc --quiet
-
-      # Caches the python virtual environment. Once the caching issues outlined in actions/setup-python (described above)
-      # are resolved, then this step can be removed
-      # (General) Info about GitHub caching:
-      # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
-      - name: Python Cache
-        id: python_cache
-        if: env.ignore_cache != 'true'
-        uses: actions/cache@v3
-        with:
-          path: venv
-          key: pip-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements_no_deps.txt') }}
-
-      - name: Create venv
-        if: steps.python_cache.outputs.cache-hit != 'true' || env.ignore_cache == 'true'
-        run: |
-          if [ -d "venv" ]; then rm -rf venv; fi
-          python3 -m venv venv
-          venv/bin/python3 -m pip install pip setuptools cmake --upgrade
-          venv/bin/python3 -m pip install -r requirements.txt
-          venv/bin/python3 -m pip install --no-deps -r requirements_no_deps.txt
 
       # Removes executable code from tutorials that are not relevant to current node
       # See documentation in github_job_scheduler.py for more details.
@@ -128,8 +106,7 @@ jobs:
            --offset=${{ matrix.offset }} \
            --verbose
 
-      - name: Gallery Cache (on Pull Request)
-        if: github.event_name == 'pull_request' && steps.python_cache.outputs.cache-hit == 'true' && env.ignore_cache != 'true'
+      - name: Gallery Cache
         uses: actions/cache@v3
         with:
           path: demos
@@ -138,30 +115,27 @@ jobs:
             gallery-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}-
             gallery-${{ hashFiles('matrix_info.txt') }}-
 
-      # Refreshes cache on 'push' event as that run on 'master' or 'dev'
-      - name: Gallery Cache (on Push to default branches)
-        if: github.event_name == 'push' && steps.python_cache.outputs.cache-hit == 'true' && env.ignore_cache != 'true'
-        uses: actions/cache@v3
-        with:
-          path: demos
-          key: gallery-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            gallery-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}-
-
       - name: Sphinx Cache
-        if: steps.python_cache.outputs.cache-hit == 'true' && env.ignore_cache != 'true'
         uses: actions/cache@v3
         with:
           path: sphinx_cache-${{ hashFiles('matrix_info.txt') }}
-          key: sphinx-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}-${{ github.sha }}
+          key: sphinx-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
-            sphinx-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}-
-            sphinx-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('matrix_info.txt') }}-
+            sphinx-${{ hashFiles('matrix_info.txt') }}-${{ github.ref_name }}-
+            sphinx-${{ hashFiles('matrix_info.txt') }}-
+
+      - name: Clear Cache
+        if: env.ignore_cache == 'true'
+        env:
+          sphinx_cache_filename: sphinx_cache-${{ hashFiles('matrix_info.txt') }}
+        run: |
+          if [ -d demos ]; then rm -rf demos; fi
+          if [ -d ${{ env.sphinx_cache_filename }} ]; then rm -rf ${{ env.sphinx_cache_filename }}; fi
 
       - name: Build Tutorials
         run: |
           make download
-          make SPHINXBUILD="venv/bin/sphinx-build" SPHINXOPTS="-d sphinx_cache-${{ hashFiles('matrix_info.txt') }}" html
+          make SPHINXOPTS="-d sphinx_cache-${{ hashFiles('matrix_info.txt') }}" html
 
       # These are files that are generated as part of sphinx-build but are not needed and supported on the live website
       # There does not seem to be an option to "not" generate them, therefore this step deletes these files before they
@@ -224,13 +198,14 @@ jobs:
             !_build/html/*.xml
             !_build/html/_static
             !_build/html/glossary
-            
 
-      # These two steps are required as the subsequent workflow_run will not have
-      # the current context available to it.
-      # Will run to create an artifact containing key pull_request event information
+  save-build-context:
+    runs-on: ubuntu-22.04
+    needs:
+      - build
+    steps:
       - name: Save Pull Request Event Context
-        if: github.event_name == 'pull_request' && matrix.offset == 0
+        if: github.event_name == 'pull_request'
         run: |
           mkdir -p /tmp/pr
           cat >/tmp/pr/pr_info.json <<EOL
@@ -241,7 +216,7 @@ jobs:
           }
           EOL
       - name: Upload Pull Request Event Context as Artifact
-        if: github.event_name == 'pull_request' && matrix.offset == 0
+        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v3
         with:
           name: pr_info.zip
@@ -250,7 +225,7 @@ jobs:
 
       # Will run to create an artifact containing key push event information
       - name: Save Push Event Context
-        if: github.event_name == 'push' && matrix.offset == 0
+        if: github.event_name == 'push'
         run: |
           mkdir -p /tmp/push
           cat >/tmp/push/push_info.json <<EOL
@@ -260,7 +235,7 @@ jobs:
           }
           EOL
       - name: Upload Push Event Context as Artifact
-        if: github.event_name == 'push' && matrix.offset == 0
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v3
         with:
           name: push_info.zip


### PR DESCRIPTION
**Title:** Add ability to refresh cache for QML CI/CD

**Summary:**
This pull request aims to add a new feature to the QML CI/CD pipeline by allowing the refreshing of cache. Previously, you either had to use existing cache, or completely ignore cache. There was no way to update/refresh the cache without using workarounds.

After this pull request is merged, users will be able to use the existing `ignore-qml-cache` label which now build fresh each time, but also refresh the cache with the new results each time. Once the label is removed, the most recent cache will be used for subsequent build.

Please note that this is vastly different from prior behavior. Before this PR, if the `ignore-qml-cache` was attached to a PR, it would ignore the cache but never update it. So removing the label was never an option to use the cache again, which slowed down a lot of PRs.

This pull request brings the following key changes:
- The Python venv will no longer be cached
- The cache key for items has been updated

Pros:
- Builds will always fetch the latest libraries
- Initial build of PRs will fetch the latest libraries at the time the PR is opened.
- No further changes are required in PRs to support a cache refresh. The existing `qml-ignore-cache` label can be used.

Cons:
- Build times will increase by 3-7 minutes


**Relevant references:**
- sc-26860

**Possible Drawbacks:**
Please see Cons list above.

Since this PR updates most cache keys, once it is merged, all existing caches will be invalidated. This should not impact anything but expect a longer build time on the very first build .. similar situation to when this workflow was first launched.

**Related GitHub Issues:**
None.