### PR TITLE
Update Quantum Transfer Learning and Error Mitigation demos to work with new return types

### DIFF
--- a/demonstrations/tutorial_error_mitigation.py
+++ b/demonstrations/tutorial_error_mitigation.py
@@ -316,7 +316,7 @@ for x, y in zip(scale_factors, noisy_expectation_values):
 # Run extrapolation
 zero_noise = fac.reduce()
 
-print(f"ZNE result: {zero_noise[0]}")
+print(f"ZNE result: {zero_noise}")
 
 ##############################################################################
 # Let's make a plot of the data and fitted extrapolation function.

--- a/demonstrations/tutorial_quantum_transfer_learning.py
+++ b/demonstrations/tutorial_quantum_transfer_learning.py
@@ -381,7 +381,7 @@ class DressedQuantumNet(nn.Module):
         q_out = torch.Tensor(0, n_qubits)
         q_out = q_out.to(device)
         for elem in q_in:
-            q_out_elem = quantum_net(elem, self.q_params).float().unsqueeze(0)
+            q_out_elem = torch.Tensor(quantum_net(elem, self.q_params)).float().unsqueeze(0)
             q_out = torch.cat((q_out, q_out_elem))
 
         # return the two-dimensional prediction from the postprocessing layer


### PR DESCRIPTION
Updated `tutotial_quantum_transfer_learning.py` and `tutorial_error_mitigation.py` to work with the new return types.

Note: Quantum Transfer Learning demo accuracy is really low after the changes, I'm not sure if that's just an issue with my local environment or with the demo itself.