### PR TITLE
Optimized CI Workflows

### DIFF
--- a/.github/workflows/build-branch-dev.yml
+++ b/.github/workflows/build-branch-dev.yml
@@ -15,3 +15,4 @@ jobs:
     uses: ./.github/workflows/build-branch.yml
     with:
       branch: dev
+      num_workers: '10'

--- a/.github/workflows/build-branch-master.yml
+++ b/.github/workflows/build-branch-master.yml
@@ -15,3 +15,4 @@ jobs:
     uses: ./.github/workflows/build-branch.yml
     with:
       branch: master
+      num_workers: '10'

--- a/.github/workflows/build-json.yml
+++ b/.github/workflows/build-json.yml
@@ -2,12 +2,17 @@ name: Build Website - JSON
 on:
   push:
     branches:
-      - master
+      # TODO: Re-enable before new React demos are live
+      # - master
       - dev
     paths:
       - 'demonstrations/**'
       - '**.py'
       - '**.rst'
+
+concurrency:
+  group: build-json-doc-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -6,9 +6,6 @@ on:
       - master
       - dev
 
-env:
-  NUM_WORKERS: 15
-
 concurrency:
   group: build-docs-${{ github.ref }}
   cancel-in-progress: true
@@ -16,8 +13,20 @@ concurrency:
 jobs:
   build:
     uses: ./.github/workflows/build-branch.yml
+
+    # Do not run for Pull Requests that are in draft by default, unless the `needs-ci` label is present
+    if: >-
+      ${{
+        github.event_name == 'push' ||
+        (
+          github.event.pull_request.draft == false ||
+          contains(github.event.pull_request.labels.*.name, 'needs-ci')
+        )
+      }}
+
     with:
       branch: ${{ github.ref }}
+      num_workers: '10'
       enable_python_cache: false
       enable_sphinx_cache: true
       refresh_sphinx_cache: ${{ contains(github.event.pull_request.labels.*.name, 'ignore-qml-cache') }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -14,14 +14,11 @@ jobs:
   build:
     uses: ./.github/workflows/build-branch.yml
 
-    # Do not run for Pull Requests that are in draft by default, unless the `needs-ci` label is present
     if: >-
       ${{
         github.event_name == 'push' ||
-        (
-          github.event.pull_request.draft == false ||
-          contains(github.event.pull_request.labels.*.name, 'needs-ci')
-        )
+        github.event.pull_request.draft == false ||
+        contains(github.event.pull_request.labels.*.name, 'needs-ci')
       }}
 
     with:

--- a/.github/workflows/update-dev.yml
+++ b/.github/workflows/update-dev.yml
@@ -15,7 +15,6 @@ jobs:
   update-dev:
     runs-on: ubuntu-latest
 
-    # If the job is triggered by a workflow_run, only run if the source workflow was triggered by a push to master
     if: >-
       ${{
         github.event_name != 'workflow_run' ||

--- a/.github/workflows/update-dev.yml
+++ b/.github/workflows/update-dev.yml
@@ -1,6 +1,10 @@
 name: update-dev
 on:
-  push:
+  workflow_run:
+    workflows:
+      - Build Website
+    types:
+      - completed
     branches:
       - master
   schedule:
@@ -11,9 +15,20 @@ jobs:
   update-dev:
     runs-on: ubuntu-latest
 
-    steps:
+    # If the job is triggered by a workflow_run, only run if the source workflow was triggered by a push to master
+    if: >-
+      ${{
+        github.event_name != 'workflow_run' ||
+        (
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.event == 'push'
+        )
+      }}
 
-      - uses: actions/checkout@v1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Nightly Merge
         uses: robotology/gh-action-nightly-merge@v1.3.3


### PR DESCRIPTION
**Title:** Optimize CI Workflows

**Summary:**
This PR brings the following set of changes to the QML CI workflows:

- Reduce the number of workers used down to 10 for parallelisation for:
  - `build-branch-master.yml`
  - `build-branch-dev.yml`
  - `build-pr.yml`
- Updated `build-pr.yml` to not run on PRs that are Draft unless the `needs-ci` label is present
- Updated `update-dev.yml` to **NOT** run on push to master.
  - This needed to be done since it was doubling the amount of workers QML used. See an example below:
```
PR (ex: new demo) => Merged to master.
  - We start building HTML version of docs to update the current site = 15 workers
  - Start building JSON version of docs for React = 15 workers
  - Update-dev merges the changes to dev
  - We start building HTML version of docs to update dev site = 15 workers
  - Start building JSON version of docs for React (dev) = 15 workers

=> 60 workers used in concurrency
```

But now update-dev will only run once the build to master is complete, here is the flow after this PR is merged:
```
PR (ex: new demo) => Merged to master.
  - We start building HTML version of docs to update the current site = 10 workers
  - ^^ Finishes running ^^
  - Update-dev merges the changes to dev
  - We start building HTML version of docs to update dev site = 10 workers
  - Start building JSON version of docs for React (dev) = 10 workers

=> 20 workers used in concurrency (~67% reduction in worker usage)
```

So now we only use 10 workers in the beginning, and then use 20. Once phase 3 of the Pennylane.ai website is don, we will only be using 10 workers.

**Relevant references:**
- [sc-38237](https://app.shortcut.com/xanaduai/story/38237/disable-building-json-for-master-branch-of-qml-until-phase-3-release-of-the-website)
- [sc-38221](https://app.shortcut.com/xanaduai/story/38221/update-workflows-in-github-pennylaneai-to-not-trigger-for-draft-prs)

**Possible Drawbacks:**
Merges to master will take longer to show up in dev environment, but that should be acceptable as it does not affect production deploys.

**Related GitHub Issues:**
None.