### PR TITLE
Fixed bug where multi paged artifact lists broke deploy-pr workflow

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -28,11 +28,13 @@ jobs:
           script: |
             const workflowContextFilePrefix = process.env.build_context_prefix;
             const workflowContextFileName = `${workflowContextFilePrefix}_info.zip`;
-            let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+
+            let artifactsOpts = github.rest.actions.listWorkflowRunArtifacts.endpoint.merge({
               owner: context.repo.owner,
               repo: context.repo.repo,
               run_id: context.payload.workflow_run.id
             });
+            let artifacts = await github.paginate(artifactsOpts);
             let prArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == workflowContextFileName
             })[0];
@@ -152,11 +154,12 @@ jobs:
               fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/${artifact.name}`, Buffer.from(download.data));
             };
             
-            let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+            let artifactsOpts = github.rest.actions.listWorkflowRunArtifacts.endpoint.merge({
               owner: context.repo.owner,
               repo: context.repo.repo,
               run_id: context.payload.workflow_run.id
             });
+            let artifacts = await github.paginate(artifactsOpts);
             let htmlArtifacts = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name.startsWith('html-')
             });


### PR DESCRIPTION
**Title:** Fixed bug where multi paged artifact lists broke deploy-pr workflow

**Summary:**

The deploy-pr uses `listWorkflowRunArtifacts` API endpoint to fetch artifact information and also download them. This endpoint is paginated but did not cause an issue up until now since all the artifacts deploy-pr needed were always in page 1. However, with the new execution times PR, that changed and now there are sporradic errors due to artifacts being missing.

**Relevant references:**
[sc-36272](https://app.shortcut.com/xanaduai/story/36272/fix-issue-in-deploy-pr-for-qml)

**Possible Drawbacks:**
If there are further bugs with pagination, urgent PRs will be opened.

**Related GitHub Issues:**
None.