### PR TITLE
[sc-29561]: Updated QML pipeline to retain downloadable python files included in demos

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Generate Build Matrix
         id: compute-strategy-matrix
         run: |
-          echo "strategy-matrix=$(python3 .github/workflows/github_job_scheduler.py \
+          echo "strategy-matrix=$(python3 .github/workflows/qml_pipeline_utils.py \
             build-strategy-matrix \
             ${{ github.workspace }} \
             --num-workers=${{ env.NUM_WORKERS }})" >> $GITHUB_OUTPUT
@@ -83,12 +83,12 @@ jobs:
           requirements: ${{ hashFiles('requirements.txt') }}
           requirements_no_deps: ${{ hashFiles('requirements_no_deps.txt') }}
           EOL
-          python3 .github/workflows/github_job_scheduler.py \
+          python3 .github/workflows/qml_pipeline_utils.py \
            remove-executable-code \
            ${{ github.workspace }} \
            --num-workers=${{ env.NUM_WORKERS }} \
            --offset=${{ matrix.offset }} \
-           --dry-run | tee -a matrix_info.txt
+           --dry-run >> matrix_info.txt
           cat matrix_info.txt
 
       - name: Install OS build dependencies
@@ -99,7 +99,7 @@ jobs:
       # See documentation in github_job_scheduler.py for more details.
       - name: Remove extraneous executable code from demos
         run: |
-          python3 .github/workflows/github_job_scheduler.py \
+          python3 .github/workflows/qml_pipeline_utils.py \
            remove-executable-code \
            ${{ github.workspace }} \
            --num-workers=${{ env.NUM_WORKERS }} \
@@ -142,7 +142,7 @@ jobs:
       # are published to the live website.
       - name: Update sitemap.xml
         run: |
-          python3 .github/workflows/github_job_scheduler.py \
+          python3 .github/workflows/qml_pipeline_utils.py \
             clean-sitemap \
             ${{  github.workspace }} \
             --html-files="demos/sg_execution_times.html" \
@@ -153,7 +153,7 @@ jobs:
       - name: Clean HTML Files
         if: matrix.offset == 0
         run: |
-          python3 .github/workflows/github_job_scheduler.py \
+          python3 .github/workflows/qml_pipeline_utils.py \
            remove-html \
            ${{ github.workspace }} \
            --num-workers=${{ env.NUM_WORKERS }} \
@@ -164,7 +164,7 @@ jobs:
       - name: Clean HTML Files and Images
         if: matrix.offset != 0
         run: |
-          python3 .github/workflows/github_job_scheduler.py \
+          python3 .github/workflows/qml_pipeline_utils.py \
            remove-html \
            ${{ github.workspace }} \
            --num-workers=${{ env.NUM_WORKERS }} \

