### PR TITLE
Fix workflows by removing ` --use-feature=2020-resolver`

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          pip install -r requirements.txt --use-feature=2020-resolver
-          pip install --no-deps -r requirements_no_deps.txt --use-feature=2020-resolver
+          pip install -r requirements.txt
+          pip install --no-deps -r requirements_no_deps.txt
 
       - name: Build tutorials
         run: |

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          pip install -r requirements.txt --use-feature=2020-resolver
-          pip install --no-deps -r requirements_no_deps.txt --use-feature=2020-resolver
+          pip install -r requirements.txt
+          pip install --no-deps -r requirements_no_deps.txt
 
       - name: Build tutorials
         run: |

--- a/.github/workflows/demo_diff_check.yml
+++ b/.github/workflows/demo_diff_check.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          pip install -r requirements.txt --use-feature=2020-resolver
-          pip install --no-deps -r requirements_no_deps.txt --use-feature=2020-resolver
+          pip install -r requirements.txt
+          pip install --no-deps -r requirements_no_deps.txt
 
       - name: Build tutorials
         run: |
@@ -77,8 +77,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          pip install -r requirements.txt --use-feature=2020-resolver
-          pip install --no-deps -r requirements_no_deps.txt --use-feature=2020-resolver
+          pip install -r requirements.txt
+          pip install --no-deps -r requirements_no_deps.txt
 
       - name: Build tutorials
         run: |


### PR DESCRIPTION
 Pip 22.3 just dropped, and it removed support for ` --use-feature=2020-resolver`, see the changelog https://pip.pypa.io/en/stable/news/#v22-3 .

To get the workflows running again, this removes that flag from the workflows.