### PR TITLE
Update github actions to support new pip version

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel
           pip install -r requirements.txt --use-feature=2020-resolver
-          pip install --no-deps -r requirements_no_deps.txt --use-feature=2020-resolver
+          pip install --no-deps -r requirements_no_deps.txt
 
       - name: Build tutorials
         run: |


### PR DESCRIPTION
With the latest release of `pip`, the `--use-feature=2020-resolver` feature has been removed.