### PR TITLE
Sc 30754 Create Quantum Computing hub

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -45,7 +45,7 @@ Learn how to program for quantum computers using PennyLane
         <section class="my-5">
             <div class="row main-cards d-flex justify-content-center">
                 <div class="info-card col-lg-3 mb-5">
-                    <a href="whatisqml.html">
+                    <a href="quantum-computing.html">
                         <div class="card rounded-lg h-100">
                         <div class="card-body text-center">
                             <h3 class="card-title">

--- a/quantum-computing.rst
+++ b/quantum-computing.rst
@@ -1,0 +1,154 @@
+.. raw:: html
+
+    <style>
+        h1 {
+            text-align: center;
+            width: auto;
+            margin: 40px 0 0 0;
+            padding: 0;
+        }
+        h2 {
+            width: 65%;
+        }
+        .info-card {
+            min-width: 260px;
+            margin: 0 10px 0 10px;
+            border-radius: 10px
+        }
+        .card-footer {
+            background-color: white;
+            border: none;
+        }
+        .card-body {
+            padding-top: 10px;
+        }
+        .video .card {
+            max-width: 600px;
+            border-radius: 10px
+        }
+        .video-card-text {
+            font-size: 24px;
+            margin: 0;
+            padding: 15px;
+            border: none;
+            width: 100%;30754
+        }
+        .mt-50 {
+            margin-top: 50px;
+        }
+    </style>
+
+Quantum Computing learning hub
+==============================
+
+.. meta::
+   :property="og:description": Placeholder until copy is provided
+   :property="og:image": https://pennylane.ai/qml/_static/qml_card.png
+
+
+.. raw:: html
+
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.5.14/css/mdb.min.css" rel="stylesheet">
+    <div>
+        <p class="lead grey-text text-center mx-auto my-5">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate libero et velit interdum, ac aliquet odio mattis. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur tempus urna at turpis condimentum lobortis.
+        </p>
+
+        <section class="my-5">
+            <div class="row main-cards d-flex justify-content-center">
+                <div class="info-card col-lg-3 mb-5">
+                    <a href="what-is-quantum-computing.html">
+                        <div class="card rounded-lg h-100">
+                        <div class="card-body text-center">
+                            <h3 class="card-title">
+                                <img src="_static/brain_board.png" class="img-fluid mb-2" style="max-width: 86px;" alt="brain board"></img>
+                                <br>
+                                What is Quantum Computing?
+                            </h3>
+                            <p class="card-text">
+                            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
+                            </p>
+                        </div>
+                        <div class="card-footer">
+                            <div class="white-text d-flex justify-content-center"><h5>Read more <i class="fas fa-angle-double-right"></i></h5></div>
+                        </div>
+                        </div>
+                    </a>
+                </div>
+
+                <div class="info-card col-lg-3 mb-5">
+                    <a href="glossary.html">
+                        <div class="card rounded-lg h-100">
+                        <div class="card-body text-center">
+                            <h3 class="card-title">
+                                <img src="_static/key.png" class="img-fluid mb-2" style="max-width: 80px;" alt="key"></img>
+                                <br>
+                                Key Terms
+                            </h3>
+                            <p class="card-text">
+                            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
+                            </p>
+                        </div>
+                        <div class="card-footer">
+                            <div class="white-text d-flex justify-content-center"><h5>Read more <i class="fas fa-angle-double-right"></i></h5></div>
+                        </div>
+                        </div>
+                    </a>
+                </div>
+                
+                <div class="info-card col-lg-3 mb-5">
+                    <a href="demonstrations.html">
+                        <div class="card rounded-lg h-100">
+                        <div class="card-body text-center">
+                            <h3 class="card-title">
+                                <img src="_static/flask.png" class="img-fluid mb-2" style="max-width: 53px;" alt="blue flask"></img>
+                                <br>
+                                Demos
+                            </h3>
+                            <p class="card-text">
+                            Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur tempus urna at turpis condimentum lobortis.
+                            </p>
+                        </div>
+                        <div class="card-footer">
+                            <div class="white-text d-flex justify-content-center"><h5>Read more <i class="fas fa-angle-double-right"></i></h5></div>
+                        </div>
+                        </div>
+                    </a>
+                </div> 
+            </div>
+        </section>
+
+        <hr class="pb-4 text-dark">
+
+        <section>
+            <div class="d-flex flex-wrap justify-content-center">
+                <h2 class="fw-normal text-center mt-1 mb-5 border-0">Curabitur tempus urna at turpis lobortis. Ut commodo efficitur neque.</h2>
+            </div>
+            <div class="video row main-cards d-flex justify-content-center">
+                <div class="card h-100">
+                    <a href="https://www.youtube.com/watch?v=_WvH3H3-aFw">
+                        <img src="https://mdbcdn.b-cdn.net/img/new/standard/city/044.webp" class="card-img-top" alt="Skyscrapers"/>
+                        <div class="video-card-body">
+                            <h2 class="video-card-text">
+                            Measurements and quantum circuits
+                            </h2>
+                        </div>
+                        <div class="card-footer border-top">
+                            <div class="white-text d-flex justify-content-end mr-4"><h5>Watch <i class="fas fa-angle-double-right"></i></h5></div>
+                        </div>
+                    </a>
+                </div>
+            </div>
+            <a href="videos.html" class="d-flex flex-wrap justify-content-center mt-50"><p class="text-info fw-bold">See all videos</p></a>
+        </section>
+
+    </div>
+
+.. toctree::
+    :maxdepth: 2
+    :hidden:
+
+    what-is-quantum-computing
+    glossary
+    demonstrations
+    videos


### PR DESCRIPTION
[sc-30754/add-quantum-computing-hub-page-in-qml-project](https://app.shortcut.com/xanaduai/story/30754/add-quantum-computing-hub-page-in-qml-project)

@josh146 @BM7878, content/copy missing in this PR:

- `what-is-quantum-computing.html` page is still being worked on according to this [PR](https://github.com/PennyLaneAI/qml/pull/614)
- missing copy for meta description, meta image, the cards' descriptions and the title above the video.
- same situation with missing high quality thumbnail for the video as with other subhubs, we can discuss hiding the video section to roll out the subhubs earlier

Demo without copy:

https://user-images.githubusercontent.com/58717051/213486901-fd130725-6e00-4c4d-b533-95a0f3e72dc5.mov

