### PR TITLE
[sc-30824]: Added build-master and dev back

### DIFF
--- a/.github/workflows/build-branch-dev.yml
+++ b/.github/workflows/build-branch-dev.yml
@@ -9,6 +9,7 @@ concurrency:
   group: build-qml-demo-branch-dev
   cancel-in-progress: true
 
+
 jobs:
   build_dev:
     uses: ./.github/workflows/build-branch.yml

--- a/.github/workflows/build-branch-dev.yml
+++ b/.github/workflows/build-branch-dev.yml
@@ -1,5 +1,6 @@
 name: Build QML Branch - Dev
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0,2,4,6' # At 00:00 on Sunday, Tuesday, Thursday, and Saturday.
 

--- a/.github/workflows/build-branch-dev.yml
+++ b/.github/workflows/build-branch-dev.yml
@@ -1,0 +1,15 @@
+name: Build QML Branch - Dev
+on:
+  schedule:
+    - cron: '0 0 * * 0,2,4,6' # At 00:00 on Sunday, Tuesday, Thursday, and Saturday.
+
+
+concurrency:
+  group: build-qml-demo-branch-dev
+  cancel-in-progress: true
+
+jobs:
+  build_dev:
+    uses: ./.github/workflows/build-branch.yml
+    with:
+      branch: dev

--- a/.github/workflows/build-branch-master.yml
+++ b/.github/workflows/build-branch-master.yml
@@ -1,5 +1,6 @@
 name: Build QML Branch - Master
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0,2,4,6' # At 00:00 on Sunday, Tuesday, Thursday, and Saturday.
 

--- a/.github/workflows/build-branch-master.yml
+++ b/.github/workflows/build-branch-master.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_dev:
+  build_master:
     uses: ./.github/workflows/build-branch.yml
     with:
       branch: master

--- a/.github/workflows/build-branch-master.yml
+++ b/.github/workflows/build-branch-master.yml
@@ -9,6 +9,7 @@ concurrency:
   group: build-qml-demo-branch-master
   cancel-in-progress: true
 
+
 jobs:
   build_master:
     uses: ./.github/workflows/build-branch.yml

--- a/.github/workflows/build-branch-master.yml
+++ b/.github/workflows/build-branch-master.yml
@@ -1,0 +1,15 @@
+name: Build QML Branch - Master
+on:
+  schedule:
+    - cron: '0 0 * * 0,2,4,6' # At 00:00 on Sunday, Tuesday, Thursday, and Saturday.
+
+
+concurrency:
+  group: build-qml-demo-branch-master
+  cancel-in-progress: true
+
+jobs:
+  build_dev:
+    uses: ./.github/workflows/build-branch.yml
+    with:
+      branch: master

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -1,30 +1,25 @@
-name: Build QML Branches
+name: Build QML Branch
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * 0,2,4,6' # At 00:00 on Sunday, Tuesday, Thursday, and Saturday.
-
-concurrency:
-  group: build-docs-default-branches-${{ github.ref }}
-  cancel-in-progress: true
+    inputs:
+      branch:
+        description: The QML branch to checkout and build demos for
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      branch:
+        description: The QML branch to checkout and build demos for
+        required: true
+        type: string
 
 jobs:
   build-branch:
     runs-on: ubuntu-22.04
-
-    strategy:
-      # Set `fail-fast` to false as we do not want a build failure on one branch to automatically stop the builds on
-      # other branches. When set to true (default behavior), a failure in one matrix job cancels all other matrix jobs.
-      fail-fast: false
-      matrix:
-        branch:
-          - master
-          - dev
-
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ matrix.branch }}
+          ref: ${{ inputs.branch }}
 
       - name: Set up Python
         uses: actions/setup-python@v3
@@ -54,9 +49,11 @@ jobs:
           qml_pipeline_utils \
           parse-execution-times \
           --build-dir="${{ github.workspace }}/_build/html" > /tmp/execution_times/execution_times.json
+          
+          cat /tmp/execution_times/execution_times.json | jq
 
       - name: Upload Execution Times
         uses: actions/upload-artifact@v3
         with:
-          name: execution_times_${{ matrix.branch }}
+          name: execution_times_${{ inputs.branch }}
           path: /tmp/execution_times


### PR DESCRIPTION
**Title:** Added workflows `build-branch-master` and `build-branch-dev`

**Summary:**
The `build-master` and `build-dev` workflows were removed as part of #660 . This was done as an effort to remove duplicate code and keep one spot of definition to build any branch. This however caused an issue as outlined [sc-30824](https://app.shortcut.com/xanaduai/story/30824/add-build-master-and-build-dev-back). The https://github.com/PennyLaneAI/plugin-test-matrix repo needs to report the status of each branch build of QML, however, a limitation exists in the GitHub Api where the status check are scoped to the overall workflow only.

So to work around this, and still keep things DRY. the build-branches workflow has been converted to a re-usable workflow. A new build dev and master workflow have been added that simply call the build branch workflow. This keeps the previous DRY behavior but also enables us to monitor the status of each workflow separately using shields.

**Relevant references:**
- [sc-30824](https://app.shortcut.com/xanaduai/story/30824/add-build-master-and-build-dev-back)

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.