### PR TITLE
[sc-29723]: QML CI Workflow - Add runner load balancing

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -332,8 +332,7 @@ jobs:
 
           ${{ steps.venv.outputs.location }}/bin/qml_pipeline_utils \
           parse-execution-times \
-          --num-workers=${{ inputs.num_workers }} \
-          --offset=${{ matrix.offset }} \
+          --worker-tasks-file-loc="${{ steps.worker_tasks.outputs.file_name }}" \
           --build-type="${{ inputs.sphinx_build_output_format }}" \
           --examples-dir="${{ github.workspace }}/demonstrations" \
           --build-dir="${{ github.workspace }}/_build/html" > /tmp/execution_times/execution_times.json

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -258,7 +258,7 @@ jobs:
           cat >matrix_info.yaml <<EOL
           nonce: a
           
-          num_workers: ${{ env.NUM_WORKERS }}
+          num_workers: ${{ inputs.num_workers }}
           worker_id: ${{ matrix.offset }}
           
           python:

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -149,7 +149,7 @@ jobs:
           echo "result=$result" >> $GITHUB_OUTPUT
 
           if [ "$result" == "true" ]; then
-            build_arg='--sphinx-examples-execution-times-file=${{ github.workspace }}/execution_times.json
+            build_arg='--sphinx-examples-execution-times-file=${{ github.workspace }}/execution_times.json'
           else
             build_arg=''
           fi

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -31,6 +31,11 @@ on:
         required: false
         type: boolean
         default: false
+      enable_qml_execution_times_cache:
+        description: Indicate if the execution_times file should be cache or fetched fresh
+        required: false
+        type: boolean
+        default: false
       skip_execution_times_aggregation:
         description: Skip aggregating all the execution times from all workers into one file
         required: false
@@ -69,16 +74,108 @@ jobs:
           cd .github/workflows/qml_pipeline_utils
           pip install .
 
+      - name: Execution Times Cache
+        id: execution_times_cache
+        if: inputs.enable_qml_execution_times_cache == true
+        uses: actions/cache@v3
+        with:
+          path: execution_times.json
+          key: execution_times-${{ inputs.branch }}
+
+      - name: Fetch Execution Times Target Branch
+        id: execution_times_target_branch
+        if: steps.execution_times_cache.outputs.cache-hit != 'true'
+        run: |
+          [[ "${{ inputs.branch }}" == "dev" || "${{ github.event.pull_request.base.ref }}" == "dev" ]] && name="dev" || name="master"
+          echo $name
+          echo "name=$name" >> $GITHUB_OUTPUT
+
+      - name: Fetch Execution Times Target Branch Latest Workflow run ID
+        id: workflow_run_id
+        if: steps.execution_times_cache.outputs.cache-hit != 'true'
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const destWorkflowBranch = "${{ steps.execution_times_target_branch.outputs.name }}";
+
+            try {
+              const workflowRuns = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: `build-branch-${destWorkflowBranch}.yml`,
+                branch: 'master',
+                status: 'success',
+                exclude_pull_requests: true,
+                per_page: 1,
+                page: 1
+              });
+              const runData = workflowRuns.data.workflow_runs;
+              return (runData.length) ? runData[0].id : '';
+            } catch (e) {
+              console.log(`Unable to fetch workflow ID, error: ${e}`);
+              return '';
+            }
+
+      - name: Download Demo Execution run times
+        if: steps.execution_times_cache.outputs.cache-hit != 'true' && steps.workflow_run_id.outputs.result != ''
+        uses: XanaduAI/cloud-actions/download-github-workflow-artifact@main
+        with:
+          workflow_run_id: ${{ steps.workflow_run_id.outputs.result }}
+          artifact_name_regex: execution_times\.zip
+          github_token: ${{ github.token }}
+
+      - name: Unpack Execution run times file
+        if: steps.execution_times_cache.outputs.cache-hit != 'true' && steps.workflow_run_id.outputs.result != ''
+        run: |
+          ls
+          FILE='execution_times.zip.zip'
+          if [ -f "$FILE" ]; then
+            echo "$FILE exists."
+            unzip execution_times.zip
+          fi
+
+      - name: Check Execution Times file exists
+        id: check_execution_times_file_existence
+        run: |
+          [ -f "execution_times.json" ] && result='true' || result='false'
+          echo $result
+          echo "result=$result" >> $GITHUB_OUTPUT
+
       - name: Generate Build Matrix
         id: compute-strategy-matrix
         run: |
-          echo "strategy-matrix=$(qml_pipeline_utils \
+          WK_LOAD_ARTIFACT_NAME='worker_load'
+          WK_LOAD_FILE_NAME='${{ github.workspace }}/worker_load.json'
+          touch $WK_LOAD_FILE_NAME
+
+          echo "$(qml_pipeline_utils \
             build-strategy-matrix \
             --num-workers=${{ inputs.num_workers }} \
-            --examples-dir='${{ github.workspace }}/demonstrations')" >> $GITHUB_OUTPUT
+            --examples-dir='${{ github.workspace }}/demonstrations' \
+            ${{ steps.check_execution_times_file_existence.outputs.result == 'true'
+                && format('--sphinx-examples-execution-times-file={0}/execution_times.json', github.workspace) 
+                || '' }})" >> $WK_LOAD_FILE_NAME
+
+          echo "worker_load_artifact_name=$WK_LOAD_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+          echo "worker_load_file_name=$WK_LOAD_FILE_NAME" >> $GITHUB_OUTPUT
+
+          cat "$WK_LOAD_FILE_NAME" | jq
+
+          worker_count=$(jq -r '.workers | length' "$WK_LOAD_FILE_NAME")
+          matrix=$(python -c "print(list(range($worker_count)))")
+          echo "strategy-matrix=$matrix" >> $GITHUB_OUTPUT
+
+      - name: Upload Worker Load Data as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.compute-strategy-matrix.outputs.worker_load_artifact_name }}
+          path: ${{ steps.compute-strategy-matrix.outputs.worker_load_file_name }}
 
     outputs:
       strategy-matrix: ${{ steps.compute-strategy-matrix.outputs.strategy-matrix }}
