### PR TITLE
bump mpl; remove duplicate sklearn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,9 +37,8 @@ toml==0.10.2
 torch==1.10.0+cpu
 torchvision==0.11.1+cpu
 dask[delayed]==2.10.1
-scikit-learn==0.23.2
 pyparsing==2.4.7
-matplotlib==3.3.3
+matplotlib==3.5.3
 noisyopt==0.2.2
 Jinja2==2.11.3
 pyyaml==5.4.1


### PR DESCRIPTION
can't install requirements.txt on mac, but I believe CI on pull_request will do it for me to confirm all is well.

Bumping MPL because many demos show warnings with 3.3.3, but they're resolved with 3.5.3 as pointed out by @eddddddy 