### PR TITLE
Bumped requirement package versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,8 +42,8 @@ matplotlib==3.5.3
 noisyopt==0.2.2
 Jinja2==2.11.3
 pyyaml==5.4.1
-jax==0.3.15
-jaxlib==0.3.15
+jax==0.4.1
+jaxlib==0.4.1
 neural-tangents==0.6.0
 flamingpy>=0.10.1b1
 plotly>=4.5.0 

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ Jinja2==2.11.3
 pyyaml==5.4.1
 jax==0.4.1
 jaxlib==0.4.1
-neural-tangents==0.6.0
+neural-tangents==0.6.1
 flamingpy>=0.10.1b1
 plotly>=4.5.0 
 kahypar==1.1.7


### PR DESCRIPTION
**Title:** Update certain requirements versions

**Summary:**
The current build of the dev branch is failing as the latest version of pennylane pulled from master branch has dropped support for some of the version pinned qml requirements.


**Relevant references:**
https://github.com/PennyLaneAI/qml/actions/runs/3722340413/jobs/6313066965#step:6:2606

**Possible Drawbacks:**
If all CI checks pass, should be good to merge

**Related GitHub Issues:**
None.