### PR TITLE
QSim demo: use gates from PennyLane core instead of PL-Cirq

### DIFF
--- a/demonstrations/qsim_beyond_classical.py
+++ b/demonstrations/qsim_beyond_classical.py
@@ -313,8 +313,8 @@ def circuit(seed=42, return_probs=False):
             single_qubit_gates[gate_idx[i][w]](wires=w)
 
         for qb_1, qb_2 in gate_order[gs]:
-            ops.ISWAP(wires=(qb_1, qb_2))
-            ops.CPhase(-np.pi/6, wires=(qb_1, qb_2))
+            qml.ISWAP(wires=(qb_1, qb_2))
+            qml.CPhase(-np.pi/6, wires=(qb_1, qb_2))
 
     # one half-cycle - single-qubit gates only
     for w in range(wires):


### PR DESCRIPTION
PennyLane-Cirq had some custom gates that are now in PennyLane. Those gates were recently removed from PennyLane-Cirq and so this PR changes the QSim demo. https://github.com/PennyLaneAI/pennylane-cirq/pull/115