### PR TITLE
Added more logging to parse_execution_times if regex error is triggered

### DIFF
--- a/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/services/parse_execution_times.py
+++ b/.github/workflows/qml_pipeline_utils/qml_pipeline_utils/services/parse_execution_times.py
@@ -97,13 +97,12 @@ def parse_execution_times(num_workers: int, offset: int,
         glob_pattern=glob_pattern
     )
 
-    assert len(tutorial_name_matches) == len(tutorial_time_matches), (
-        f"Unable to properly parse "
-        f"{str(sg_execution_file_location)}. "
-        f"Got {len(tutorial_name_matches)} tutorial "
-        f"names, but {len(tutorial_time_matches)} "
-        f"execution time matches"
-    )
+    if len(tutorial_name_matches) != len(tutorial_time_matches):
+        print("File content of sg_execution_times.html\n", sg_execution_file_content)
+        raise ValueError(
+            f"Unable to properly parse {str(sg_execution_file_location)}. "
+            f"Got {len(tutorial_name_matches)} tutorial names, "
+            f"but {len(tutorial_time_matches)} exection times.")
 
     return {
         tutorial_name: convert_execution_time_to_ms(tutorial_time)


### PR DESCRIPTION
**Title:** Added more logging to parse_execution_times if regex error is triggered

**Summary:**
When parsing and generating the execution time, there seems be an occasional case where the execution time for all demos cannot be parsed out by the regex from the sphinx generated html.

This case has not been reproducible locally, this PR adds more verbose logging for when this happens.

**Relevant references:**
https://github.com/PennyLaneAI/qml/actions/runs/4309304990/jobs/7516549630

**Possible Drawbacks:**
N/A.

**Related GitHub Issues:**
N/A.