### PR TITLE
Fix a typo in the QFT demo

### DIFF
--- a/demonstrations/tutorial_qft_arithmetics.py
+++ b/demonstrations/tutorial_qft_arithmetics.py
@@ -239,7 +239,7 @@ dev = qml.device("default.qubit", wires=wires_m + wires_k + wires_solution, shot
 
 n_wires = len(dev.wires) # total number of qubits used
 
-def addition(wires_m, wires_k, wires_sol):
+def addition(wires_m, wires_k, wires_solution):
     # prepare solution qubits to counting
     qml.QFT(wires=wires_solution)
 


### PR DESCRIPTION
This PR fixes the usage of global wire variable where the local one is likely expected.