+      worker-load-file-name: ${{ steps.compute-strategy-matrix.outputs.worker_load_file_name }}
+      worker-load-artifact-name: ${{ steps.compute-strategy-matrix.outputs.worker_load_artifact_name }}
 
   build-branch:
     runs-on: ubuntu-22.04
@@ -125,38 +222,62 @@ jobs:
           ${{ steps.venv.outputs.location }}/bin/python3 -m pip install --no-deps -r requirements_no_deps.txt
           ${{ steps.venv.outputs.location }}/bin/python3 -m pip install --upgrade pip 'setuptools<65' cmake
 
-      # Creates a temp file with current matrix information, which includes:
-      #  - Current offset
-      #  - Total Workers
-      #  - Metadata regarding the Python version and dependencies
-      #  - The name of files that will be executed by this worker
+      - name: Download Worker Load Data Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.compute-build-strategy-matrix.outputs.worker-load-artifact-name }}
+
+      - name: Extract Current Worker Tasks
+        id: worker_tasks
+        env:
+          worker_id: ${{ matrix.offset }}
+          worker_load_file_name: ${{ needs.compute-build-strategy-matrix.outputs.worker-load-file-name }}
+        run: |
+          WK_TASKS_FILE_NAME='worker_tasks.json'
+          jq .workers[${{ env.worker_id }}].tasks ${{ env.worker_load_file_name }} > "$WK_TASKS_FILE_NAME"
+          
+          cat "$WK_TASKS_FILE_NAME" | jq
+          
+          echo "file_name=$WK_TASKS_FILE_NAME" >> $GITHUB_OUTPUT 
+
+      # Creates a temp yaml file with current environment information:
+      # ```
+      #  nonce: arbitrary value, we can change this to invalidate all previous caches if needed
+      #  num_workers: The total number of workers currently spawned
+      #  worker_id: The offset in the strategy matrix for the current worker
+      #  python.version: The version of python that was setup using actions/setup-python
+      #  python.hash.requirements-txt: The hash of the requirements.txt file
+      #  python.hash.requirements_no_deps-txt: The hash of the requirements_no_deps.txt file
+      # ```
       # The hash of this file is used as portion of the key in subsequent caching steps.
-      # This ensures that if the number of worker, tutorials, or python evironment details change,
+      # This ensures that if the values in this file change,
       # it will invalidate the previous cache and build fresh.
       - name: Set Matrix offset file
         run: |
-          cat >matrix_info.txt <<EOL
-          workers: ${{ env.NUM_WORKERS }}
-          offset: ${{ matrix.offset }}
-          ---
-          python_version: ${{ steps.setup_python.outputs.python-version }}
-          requirements: ${{ hashFiles('requirements.txt') }}
-          requirements_no_deps: ${{ hashFiles('requirements_no_deps.txt') }}
+          worker_files=$(jq [.[].name] ${{ steps.worker_tasks.outputs.file_name }} | sed 's/^/  /')
+          cat >matrix_info.yaml <<EOL
+          nonce: a
+          
+          num_workers: ${{ env.NUM_WORKERS }}
+          worker_id: ${{ matrix.offset }}
+          
+          python:
+            version: ${{ steps.setup_python.outputs.python-version }}
+            hash:
+              requirements-txt: ${{ hashFiles('requirements.txt') }}
+              requirements_no_deps-txt: ${{ hashFiles('requirements_no_deps.txt') }}
+          
+          worker_files: |
+          $worker_files
           EOL
 
-          ${{ steps.venv.outputs.location }}/bin/qml_pipeline_utils \
-          show-worker-files \
-          --num-workers=${{ inputs.num_workers }} \
-          --examples-dir="${{ github.workspace }}/demonstrations" \
-          --offset=${{ matrix.offset }} >> matrix_info.txt
-
-          cat matrix_info.txt
+          cat matrix_info.yaml
 
       - name: Generate hash of the matrix file
         id: matrix_file
         if: inputs.enable_sphinx_cache == true
         run: |
-          echo "hash=${{ hashFiles('matrix_info.txt') }}" >> $GITHUB_OUTPUT
+          echo "hash=${{ hashFiles('matrix_info.yaml') }}" >> $GITHUB_OUTPUT
 
       - name: Install OS build dependencies
         run: |
@@ -168,9 +289,8 @@ jobs:
         run: |
           ${{ steps.venv.outputs.location }}/bin/qml_pipeline_utils \
           remove-executable-code-from-extraneous-demos \
-          --num-workers=${{ inputs.num_workers }} \
+          --worker-tasks-file-loc="${{ steps.worker_tasks.outputs.file_name }}" \
           --examples-dir="${{ github.workspace }}/demonstrations" \
