### PR TITLE
Remove step to invalidate old CloudFront distribution (no longer exists)

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -253,15 +253,6 @@ jobs:
           s3-action: upload
           invalidate-cloudfront-cache: true
 
-      - name: Invalidate Cloudfront cache (Prod)
-        if: github.event.workflow_run.event == 'push' && steps.push_info.outputs.push_ref_name == 'master'
-        env:
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: |
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths /qml/*
-
       - name: Comment on PR
         if: github.event.workflow_run.event == 'pull_request'
         uses: actions/github-script@v6


### PR DESCRIPTION
**Title:** Remove step to invalidate old CloudFront distribution (no longer exists)

**Summary:**

**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**
