### PR TITLE
add note for prerequisites for qnspsa demo

### DIFF
--- a/demonstrations/qnspsa.py
+++ b/demonstrations/qnspsa.py
@@ -961,9 +961,9 @@ for i in range(300):
 #
 # .. note::
 #     In order for the remainder of this demo to work, you will need to have done 3 things:
-#     1. Copied the `source_scripts` folder (linked above) to your working directory
-#     2. Authenticated with AWS locally
-#     3. Granted yourself the appropriate permissions as described in this `AWS Braket setup document <https://docs.aws.amazon.com/braket/latest/developerguide/braket-enable-overview.html>`__
+#     #. Copied the `source_scripts` folder (linked above) to your working directory
+#     #. Authenticated with AWS locally
+#     #. Granted yourself the appropriate permissions as described in this `AWS Braket setup document <https://docs.aws.amazon.com/braket/latest/developerguide/braket-enable-overview.html>`__
 
 from braket.aws import AwsSession, AwsQuantumJob
 from braket.jobs.config import InstanceConfig

--- a/demonstrations/qnspsa.py
+++ b/demonstrations/qnspsa.py
@@ -959,6 +959,11 @@ for i in range(300):
 # with its dependencies in the `source_scripts`
 # `folder <https://github.com/aws/amazon-braket-examples/blob/main/examples/hybrid_jobs/6_QNSPSA_optimizer_with_embedded_simulator/source_scripts/>`__.
 #
+# .. note::
+#     In order for the remainder of this demo to work, you will need to have done 3 things:
+#     1. Copied the `source_scripts` folder (linked above) to your working directory
+#     2. Authenticated with AWS locally
+#     3. Granted yourself a role with the `AmazonBraketJobsExecutionPolicy`. This can be done in the AWS console at Braket -> Permissions and Settings -> Execution Roles
 
 from braket.aws import AwsSession, AwsQuantumJob
 from braket.jobs.config import InstanceConfig

--- a/demonstrations/qnspsa.py
+++ b/demonstrations/qnspsa.py
@@ -963,7 +963,7 @@ for i in range(300):
 #     In order for the remainder of this demo to work, you will need to have done 3 things:
 #     1. Copied the `source_scripts` folder (linked above) to your working directory
 #     2. Authenticated with AWS locally
-#     3. Granted yourself a role with the `AmazonBraketJobsExecutionPolicy`. This can be done in the AWS console at Braket -> Permissions and Settings -> Execution Roles
+#     3. Granted yourself the appropriate permissions as described in this `AWS Braket setup document <https://docs.aws.amazon.com/braket/latest/developerguide/braket-enable-overview.html>`__
 
 from braket.aws import AwsSession, AwsQuantumJob
 from braket.jobs.config import InstanceConfig

--- a/demonstrations/qnspsa.py
+++ b/demonstrations/qnspsa.py
@@ -961,6 +961,7 @@ for i in range(300):
 #
 # .. note::
 #     In order for the remainder of this demo to work, you will need to have done 3 things:
+#
 #     #. Copied the `source_scripts` folder (linked above) to your working directory
 #     #. Authenticated with AWS locally
 #     #. Granted yourself the appropriate permissions as described in this `AWS Braket setup document <https://docs.aws.amazon.com/braket/latest/developerguide/braket-enable-overview.html>`__


### PR DESCRIPTION
**Summary:**
The QNSPSA demo assumes a fair bit about the user setup. This adds a note with 3 steps to guide the user to ensure they are properly set up to run this demo.

**Possible Drawbacks:**
The note may not be clear enough?

**Related GitHub Issues:**
N/A

Link to updated demo in CI site build: https://qml-build-previews.pennylane.ai/pull_request_build_preview/629/demos/qnspsa.html