-          --offset=${{ matrix.offset }} \
           --verbose
 
       - name: Gallery Cache
@@ -246,11 +366,10 @@ jobs:
         run: |
           ${{ steps.venv.outputs.location }}/bin/qml_pipeline_utils \
           remove-extraneous-built-html-files \
-          --num-workers=${{ inputs.num_workers }} \
+          --worker-tasks-file-loc="${{ steps.worker_tasks.outputs.file_name }}" \
           --build-dir="${{ github.workspace }}/_build/html" \
           --examples-dir="${{ github.workspace }}/demonstrations" \
           --build-type="${{ inputs.sphinx_build_output_format }}" \
-          --offset=${{ matrix.offset }} \
           --preserve-non-sphinx-images \
           --verbose
 
@@ -259,11 +378,10 @@ jobs:
         run: |
           ${{ steps.venv.outputs.location }}/bin/qml_pipeline_utils \
           remove-extraneous-built-html-files \
-          --num-workers=${{ inputs.num_workers }} \
+          --worker-tasks-file-loc="${{ steps.worker_tasks.outputs.file_name }}" \
           --build-dir="${{ github.workspace }}/_build/html" \
           --examples-dir="${{ github.workspace }}/demonstrations" \
           --build-type="${{ inputs.sphinx_build_output_format }}" \
-          --offset=${{ matrix.offset }} \
           --verbose
 
       - name: Upload Html

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -86,7 +86,13 @@ jobs:
         id: execution_times_target_branch
         if: steps.execution_times_cache.outputs.cache-hit != 'true'
         run: |
-          [[ "${{ inputs.branch }}" == "dev" || "${{ github.event.pull_request.base.ref }}" == "dev" ]] && name="dev" || name="master"
+          current_build_branch='${{ inputs.branch }}'
+          pull_request_target_branch='${{ github.event.pull_request.base.ref }}'
+          if [ "$current_build_branch" == "dev" || "$pull_request_target_branch" == "dev" ]; then
+            name="dev"
+          else
+            name="master
+          fi
           echo $name
           echo "name=$name" >> $GITHUB_OUTPUT
 
@@ -142,6 +148,13 @@ jobs:
           echo $result
           echo "result=$result" >> $GITHUB_OUTPUT
 
+          if [ "$result" == "true" ]; then
+            build_arg='--sphinx-examples-execution-times-file=${{ github.workspace }}/execution_times.json
+          else
+            build_arg=''
+          fi
+          echo "build_arg=$build_arg" >> $GITHUB_OUTPUT
+
       - name: Generate Build Matrix
         id: compute-strategy-matrix
         run: |
@@ -153,9 +166,7 @@ jobs:
             build-strategy-matrix \
             --num-workers=${{ inputs.num_workers }} \
             --examples-dir='${{ github.workspace }}/demonstrations' \
-            ${{ steps.check_execution_times_file_existence.outputs.result == 'true'
-                && format('--sphinx-examples-execution-times-file={0}/execution_times.json', github.workspace) 
-                || '' }})" >> $WK_LOAD_FILE_NAME
+            ${{ steps.check_execution_times_file_existence.outputs.build_arg }})" >> $WK_LOAD_FILE_NAME
 
           echo "worker_load_artifact_name=$WK_LOAD_ARTIFACT_NAME" >> $GITHUB_OUTPUT
           echo "worker_load_file_name=$WK_LOAD_FILE_NAME" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -166,7 +166,7 @@ jobs:
           matrix=$(python -c "print(list(range($worker_count)))")
           echo "strategy-matrix=$matrix" >> $GITHUB_OUTPUT
 
-      - name: Upload Worker Load Data as Artifact
+      - name: Upload Workers Load Data as Artifact
         uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.compute-strategy-matrix.outputs.worker_load_artifact_name }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -21,6 +21,7 @@ jobs:
       enable_python_cache: false
       enable_sphinx_cache: true
       refresh_sphinx_cache: ${{ contains(github.event.pull_request.labels.*.name, 'ignore-qml-cache') }}
+      enable_qml_execution_times_cache: true
       skip_execution_times_aggregation: true
       skip_sphinx_build_file_aggregation: true
       sphinx_build_output_format: html

