### PR TITLE
Update tutorial_noisy_circuits.py

### DIFF
--- a/demonstrations/tutorial_noisy_circuits.py
+++ b/demonstrations/tutorial_noisy_circuits.py
@@ -259,7 +259,7 @@ def cost(x, target):
 
 opt = qml.GradientDescentOptimizer(stepsize=10)
 steps = 35
-x = np.tensor(0.0, requires_grad=True)
+x = np.tensor(0.01, requires_grad=True)
 
 for i in range(steps):
     (x, ev), cost_val = opt.step_and_cost(cost, x, ev)


### PR DESCRIPTION
The current version of the noisy circuits tutorial begins at a critical point in the optimization landscape. Consequently, the optimization never progresses (or converges!). This can be fixed by starting slightly away from a critical point
