### PR TITLE
Replaced Grouping module with Pauli module from all demos

### DIFF
--- a/demonstrations/tutorial_diffable_shadows.py
+++ b/demonstrations/tutorial_diffable_shadows.py
@@ -275,11 +275,11 @@ for observable in all_observables[:10]:
     print(observable)
 
 ##############################################################################
-# We now group these into qubit-wise-commuting (qwc) groups using :func:`~pennylane.grouping.group_observables` to learn the number of
+# We now group these into qubit-wise-commuting (qwc) groups using :func:`~pennylane.pauli.group_observables` to learn the number of
 # groups. We need this number to make a fair comparison with classical shadows as we allow for only ``T/n_groups`` shots per group, such that
 # the total number of shots is the same as for the classical shadow execution. We again compare both approaches.
 
-n_groups = len(qml.grouping.group_observables(all_observables))
+n_groups = len(qml.pauli.group_observables(all_observables))
 
 dev_ideal = qml.device("default.qubit", wires=range(n), shots=None)
 
@@ -379,7 +379,7 @@ H, n_wires = qml.qchem.molecular_hamiltonian(
 coeffs, obs = H.coeffs, H.ops
 H_qwc = qml.Hamiltonian(coeffs, obs, grouping_type="qwc")
 
-groups = qml.grouping.group_observables(obs)
+groups = qml.pauli.group_observables(obs)
 n_groups = len(groups)
 print(f"number of ops in H: {len(obs)}, number of qwc groups: {n_groups}")
 print(f"Each group has sizes {[len(_) for _ in groups]}")
@@ -474,8 +474,8 @@ plt.show()
 # Overall, we saw that classical shadows always waste unused quantum resources for measurements that are not used, except some extreme cases.
 # For the rare case that the observables that are to be determined are not known before the measurement, classical shadows may prove advantageous.
 # 
-# We have been using a relatively simple approach to qwc grouping, as :func:`~pennylane.grouping.group_observables`
-# is based on the largest first (LF) heuristic (see :func:`~pennylane.grouping.graph_colouring.largest_first`).
+# We have been using a relatively simple approach to qwc grouping, as :func:`~pennylane.pauli.group_observables`
+# is based on the largest first (LF) heuristic (see :func:`~pennylane.pauli.graph_colouring.largest_first`).
 # There has been intensive research in recent years on optimizing qwc measurement schemes.
 # Similarily, it has been realized by the original authors that the randomized shadow protocol can be improved by what they call derandomization [#Huang2021]_.
 # Currently, it seems advanced grouping algorithms are still the preferred choice, as is illustrated and discused in [#Yen]_.

--- a/demonstrations/tutorial_measurement_optimize.py
+++ b/demonstrations/tutorial_measurement_optimize.py
@@ -467,10 +467,10 @@ print(circuit(weights))
 
 ##############################################################################
 # Behind the scenes, PennyLane is making use of our built-in
-# :mod:`qml.grouping <pennylane.grouping>` module, which contains functions for diagonalizing QWC
+# :mod:`qml.pauli <pennylane.pauli>` module, which contains functions for diagonalizing QWC
 # terms:
 
-rotations, new_obs = qml.grouping.diagonalize_qwc_pauli_words(obs)
+rotations, new_obs = qml.pauli.diagonalize_qwc_pauli_words(obs)
 
 print(rotations)
 print(new_obs)
@@ -478,7 +478,7 @@ print(new_obs)
 
 ##############################################################################
 # Here, the first line corresponds to the basis rotations that were discussed above, written in
-# terms of ``RX`` and ``RY`` rotations. Check out the :mod:`qml.grouping <pennylane.grouping>`
+# terms of ``RX`` and ``RY`` rotations. Check out the :mod:`qml.pauli <pennylane.pauli>`
 # documentation for more details on its provided functionality and how it works.
 #
 # Given a Hamiltonian containing a large number of Pauli terms,
@@ -678,13 +678,13 @@ for i in range(num_groups):
 # 5. Finally, post-process the probability distributions with the observable eigenvalues
 #    to recover the Hamiltonian expectation value.
 #
-# Luckily, the PennyLane ``grouping`` module makes this relatively easy. Let's walk through
+# Luckily, the PennyLane ``pauli`` module makes this relatively easy. Let's walk through
 # the entire process using the provided grouping functions.
 #
 # Steps 1-3 (finding and grouping QWC terms in the Hamiltonian) can be done via the
-# :func:`qml.grouping.group_observables <pennylane.grouping.group_observables>` function:
+# :func:`qml.pauli.group_observables <pennylane.pauli.group_observables>` function:
 
-obs_groupings = qml.grouping.group_observables(terms, grouping_type='qwc', method='rlf')
+obs_groupings = qml.pauli.group_observables(terms, grouping_type='qwc', method='rlf')
 
 
 ##############################################################################
@@ -693,10 +693,10 @@ obs_groupings = qml.grouping.group_observables(terms, grouping_type='qwc', metho
 # heuristic (in this case, ``"rlf"`` refers to Recursive Largest First, a variant of largest first colouring heuristic).
 #
 # If we want to see what the required rotations and measurements are, we can use the
-# :func:`qml.grouping.diagonalize_qwc_groupings <pennylane.grouping.diagonalize_qwc_groupings>`
+# :func:`qml.pauli.diagonalize_qwc_groupings <pennylane.pauli.diagonalize_qwc_groupings>`
 # function:
 
-rotations, measurements = qml.grouping.diagonalize_qwc_groupings(obs_groupings)
+rotations, measurements = qml.pauli.diagonalize_qwc_groupings(obs_groupings)
 
 ##############################################################################
 # However, this isn't strictly necessary---recall previously that the QNode
@@ -748,7 +748,7 @@ H, num_qubits = qml.qchem.molecular_hamiltonian(symbols, coordinates)
 print("Number of Hamiltonian terms/required measurements:", len(H.ops))
 
 # grouping
-groups = qml.grouping.group_observables(H.ops, grouping_type='qwc', method='rlf')
+groups = qml.pauli.group_observables(H.ops, grouping_type='qwc', method='rlf')
 print("Number of required measurements after optimization:", len(groups))
 
 ##############################################################################

--- a/demonstrations/tutorial_quantum_circuit_cutting.py
+++ b/demonstrations/tutorial_quantum_circuit_cutting.py
@@ -146,7 +146,7 @@ def circuit(x):
 
     qml.CZ(wires=[1, 2])
 
-    return qml.expval(qml.grouping.string_to_pauli_word("ZZZ"))
+    return qml.expval(qml.pauli.string_to_pauli_word("ZZZ"))
 
 
 x = np.array(0.531, requires_grad=True)
@@ -185,7 +185,7 @@ def circuit(x):
 
     qml.CZ(wires=[1, 2])
 
-    return qml.expval(qml.grouping.string_to_pauli_word("ZZZ"))
+    return qml.expval(qml.pauli.string_to_pauli_word("ZZZ"))
 
 
 x = np.array(0.531, requires_grad=True)  # Defining the parameter x
@@ -220,7 +220,7 @@ def circuit(x):
 
     qml.CZ(wires=[1, 2])
 
-    return qml.expval(qml.grouping.string_to_pauli_word("ZZZ"))
+    return qml.expval(qml.pauli.string_to_pauli_word("ZZZ"))
 
 
 x = np.array(0.531, requires_grad=True)
@@ -308,7 +308,7 @@ def circuit(x):
 
     qml.CZ(wires=[1, 2])
 
-    return qml.expval(qml.grouping.string_to_pauli_word("ZZZ"))
+    return qml.expval(qml.pauli.string_to_pauli_word("ZZZ"))
 
 
 x = np.array(0.531, requires_grad=True)

--- a/demonstrations/tutorial_resource_estimation.py
+++ b/demonstrations/tutorial_resource_estimation.py
@@ -232,10 +232,10 @@ print(f'Shots : {m:.2e}')
 ##############################################################################
 # This number corresponds to the measurement process where each term in the Hamiltonian is measured
 # independently. The number can be reduced by using
-# :func:`~.pennylane.grouping.group_observables()`, which partitions the Pauli words into
+# :func:`~.pennylane.pauli.group_observables()`, which partitions the Pauli words into
 # groups of commuting terms that can be measured simultaneously.
 
-ops, coeffs = qml.grouping.group_observables(H.ops, H.coeffs)
+ops, coeffs = qml.pauli.group_observables(H.ops, H.coeffs)
 
 m = qml.resource.estimate_shots(coeffs)
 print(f'Shots : {m:.2e}')

--- a/demonstrations/vqe_parallel.py
+++ b/demonstrations/vqe_parallel.py
@@ -260,14 +260,14 @@ print(f"Evaluation time: {dt_par:.2f} s")
 ##############################################################################
 # We can improve this procedure further by optimizing the measurement. Currently, we are measuring each term of the Hamiltonian
 # in a separate measurement. This is not necessary as there are sub-groups of commuting terms in the Hamiltonian that can be measured
-# simultaneously. We can utilize the grouping function :func:`~.pennylane.grouping.group_observables` to generate few measurements that
+# simultaneously. We can utilize the grouping function :func:`~.pennylane.pauli.group_observables` to generate few measurements that
 # are executed in parallel:
 
 def compute_energy_parallel_optimized(H, devs, param):
     assert len(H.ops) == len(devs)
     results = []
 
-    obs_groupings, coeffs_groupings = qml.grouping.group_observables(H.ops, H.coeffs, "qwc")
+    obs_groupings, coeffs_groupings = qml.pauli.group_observables(H.ops, H.coeffs, "qwc")
 
     for i, (obs, coeffs) in enumerate(zip(obs_groupings, coeffs_groupings)):
         H_part = qml.Hamiltonian(coeffs, obs)


### PR DESCRIPTION
**Title: Stop using the now deprecated grouping module**

**Summary:**
We are removing the grouping module in favour of the Pauli module. We remove uses of it from the demos and instead use the same functionality from the Pauli module.