--- a/.github/workflows/qml_pipeline_utils.py
+++ b/.github/workflows/qml_pipeline_utils.py
@@ -299,6 +299,17 @@ def _get_sphinx_role_targets(
     with sphinx_file_location.open("r", encoding=sphinx_file_encoding) as fh:
         sphinx_file_content = fh.read()
 
+    # Matches instances of the following two patterns in a file:
+    #  :{given sphinx role name}: `direct link to another asset`
+    #            OR
+    #  :{given sphinx role name}: `link text <link to another asset>`
+    # The regex itself is quite simple, the role name is added as an f-string format.
+    # The parsing of the text portion is done as:
+    #  `(.+ ?<.+>|.+)`
+    # So this matches `text <text>` OR `text`
+    # The ?P<label> notation is a feature of regex called "named groups".
+    # They make the captured data easier to use.
+    # Read more on Named groups: https://docs.python.org/3/howto/regex.html#non-capturing-and-named-groups
     sphinx_role_pattern = re.compile(
         fr":{sphinx_role_name}: ?`(.+ ?<(?P<hyperlinked_target>.+)>|(?P<direct_target>.+))`",
         flags=re_flags | re.MULTILINE,

--- a/.github/workflows/qml_pipeline_utils.py
+++ b/.github/workflows/qml_pipeline_utils.py
@@ -261,9 +261,12 @@ def _calculate_files_to_retain(
     return list(map(lambda x: x.name, files_to_retain))
 
 
-def _get_sphinx_role_targets(sphinx_file_location: PosixPath, sphinx_role_name: str,
-                             sphinx_file_encoding: str = "utf-8",
-                             re_flags: int = 0) -> List[str]:
+def _get_sphinx_role_targets(
+    sphinx_file_location: PosixPath,
+    sphinx_role_name: str,
+    sphinx_file_encoding: str = "utf-8",
+    re_flags: int = 0,
+) -> List[str]:
     """
     Given the path to a sphinx python file, this function finds the usage of a given sphinx role in the file and returns
     the targets for those roles.
@@ -296,8 +299,10 @@ def _get_sphinx_role_targets(sphinx_file_location: PosixPath, sphinx_role_name: 
     with sphinx_file_location.open("r", encoding=sphinx_file_encoding) as fh:
         sphinx_file_content = fh.read()
 
-    sphinx_role_pattern = re.compile(fr":{sphinx_role_name}: ?`(.+ ?<(?P<hyperlinked_target>.+)>|(?P<direct_target>.+))`",
-                                     flags=re_flags | re.MULTILINE)
+    sphinx_role_pattern = re.compile(
+        fr":{sphinx_role_name}: ?`(.+ ?<(?P<hyperlinked_target>.+)>|(?P<direct_target>.+))`",
+        flags=re_flags | re.MULTILINE,
+    )
 
     role_targets = []
     for match in sphinx_role_pattern.finditer(sphinx_file_content):
@@ -453,7 +458,9 @@ def remove_extraneous_html(
     verbose = parser_namespace.verbose
     offset = parser_namespace.offset
     glob_pattern = parser_namespace.glob_pattern
-    files_to_retain_with_suffix = _calculate_files_to_retain(num_workers, offset, build_directory, glob_pattern)
+    files_to_retain_with_suffix = _calculate_files_to_retain(
+        num_workers, offset, build_directory, glob_pattern
+    )
     files_to_retain = list(map(lambda f: "".join(f.split(".")[:-1]), files_to_retain_with_suffix))
 
     image_files = (root_directory / "_build" / "html" / "_images").glob("*")
@@ -504,12 +511,16 @@ def remove_extraneous_html(
                 print("Deleted", file_name)
 
     files_downloadable_artifact_targets = [
-        target.split("/")[-1]  # Get the last part (the actual file name, instead of full path to file)
+        # Get the last part (the actual file name, instead of full path to file)
+        target.split("/")[-1]
         for file_to_retain in files_to_retain_with_suffix
-        for target in _get_sphinx_role_targets(PosixPath(f"{build_directory}/{file_to_retain}"), "download")
+        for target in _get_sphinx_role_targets(
+            PosixPath(f"{build_directory}/{file_to_retain}"), "download"
+        )
     ]
-    files_downloadable_artifact_stem = list(map(lambda f: "".join(f.split(".")[:-1]),
-                                                files_downloadable_artifact_targets))
+    files_downloadable_artifact_stem = list(
+        map(lambda f: "".join(f.split(".")[:-1]), files_downloadable_artifact_targets)
+    )
     for file in chain(downloadable_python_files, downloadable_notebook_files):
         file_stem = file.stem
         file_parent = file.parent


### PR DESCRIPTION
**Title:** Updated QML pipeline to retain downloadable python files included in demos

**Summary:**
There is a bug currently in the QML pipeline where downloadable content put in _downloads/ by sphinx (with the usage of the `:download:`) is not retained and deployed by the pipeline. This results in errors on the site when downloading files that should exist.

This PR fixes the bug by attempting to retain the downloadable files for each demo.

**Relevant references:**
[sc-29561](https://app.shortcut.com/xanaduai/story/29561/qml-ci-cd-unexpected-deletion-of-downloadable-files)

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.
