### PR TITLE
remove nlopt from list of requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ autograd==1.5
 numpy~=1.21
 numba==0.53.1
 networkx==2.5.1
-nlopt==2.6.2
 semantic_version==2.10
 strawberryfields==0.22
 sympy==1.6.2


### PR DESCRIPTION
NLOpt is causing the CI to fail due to the absence of wheels (https://github.com/PennyLaneAI/qml/actions/runs/4790041189/jobs/8518643923), but only the manually run `qonn.py` demo uses it.

Since no demos are actually using `nlopt`, we remove it from the list of dependencies.