### PR TITLE
Fix toric code and classical kernels demos

### DIFF
--- a/demonstrations/tutorial_classical_kernels.py
+++ b/demonstrations/tutorial_classical_kernels.py
@@ -701,7 +701,10 @@ plt.show();
 # itself, in case it is of use later:
 
 def fourier_q(d, thetas, amplitudes):
-    return np.real(coefficients(lambda x: QK(x, thetas, amplitudes), 1, d-1))
+    def QK_partial(x):
+        squeezed_x = qml.math.squeeze(x)
+        return QK(squeezed_x, thetas, amplitudes)
+    return np.real(coefficients(QK_partial, 1, d-1))
 
 ###############################################################################
 # And with this, we can finally visualize how the Fourier spectrum of the

--- a/demonstrations/tutorial_toric_code.py
+++ b/demonstrations/tutorial_toric_code.py
@@ -448,7 +448,7 @@ print("ZGroup: ", z_expvals)
 # expectation value is :math:`-1`, then a quasiparticle exists in that location.
 #
 
-occupation_numbers = lambda expvals: 0.5 * (1 - expvals)
+occupation_numbers = lambda expvals: [0.5 * (1 - val) for val in expvals]
 
 def print_info(x_expvals, z_expvals):
     E = -sum(x_expvals) - sum(z_expvals)


### PR DESCRIPTION
A line of the toric code needed to iterate over values in a list instead of broadcasting the operations over a numpy array.

The classical kernels demo had a variable with a single-parameter broadcasting dimension. We needed to squeeze that out so that the result didn't end up with an additional, unneeded dimension.

We should consider switching to using `qml.prod` in the toric code demo, but we can't simultaneously measure more than one `Prod` at a time right now.

[sc-37264]