--- a/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/cli.py
+++ b/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/cli.py
@@ -145,8 +145,7 @@ def cli_parser():
     )
     add_flags_to_subparser(
         subparsers_parse_execution_times,
-        "num-workers",
-        "offset",
+        "worker-tasks-file-loc",
         "examples-dir",
         "build-dir",
         "gallery-dir-name",
@@ -218,8 +217,7 @@ def cli_parser():
         "parse-execution-times": {
             "func": qml_pipeline_utils.services.parse_execution_times,
             "kwargs": {
-                "num_workers": getattr(parser_results, "num_workers", None),
-                "offset": getattr(parser_results, "offset", None),
+                "worker_tasks_file_loc": Path(getattr(parser_results, "worker_tasks_file_loc", "")),
                 "sphinx_examples_dir": Path(getattr(parser_results, "examples_dir", "")),
                 "glob_pattern": getattr(parser_results, "glob_pattern", None),
                 "sphinx_build_directory": Path(getattr(parser_results, "build_dir", "")),

--- a/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/cli.py
+++ b/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/cli.py
@@ -31,7 +31,7 @@ COMMON_CLI_FLAGS = {
         "type": str,
         "help": "The output format of sphinx-build",
         "required": False,
-        "default": "html"
+        "default": "html",
     },
     "offset": {
         "type": int,
@@ -48,6 +48,11 @@ COMMON_CLI_FLAGS = {
         "default": "demos",
         "required": False,
         "help": "The gallery directory name inside build-dir where sphinx puts all gallery demo html files",
+    },
+    "worker-tasks-file-loc": {
+        "type": str,
+        "help": "The location of the worker tasks file containing files relevant for the current worker",
+        "required": True,
     },
 }
 
@@ -74,6 +79,12 @@ def cli_parser():
     add_flags_to_subparser(
         subparsers_build_strategy_matrix, "num-workers", "examples-dir", "glob-pattern"
     )
+    subparsers_build_strategy_matrix.add_argument(
+        "--sphinx-examples-execution-times-file",
+        help="The path to the JSON file containing all the execution times for the demos",
+        default=None,
+        required=False,
+    )
 
     subparsers_remove_executable_code = subparsers.add_parser(
         "remove-executable-code-from-extraneous-demos",
@@ -81,9 +92,8 @@ def cli_parser():
     )
     add_flags_to_subparser(
         subparsers_remove_executable_code,
-        "num-workers",
+        "worker-tasks-file-loc",
         "examples-dir",
-        "offset",
         "dry-run",
         "verbose",
         "glob-pattern",
@@ -96,15 +106,13 @@ def cli_parser():
     )
     add_flags_to_subparser(
         subparsers_remove_html,
-        "num-workers",
+        "worker-tasks-file-loc",
         "build-dir",
         "examples-dir",
         "gallery-dir-name",
         "build-type",
-        "offset",
         "dry-run",
         "verbose",
-        "glob-pattern",
     )
     subparsers_remove_html.add_argument(
         "--preserve-non-sphinx-images",
@@ -154,15 +162,17 @@ def cli_parser():
             "kwargs": {
                 "num_workers": getattr(parser_results, "num_workers", None),
                 "sphinx_examples_dir": Path(getattr(parser_results, "examples_dir", "")),
+                "sphinx_examples_execution_times_file_loc": getattr(
+                    parser_results, "sphinx_examples_execution_times_file", None
+                ),
                 "glob_pattern": getattr(parser_results, "glob_pattern", None),
             },
         },
         "remove-executable-code-from-extraneous-demos": {
             "func": qml_pipeline_utils.services.remove_executable_code_from_extraneous_demos,
             "kwargs": {
-                "num_workers": getattr(parser_results, "num_workers", None),
+                "worker_tasks_file_loc": Path(getattr(parser_results, "worker_tasks_file_loc", "")),
                 "sphinx_examples_dir": Path(getattr(parser_results, "examples_dir", "")),
-                "offset": getattr(parser_results, "offset", None),
                 "dry_run": getattr(parser_results, "dry_run", None),
                 "verbose": getattr(parser_results, "verbose", None),
                 "glob_pattern": getattr(parser_results, "glob_pattern", None),
@@ -171,7 +181,7 @@ def cli_parser():
         "remove-extraneous-built-html-files": {
             "func": qml_pipeline_utils.services.remove_extraneous_built_html_files,
             "kwargs": {
-                "num_workers": getattr(parser_results, "num_workers", None),
+                "worker_tasks_file_loc": Path(getattr(parser_results, "worker_tasks_file_loc", "")),
                 "sphinx_build_directory": Path(getattr(parser_results, "build_dir", "")),
                 "sphinx_examples_dir": Path(getattr(parser_results, "examples_dir", "")),
                 "sphinx_gallery_dir_name": getattr(parser_results, "gallery_dir_name", None),
@@ -179,10 +189,8 @@ def cli_parser():
                 "preserve_non_sphinx_images": getattr(
                     parser_results, "preserve_non_sphinx_images", None
                 ),
-                "offset": getattr(parser_results, "offset", None),
                 "dry_run": getattr(parser_results, "dry_run", None),
                 "verbose": getattr(parser_results, "verbose", None),
-                "glob_pattern": getattr(parser_results, "glob_pattern", None),
             },
         },
         "clean-sitemap": {

--- a/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/job_distributor.py
+++ b/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/job_distributor.py
@@ -151,6 +151,7 @@ class Worker:
     def tasks(self) -> List[QMLDemo]:
         return sorted(self.__tasks, key=lambda t: t.name)
 
+    # this add_task should not be used directly. See add_task in `SortedWorkerHandler` instead
     def add_task(self, task: QMLDemo) -> None:
         self.__tasks.append(task)
 

--- a/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/job_distributor.py
+++ b/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/job_distributor.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+
+"""
+This python file implements a very simple version of the "Least Connection" load balancing algorithm.
+Read More on the least connection algorithm here:
+  - https://www.cloudflare.com/en-gb/learning/performance/types-of-load-balancing-algorithms/
+  - https://nginx.org/en/docs/http/ngx_http_upstream_module.html#least_conn
+  - https://www.educative.io/answers/what-is-the-least-connections-load-balancing-technique
+
+The `SortedWorkerHandler` implements this algorithm by assigning tasks to the Worker that currently
+has the least load on it. The specific implementation of the algorithm in this module is specific to QML
+and works most efficiently when the load of all tasks are known ahead of time, since that can be distributed the best.
+
+Sample Usage:
+
+>>> my_demo_loads = [
+...    QMLDemo("QML_Demo_A", 7),
+...    QMLDemo("QML_Demo_B", 4),
+...    QMLDemo("QML_Demo_C", 1),
+...    QMLDemo("QML_Demo_D", 9),
+...    QMLDemo("QML_Demo_E", 16),
+...    QMLDemo("QML_Demo_F", 23),
+...    QMLDemo("QML_Demo_G", 1),
+...    QMLDemo("QML_Demo_H", 4),
+...]
+>>> worker_handler = SortedWorkerHandler(num_workers=3)
+
+The main thing to note here are the loads that will be distributed over the 3 workers:
+ -> 7, ,4, 1, 9, 16, 23, 1, 4
+
+>>> worker_handler.add_task(*my_demo_loads)
+>>> worker_handler.assign_tasks_to_workers()
+
+The first thing that will happen is that the tasks will be sorted from the highest load to lowest:
+  -> 23, 16, 9, 7, 4, 4, 1, 1
+
+Next the first task will be assigned to the worker that currently has the lowest load. The SortedWorkerHandler maintains
+a sorted list of workers internally, after a task is added to a worker, the list is re-sorted such that
+the first element is always the worker currently with the least amount of load.
+
+So let's say we have the following workers: [0, 1, 2]
+
+The tasks will be distributed as following:
+
+Task Load  |  Worker ID  |  Total Load on Worker after this task is added
+--------------------------------------------------------------------------
+  23       |     0       |    23
+  16       |     1       |    16
+  9        |     2       |     9
+  7        |     2       |    16
+  4        |     1       |    20
+  4        |     2       |    20
+  1        |     1       |    21
+  1        |     1       |    21
+Note: The `Worker ID` here is added for illustrative purposes, there is no worker id needed in the actual implementation
+      as the list indexes do the job much better.
+
+So at the end the total load on each worker is: 23, 21, 21
+Which is the closest equal distribution of that list of tasks possible.
+
+The `load` here refers to the amount of time it takes to execute a sphinx demo.
+
+Once all the tasks have been passed to the worker handler:
+
+>>> worker_handler.workers
+
+Will return the list of workers with the tasks distributed
+
+Another example:
+
+>>> my_demo_loads = [
+...    QMLDemo("QML_Demo_A", 1),
+...    QMLDemo("QML_Demo_B", 1),
+...    QMLDemo("QML_Demo_C", 1),
+...    QMLDemo("QML_Demo_D", 6),
+...    QMLDemo("QML_Demo_E", 12),
+...    QMLDemo("QML_Demo_F", 9)
+...]
+>>> worker_handler = SortedWorkerHandler(num_workers=2)
+>>> worker_handler.add_task(*my_demo_loads)
+>>> worker_handler.assign_tasks_to_workers()
+
+Step 1: sort all loads from the highest to lowest:
+  -> 12, 9, 6, 1, 1, 1
+
+Step 2: Create two workers Worker(0) and Worker(1)
+
+
+Step 3: Distribute:
+Task Load  |  Worker ID  |  Total Load on Worker after this task is added
+--------------------------------------------------------------------------
+  12       |     0       |    12
+   9       |     1       |     9
+   6       |     1       |    15
+   1       |     0       |    13
+   1       |     0       |    14
+   1       |     0       |    15
+
+Final workload:
+  - Worker(0) = 15
+  - Worker(1) = 15
+
+Serializing the result:
+
+>>> json.dumps(worker_handler, cls=WorkerAndTaskJSONEncoder)
+"""
+
+import json
+from dataclasses import dataclass, asdict, field
+from typing import Any, Dict, List, Union
+
+
+@dataclass(frozen=True)
+class ReturnTypes:
+    DictQMLDemo = Dict[str, Union[int, float, str, Dict[str, Any]]]
+    DictWorker = Dict[str, Union[int, float, DictQMLDemo]]
+    DictSortedWorkerHandler = Dict[str, Union[int, List[DictWorker]]]
+
+
+@dataclass
+class QMLDemo:
+    """
+    A simple struct representing a QML Demo. The most important attribute here is the `load`, however
+    the name is required to distinguish the Demo once it has been assigned to a worker.
+
+    Args:
+        name (str): The name of the Demo, can be path to demo as string.
+        load (int, float): The amount of time it takes sphinx to execute this demo.
+        metadata (Dict[str, Any]): Any additional (and optional) information about the demo that can be stored at
+                                   initialization for usage later.
+    """
+
+    name: str
+    load: Union[int, float]
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class Worker:
+    """
+    Represent a worker and is used to track all the tasks assigned to a specific instance of Worker.
+    """
+
+    def __init__(self):
+        self.__tasks: List[QMLDemo] = []
+
+    @property
+    def load(self) -> Union[int, float]:
+        return sum([task.load for task in self.__tasks])
+
+    @property
+    def tasks(self) -> List[QMLDemo]:
+        return sorted(self.__tasks, key=lambda t: t.name)
+
+    def add_task(self, task: QMLDemo) -> None:
+        self.__tasks.append(task)
+
+    def __repr__(self):
+        return f"<Worker({self.tasks})>"
+
+    def asdict(self) -> ReturnTypes.DictWorker:
+        return {"load": self.load, "tasks": [asdict(t) for t in self.tasks]}
+
+
+class SortedWorkerHandler:
+    """
+    Manages a sorted list of `Worker` class instances.
+
+    Tasks should be added to this class instead of an instance of a Worker class directly. This class will manage and
+    track the loads of all the workers.
+
+    The class buffers all incoming tasks in an internal list and distributes the load across workers once `assign_tasks_to_workers`
+    is called.
+    """
+
+    def __init__(self, num_workers: int):
+        self.__task_buffer: List[QMLDemo] = []
+        self.__workers: List[Worker] = [Worker() for _ in range(num_workers)]
+
+    @property
+    def workers(self) -> List[Worker]:
+        return self.__workers
+
+    @property
+    def num_workers(self) -> int:
+        return len(self.__workers)
+
+    def add_task(self, *task: QMLDemo) -> None:
+        self.__task_buffer.extend(task)
+
+    def __assign_task_to_workers(self, task: QMLDemo) -> None:
+        min_loaded_worker = self.__workers.pop(0)
+        min_loaded_worker.add_task(task)
+
+        if self.num_workers == 0:  # There is only 1 worker
+            self.__workers.append(min_loaded_worker)
+            return None
+
+        new_load_on_worker = min_loaded_worker.load
+
+        max_loaded_worker = self.__workers[-1].load
+        index_to_insert_worker = self.num_workers
+        if new_load_on_worker < max_loaded_worker:
+            for i, worker in enumerate(self.__workers):
+                if worker.load > new_load_on_worker:
+                    index_to_insert_worker = i
+                    break
+        self.__workers.insert(index_to_insert_worker, min_loaded_worker)
+
+        return None
+
+    def assign_tasks_to_workers(self) -> None:
+        sorted_tasks = sorted(self.__task_buffer, key=lambda t: t.load, reverse=True)
+        for task in sorted_tasks:
+            self.__assign_task_to_workers(task)
+        self.__task_buffer: List[QMLDemo] = []
+
+    def __getitem__(self, index: int) -> Worker:
+        return self.__workers[index]
+
+    def asdict(self) -> ReturnTypes.DictSortedWorkerHandler:
+        return {"num_workers": self.num_workers, "workers": [wk.asdict() for wk in self.workers]}
+
+
+class WorkerAndTaskJSONEncoder(json.JSONEncoder):
+    def default(self, o: Union[QMLDemo, Worker, SortedWorkerHandler]):
+        if isinstance(o, QMLDemo):
+            return asdict(o)
+        elif isinstance(o, Worker):
+            return {"load": o.load, "tasks": [self.default(t) for t in o.tasks]}
+        elif isinstance(o, SortedWorkerHandler):
+            return {"num_workers": o.num_workers, "workers": [self.default(wk) for wk in o.workers]}
+        else:
+            return super().default(o)

--- a/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/job_distributor.py
+++ b/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/job_distributor.py
@@ -26,7 +26,7 @@ Sample Usage:
 >>> worker_handler = SortedWorkerHandler(num_workers=3)
 
 The main thing to note here are the loads that will be distributed over the 3 workers:
- -> 7, ,4, 1, 9, 16, 23, 1, 4
+ -> 7, 4, 1, 9, 16, 23, 1, 4
 
 >>> worker_handler.add_task(*my_demo_loads)
 >>> worker_handler.assign_tasks_to_workers()

--- a/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/services/build_strategy_matrix.py
+++ b/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/services/build_strategy_matrix.py
@@ -1,80 +1,70 @@
 from __future__ import annotations
-from typing import List, TYPE_CHECKING
+import json
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-from ..common import calculate_files_per_worker, WorkerFileCount
+from ..job_distributor import SortedWorkerHandler, QMLDemo, ReturnTypes
 
 
 def build_strategy_matrix_offsets(
-    num_workers: int, sphinx_examples_dir: Path, glob_pattern: str = "*.py"
-) -> List[str]:
+    num_workers: int,
+    sphinx_examples_dir: Path,
+    sphinx_examples_execution_times_file_loc: str = None,
+    glob_pattern: str = "*.py",
+) -> ReturnTypes.DictSortedWorkerHandler:
     """
-    Generates a JSON list of "offsets" that indicate where each node should start building tutorials from.
-    This function calculates how many files should be allocated per worker, then generates a list indicating the index
-    each worker should start executing tutorials at.
+    Generates a JSON Dict of the following schema:
 
-    Example:
-        If you have 15 tutorials (files are globbed using pathlib):
-        [
-          "0.py",  # File names in this case are their respective indexes in this list (illustrative purpose)
-          "1.py",
-          "2.py",
-          "3.py",
-          "4.py",
-          "5.py",
-          "6.py",
-          "7.py",
-          "8.py",
-          "9.py",
-          "10.py",
-          "11.py",
-          "12.py",
-          "13.py",
-          "14.py"
+    {
+        "num_workers": <int: Total number of workers jobs were distributed across>
+        "workers": [
+            {
+                "load": <int: Total load on this worker (sum of load on all assigned tasks)>
+                "tasks": [
+                    {
+                        "name": <str: The name of the demo (example.py)>
+                        "load": <int: The millisecond representation of how long it took to execute this demo>
+                    }
+                ]
+            }
         ]
-        And you have 3 workers, then the files to be executed per worker is:
-        math.ceil(15 / 3) = 5
+    }
 
-        The above list is then broken into chunks of 5
-        [
-          "0.py",  <-- Worker 1 start point
-          "1.py",
-          "2.py",
-          "3.py",
-          "4.py",
-          "5.py",  <-- Worker 2 start point
-          "6.py",
-          "7.py",
-          "8.py",
-          "9.py",
-          "10.py", <-- Worker 3 start point
-          "11.py",
-          "12.py",
-          "13.py",
-          "14.py"
-        ]
+    The jobs are distributed across the workers as evenly as possible. To see the methodology of the distribution,
+    please see ../../job_distributor.py. Details are there.
 
-        Keeping the above in mind, the output of the function for the above case would be:
+    This function also adds 1 to the load of all demos. This is done to handle the case where you may not know the
+    load of the demos or unable to fetch that information. This would make the SortedWorkerHandler job to distribute
+    the jobs evenly across all the workers, if all the demos had a load of 0, then they would all go into 1 worker
+    as the SortedWorkerHandler would see them all not requiring any power to build.
 
-        -> [0, 5, 10]
-        This when fed into GitHub's strategy.matrix will tell the workflow to spawn 3 nodes.
 
-        Each node will have access to its own offset from this list. It will recalculate the total files to execute
-        and determine the files relevant to it.
     Args:
         num_workers: The total number of nodes that needs to be spawned
         sphinx_examples_dir: The directory where all the sphinx demonstrations reside
+        sphinx_examples_execution_times_file_loc: The path to the JSON file
+                                                  containing the name of demos to execution time
         glob_pattern: The pattern use to glob all demonstration files inside sphinx_examples_dir. Defaults to "*.py"
 
     Returns:
-        List[str]. JSON list of integers indicating the offset of each node to execute tutorials.
+        ReturnTypes.DictSortedWorkerHandler
     """
-    file_info: WorkerFileCount = calculate_files_per_worker(
-        num_workers, sphinx_examples_dir, glob_pattern
-    )
-    file_count = file_info.total_files
-    files_per_worker = file_info.files_per_worker
+    if sphinx_examples_execution_times_file_loc is not None:
+        with open(sphinx_examples_execution_times_file_loc) as fh:
+            execution_times = json.load(fh)
+    else:
+        execution_times = {}
+    job_distribution_handler = SortedWorkerHandler(num_workers=num_workers)
+    for sphinx_examples_file_name in sphinx_examples_dir.glob(glob_pattern):
+        # Adding +1 to load of each demo as we want the load on all demos to be >1 in order for distribution
+        # To work well
+        job = QMLDemo(
+            name=sphinx_examples_file_name.name,
+            load=execution_times.get(sphinx_examples_file_name.name, 0) + 1,
+        )
+        job_distribution_handler.add_task(job)
+    job_distribution_handler.assign_tasks_to_workers()
 
-    return list(range(0, file_count, files_per_worker))
+    return job_distribution_handler.asdict()

--- a/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/services/parse_execution_times.py
+++ b/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/services/parse_execution_times.py
@@ -11,11 +11,10 @@ PATTERN_FLAGS = re.MULTILINE
 PATTERN_TUTORIAL_NAME = re.compile(
     r"<span\sclass=\\?\"pre\\?\">([a-zA-Z0-9_\-]+\.py)</span>", flags=PATTERN_FLAGS
 )
-PATTERN_TUTORIAL_TIME = re.compile(r"<td><p>(\d{2}:\d{2}.\d{3})</p></td>", flags=PATTERN_FLAGS)
+PATTERN_TUTORIAL_TIME = re.compile(r"<td><p>(\d{2}:\d{2}.\d{3,4})</p></td>", flags=PATTERN_FLAGS)
 
 MS_IN_MIN = 60000  # Number of milliseconds in a minute
 MS_IN_SEC = 1000  # Number of milliseconds in a second
-MS_IN_DSC = 100  # Number of milliseconds in a decisecond (tenth of a second)
 
 
 def convert_execution_time_to_ms(execution_time: str) -> int:
@@ -33,7 +32,7 @@ def convert_execution_time_to_ms(execution_time: str) -> int:
     return (
         (execution_time_min * MS_IN_MIN)
         + (execution_time_sec * MS_IN_SEC)
-        + (execution_time_dsc * MS_IN_DSC)
+        + execution_time_dsc
     )
 
 

--- a/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/services/parse_execution_times.py
+++ b/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/services/parse_execution_times.py
@@ -100,9 +100,7 @@ def parse_execution_times(
     # Hard coding the filename here as it is not something the user controls.
     # The sg_execution_times exists inside the directory sphinx puts all the built "galleries"
     sg_execution_file_location = (
-        sphinx_build_directory
-        / sphinx_gallery_dir_name
-        / f"sg_execution_times.{sphinx_build_type}"
+        sphinx_build_directory / sphinx_gallery_dir_name / f"sg_execution_times.{sphinx_build_type}"
     )
 
     with sg_execution_file_location.open("r") as fh:

--- a/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/services/remove_extraneous_built_html_files.py
+++ b/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/services/remove_extraneous_built_html_files.py
@@ -1,23 +1,26 @@
+from __future__ import annotations
 import re
+import json
 from shutil import rmtree
 from pathlib import Path
 from itertools import chain
-from typing import Optional, List
+from typing import Optional, List, TYPE_CHECKING
 
-from ..common import calculate_files_to_retain, get_sphinx_role_targets
+from ..common import get_sphinx_role_targets
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def remove_extraneous_built_html_files(
-    num_workers: int,
+    worker_tasks_file_loc: Path,
     sphinx_build_directory: Path,
     sphinx_examples_dir: Path,
     sphinx_gallery_dir_name: str,
     preserve_non_sphinx_images: bool,
-    offset: int,
     sphinx_build_type: str = "html",
     dry_run: bool = False,
     verbose: bool = False,
-    glob_pattern: str = "*.py",
 ) -> Optional[List[str]]:
     """
     Deletes all html files after sphinx-build that are not relevant to the current node.
@@ -29,29 +32,32 @@ def remove_extraneous_built_html_files(
     That can be used to determine which images are relevant to this node and the remaining images are deleted.
 
     Args:
-        num_workers: The total number of workers that are in the workflow
+        worker_tasks_file_loc: Path to JSON file that contains the tasks relevant to the current worker.
+                  Expected synatx of file:
+                  ```
+                  [
+                    {"name": "demo_name.py", "load": 123123},
+                    ...
+                  ]
+                  ```
         sphinx_build_directory: The directory where sphinx outputs the built demo html files reside
         sphinx_examples_dir: The directory where all the sphinx demonstrations reside
         sphinx_gallery_dir_name: The same of the directory in sphinx_build_directory
         preserve_non_sphinx_images: Indicate if images that are static across all workers should be preserved
-        offset: The current worker offset from GitHub strategy matrix
-        sphinx_build_type: The output format of sphinx-build, Valid values are "html" and "json"
         dry_run: Return files that will be updated instead of updating them
         verbose: Additional logging output
-        glob_pattern: Pattern to use to glob all files in the sphinx_examples_dir
 
     Returns:
         By default, return `None`. If dry_run flag is set from cli, then returns a list of file names that will
         be deleted.
     """
+    with worker_tasks_file_loc.open() as fh:
+        worker_tasks_all = json.load(fh)
 
-    assert sphinx_build_type in {"html", "json"}, "Invalid sphinx build type"
     if sphinx_build_type == "json":
         sphinx_build_type = "fjson"
 
-    files_to_retain_with_suffix = calculate_files_to_retain(
-        num_workers, offset, sphinx_examples_dir, glob_pattern
-    )
+    files_to_retain_with_suffix = [task["name"] for task in worker_tasks_all]
     files_to_retain = list(map(lambda f: "".join(f.split(".")[:-1]), files_to_retain_with_suffix))
 
     image_files = (sphinx_build_directory / "_images").glob("*")


### PR DESCRIPTION
**Title:** QML CI Workflow - Add runner load balancing

**Summary:**

This PR adds an important feature to the QML CI pipeline, which is the ability to distribute demos across different runners based on a load .. the load in this case being how long it takes to build the said demo.

Let's take a look at a quick example to showcase the changes:

There are 4 demos that we need to build parallelised across two workers:
 - Demo 1 (Load: 1)
 - Demo 2 (Load: 1)
 - Demo 3 (Load: 3)
 - Demo 4 (Load: 1)

The current behaviour does not account for the load at all, it simply takes all the demos and event splits it across the two workers as such:

- Worker 1 => Demo 1, Demo 2
- Worker 2 => Demo 3, Demo 4

However, this has the downfall that Worker 1 has a load of 2 but the second worker has a load of 4. This results in some workers finishing much faster than others as is the case today.

This PR changes this behaviour and the Demos would instead be distributed as such:

- Worker 1 => Demo 3
- Worker 2 => Demo 1, Demo 2, Demo 4

Notice that even though Worker 2 has more demos to build, the total load between them are the same. This way, they both finish building at around the same time, and faster since Worker 1 would not have additional Demos to build.

**Some Important Questions**
`How exactly are these "loads" being calcuated?`
The "load" in this case is the amount of time it takes to build a demo (but converted to milliseconds to keep it a nice integer and avoid floats). The [build-branch.yml](https://github.com/PennyLaneAI/qml/blob/a6fa7e0ee8e1557e7764f30b2420b1cde51d9646/.github/workflows/build-branch.yml) workflow automatically tracks this using the output of sphinx. There are subsequent [build-branch-master.yml](https://github.com/PennyLaneAI/qml/blob/a6fa7e0ee8e1557e7764f30b2420b1cde51d9646/.github/workflows/build-branch-master.yml) and [build-branch-dev.yml](https://github.com/PennyLaneAI/qml/blob/a6fa7e0ee8e1557e7764f30b2420b1cde51d9646/.github/workflows/build-branch-dev.yml) where the load (AKA execution_time) of all demos are saved as an artifact.

Those artifacts are then downloaded and used as source of truth to split the demos across the workers.

`What happens if we cannot fetch the file that has this load information, or if it is missing?`
The workflow falls back to previous behaviour.

`What if a PR adds a new demo and we do not know the "load" of that demo?`
It will get assigned a default load of `1`. This in most cases will not be accurate but the impact is scoped to each respective PR. Once a PR is merged to master and the new load files are available, new PRs will have that previous demo distributed properly.

This is also not that big of a problem, since as soon as a successful build occurs, the sphinx cache for that PR is updated and subsequent builds are automatically faster.

**Relevant references:**
- [sc-29723](https://app.shortcut.com/xanaduai/story/29723/qml-implement-job-scheduling-based-on-load)

**Possible Drawbacks:**
This is a big change in the overall build workflow. Some minor bugs can occur but urgent PRs will be opened to address those if any are identified.

**Related GitHub Issues:**
None.