### PR TITLE
remove nlopt from requirements on master

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ autograd==1.5
 numpy~=1.21
 numba==0.53.1
 networkx==2.5.1
-nlopt==2.6.2
 semantic_version==2.10
 strawberryfields==0.22
 sympy==1.6.2


### PR DESCRIPTION
See also #755 .  Removing `nlopt` is necessary for the CI checks to run.