### PR TITLE
Pin setuptools to avoid breaking changes introduces in 65.6.0

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install --no-deps -r requirements_no_deps.txt
-          pip install --upgrade pip setuptools cmake
+          pip install --upgrade pip 'setuptools<65' cmake
 
       # Creates a temp file with current matrix information, which includes:
       #  - Current offset


### PR DESCRIPTION
**Title:** Pin setuptools to below 65 to avoid breaking changes

**Summary:**
There have been changes introduced in setuptools 65.6.0 that is causing issues with installation of numpy.

https://github.com/pypa/setuptools/issues/3693

This pull request pins the version of setuptools used by the pipeline to avert this issue.

@josh146 has mentioned that an alternative could be to bump the version of numpy being used. I am not sure if there would be code changes or anything else neeeded with a numpy version bump, but if there is an upgrade to the version of numpy being used then this pin can most likely be removed afterwards.

**Relevant references:**
- https://github.com/pypa/setuptools/issues/3693

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.