### PR TITLE
FIx photonics and noisy demos

### DIFF
--- a/demonstrations/tutorial_noisy_circuits.py
+++ b/demonstrations/tutorial_noisy_circuits.py
@@ -231,7 +231,7 @@ for p in ps:
 # ensure that the trainable parameters give rise to a valid channel parameter, i.e., a number
 # between 0 and 1.
 #
-ev = np.tensor(0.7781, requires_grad=False)  # observed expectation value
+ev = 0.7781  # observed expectation value
 
 def sigmoid(x):
     return 1/(1+np.exp(-x))
@@ -250,7 +250,7 @@ def damping_circuit(x):
 
 
 def cost(x, target):
-    return (damping_circuit(x) - qml.numpy.array(target, requires_grad=True))**2
+    return (damping_circuit(x) - target)**2
 
 ######################################################################
 # All that remains is to optimize the parameter. We use a straightforward gradient descent

--- a/demonstrations/tutorial_noisy_circuits.py
+++ b/demonstrations/tutorial_noisy_circuits.py
@@ -250,7 +250,7 @@ def damping_circuit(x):
 
 
 def cost(x, target):
-    return (damping_circuit(x) - target)**2
+    return (damping_circuit(x) - qml.numpy.array(target, requires_grad=True))**2
 
 ######################################################################
 # All that remains is to optimize the parameter. We use a straightforward gradient descent

--- a/demonstrations/tutorial_photonics.py
+++ b/demonstrations/tutorial_photonics.py
@@ -168,8 +168,8 @@ def vacuum_measure_p():
 
 
 # Sample measurements in phase space
-x_sample = vacuum_measure_x().numpy()
-p_sample = vacuum_measure_p().numpy()
+x_sample = vacuum_measure_x()
+p_sample = vacuum_measure_p()
 
 # Import some libraries for a nicer plot
 from scipy.stats import gaussian_kde
@@ -287,8 +287,8 @@ def measure_coherent_p(alpha, phi):
 
 
 # Choose alpha and phi and sample 1000 measurements
-x_sample_coherent = measure_coherent_x(3, np.pi / 3).numpy()
-p_sample_coherent = measure_coherent_p(3, np.pi / 3).numpy()
+x_sample_coherent = measure_coherent_x(3, np.pi / 3)
+p_sample_coherent = measure_coherent_p(3, np.pi / 3)
 
 # Plot as before
 xp = vstack([x_sample_coherent, p_sample_coherent])
@@ -514,8 +514,8 @@ def measure_squeezed_p(r):
 
 
 # Choose alpha and phi and sample 1000 measurements
-x_sample_squeezed = measure_squeezed_x(0.4).numpy()
-p_sample_squeezed = measure_squeezed_p(0.4).numpy()
+x_sample_squeezed = measure_squeezed_x(0.4)
+p_sample_squeezed = measure_squeezed_p(0.4)
 
 # Plot as before
 xp = vstack([x_sample_squeezed, p_sample_squeezed])
@@ -617,22 +617,29 @@ def measurement(a, phi):
 
 
 @qml.qnode(dev_exact2)
-def measurement2(a, theta, alpha, phi):
+def measurement2_0(a, theta, alpha, phi):
     qml.Displacement(a, theta, wires = 0)  # We choose the initial to be a displaced vacuum
     qml.CoherentState(alpha, phi, wires = 1)  # Prepare coherent as second qumode
     qml.Beamsplitter(np.pi / 4, 0, wires=[0, 1])  # Interfere both states
-    return qml.expval(qml.NumberOperator(0)), qml.expval(qml.NumberOperator(1))  # Read out N
+    return qml.expval(qml.NumberOperator(0))  # Read out N
+
+@qml.qnode(dev_exact2)
+def measurement2_1(a, theta, alpha, phi):
+    qml.Displacement(a, theta, wires = 0)  # We choose the initial to be a displaced vacuum
+    qml.CoherentState(alpha, phi, wires = 1)  # Prepare coherent as second qumode
+    qml.Beamsplitter(np.pi / 4, 0, wires=[0, 1])  # Interfere both states
+    return qml.expval(qml.NumberOperator(1))  # Read out N
 
 
 print(
-    "Expectation value of x-quadrature after displacement: {}\n".format(measurement(3, 0).numpy())
+    "Expectation value of x-quadrature after displacement: {}\n".format(measurement(3, 0))
 )
 print("Expected current in each detector:")
-print("Detector 1: {}".format(measurement2(3, 0, 1, 0)[0].numpy()))
-print("Detector 2: {}".format(measurement2(3, 0, 1, 0)[1].numpy()))
+print("Detector 1: {}".format(measurement2_0(3, 0, 1, 0)))
+print("Detector 2: {}".format(measurement2_1(3, 0, 1, 0)))
 print(
     "Difference between currents: {}".format(
-        measurement2(3, 0, 1, 0)[1].numpy() - measurement2(3, 0, 1, 0)[0].numpy()
+        measurement2_1(3, 0, 1, 0) - measurement2_0(3, 0, 1, 0)
     )
 )
 


### PR DESCRIPTION


**Changes:**

1) Photonics demo: remove `.numpy()` and separate the defautl Gaussian qnode in two because (multiple measurement not supported on default Gaussian).

2) Noisy circuits: Add array on target to get the right array box

