### PR TITLE
[sc-26851]: Bump nightly merge version

### DIFF
--- a/.github/workflows/update-dev.yml
+++ b/.github/workflows/update-dev.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Nightly Merge
-        uses: robotology/gh-action-nightly-merge@v1.2.0
+        uses: robotology/gh-action-nightly-merge@v1.3.3
         with:
           stable_branch: 'master'
           development_branch: 'dev'


### PR DESCRIPTION
**Title:** Bump the Nightly merge action version

**Summary:**
The nightly merge is currently failing with the following error in the logs:
```
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```

This issue is due to some mishap on the files when they are volume mounted to the docker container that nightly runs. This bug has been fixed in nightly action since 1.2.0:

https://github.com/robotology/gh-action-nightly-merge/commit/bf00aca8548a774ef1e9351784cbd68c7be4d62d

Updating the action to 1.3.3 should fix this error message.


**Relevant references:**
- [sc-26851](https://app.shortcut.com/xanaduai/story/26851/fix-update-dev-workflow)

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.
