### PR TITLE
Fix spsa demo: cast coefficients to real

### DIFF
--- a/demonstrations/tutorial_spsa.py
+++ b/demonstrations/tutorial_spsa.py
@@ -337,6 +337,7 @@ from pennylane import qchem
 symbols = ["H", "H"]
 coordinates = np.array([0.0, 0.0, -0.6614, 0.0, 0.0, 0.6614])
 h2_ham, num_qubits = qchem.molecular_hamiltonian(symbols, coordinates)
+h2_ham = qml.Hamiltonian(qml.math.real(h2_ham.coeffs), h2_ham.ops)
 
 true_energy = -1.136189454088
 


### PR DESCRIPTION
The demo is failing due to complex coefficients in the hamiltonian. This casts them to real first, allowing the demo to execute.