### PR TITLE
Run CI to find what tutorials are broken

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -194,6 +194,7 @@ jobs:
       - compute-build-strategy-matrix
       - validate-inputs
     strategy:
+      fail-fast: true
       matrix:
         offset: ${{ fromJson(needs.compute-build-strategy-matrix.outputs.strategy-matrix) }}
     steps:

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -194,7 +194,7 @@ jobs:
       - compute-build-strategy-matrix
       - validate-inputs
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         offset: ${{ fromJson(needs.compute-build-strategy-matrix.outputs.strategy-matrix) }}
     steps:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -11,7 +11,7 @@ env:
 
 concurrency:
   group: build-docs-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:


### PR DESCRIPTION
The plugin test matrix cancels all other runners when it finds the first failure. This makes it impossible for us to have a concrete list of what tutorials need to be updated.

This PR toggles the "cancel-in-progress" on the CI workflow, so we can find all failures on the dev branch.