### PR TITLE
Use dev lightning on demo diff checker

### DIFF
--- a/.github/workflows/demo_diff_check.yml
+++ b/.github/workflows/demo_diff_check.yml
@@ -35,7 +35,7 @@ jobs:
           python -m pip install --upgrade pip wheel
           pip install -r requirements.txt
           pip install --no-deps -r requirements_no_deps.txt
-          pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --no-deps
+          pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --no-deps --upgrade
 
       - name: Build tutorials
         run: |
@@ -80,7 +80,7 @@ jobs:
           python -m pip install --upgrade pip wheel
           pip install -r requirements.txt
           pip install --no-deps -r requirements_no_deps.txt
-          pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --no-deps
+          pip install pennylane-lightning
 
       - name: Build tutorials
         run: |


### PR DESCRIPTION
See failure on https://github.com/PennyLaneAI/qml/actions/runs/4791273197/jobs/8521476423


The demo diff checker needs to build the dev branch with the updated dev version of lightning.