### PR TITLE
Replacing the triple and double hyphens in demos to em and en dashes

### DIFF
--- a/demonstrations/gbs.py
+++ b/demonstrations/gbs.py
@@ -75,7 +75,7 @@ matter like electrons, which must follow the Pauli Exclusion Principle and keep 
 This property can be observed in simple interference experiments such as the
 `Hong-Ou Mandel setup <https://en.wikipedia.org/wiki/Hong%E2%80%93Ou%E2%80%93Mandel_effect>`__.
 If two single photons are interfered on a balanced beamsplitter, they will both emerge at
-the same output port---there is zero probability that they will emerge at separate outputs.
+the same output port—there is zero probability that they will emerge at separate outputs.
 This is a simple but notable quantum property of light; if electrons were brought
 together in a similar experiement, they would always appear at separate output ports.
 
@@ -91,8 +91,8 @@ the random circuit sampling, it's just a quantum system being its best self. Wit
 size and quality, it is strongly believed to be hard for a classical computer to simulate this efficiently.
 
 Finally, the "Gaussian" in GBS refers to the fact that we modify the original Boson Sampling
-proposal slightly: instead of injecting single photons---which are hard to jointly create in the
-size and quality needed to demonstrate Boson Sampling conclusively---we instead use states of
+proposal slightly: instead of injecting single photons—which are hard to jointly create in the
+size and quality needed to demonstrate Boson Sampling conclusively—we instead use states of
 light that are experimentally less demanding (though still challenging!).
 These states of light are called Gaussian states,
 because they bear strong connections to the
@@ -292,7 +292,7 @@ for i in measure_states:
 #         \end{matrix}\right]\right).
 #
 # As any algorithm that could calculate (or even approximate) the hafnian could also calculate the
-# permanent---a `#P-hard problem <https://en.wikipedia.org/wiki/%E2%99%AFP>`__---it follows that
+# permanent—a `#P-hard problem <https://en.wikipedia.org/wiki/%E2%99%AFP>`__---it follows that
 # calculating or approximating the hafnian must also be a classically hard problem. This lies behind
 # the classical hardness of GBS.
 #

--- a/demonstrations/qsim_beyond_classical.py
+++ b/demonstrations/qsim_beyond_classical.py
@@ -25,8 +25,8 @@ In the paper `Quantum supremacy using a programmable superconducting
 processor <https://www.nature.com/articles/s41586-019-1666-5>`__, the
 Google AI Quantum team and collaborators showed that the Sycamore quantum processor could
 complete a task that would take a classical computer potentially thousands
-of years. They faced their quantum chip off against JEWEL---one of the
-world's most powerful supercomputers---using a classical statevector simulator called
+of years. They faced their quantum chip off against JEWEL—one of the
+world's most powerful supercomputers—using a classical statevector simulator called
 `qsim <https://github.com/quantumlib/qsim>`__. The main idea behind this
 showdown was to prove that a quantum device could solve a specific task
 that no classical method could do in a reasonable amount of time.
@@ -42,7 +42,7 @@ bitstring distribution classically. By comparing run-times for the
 classical simulations and the Sycamore chip
 on smaller circuits, and then extrapolating classical run-times for larger
 circuits, the team concluded that simulating larger circuits on Sycamore
-was intractable classically---i.e., the Sycamore chips had demonstrated
+was intractable classically—i.e., the Sycamore chips had demonstrated
 what is called "quantum supremacy".
 
 In this demonstration, we will walk you through how their random quantum
@@ -116,11 +116,11 @@ qb2wire = {i: j for i, j in zip(qubits, range(wires))}
 # Now let's create the ``qsim`` device, available via the Cirq plugin, making
 # use of the ``wires`` and ``qubits`` keywords that we defined above.
 # First, we need to define the number of 'shots' per circuit instance to
-# be used---where the number of shots simply corresponds to the number
+# be used—where the number of shots simply corresponds to the number
 # of times that the circuit is sampled. This will also be needed later when
 # calculating the cross-entropy benchmarking fidelity. The more shots, the
-# more accurate the results will be. 500,000 shots will be used here---the same
-# number of samples used in the paper---but feel free to
+# more accurate the results will be. 500,000 shots will be used here—the same
+# number of samples used in the paper—but feel free to
 # change this (depending on your own computational restrictions).
 #
 
@@ -530,7 +530,7 @@ print("\rObserved:", f"{np.mean(f_circuit):.7f}".rjust(27))
 #
 # There's still one issue that hasn't been touched on yet: the addition of
 # noise in quantum hardware. Simply put, this noise will lower the
-# cross-entropy benchmarking fidelity---the larger the
+# cross-entropy benchmarking fidelity—the larger the
 # circuit, the more noise there will be, and thus the lower the fidelity, with the
 # fidelity approaching 0 as the noise increases.
 # By calculating the specific single-qubit, two-qubit, and readout errors

--- a/demonstrations/quantum_volume.py
+++ b/demonstrations/quantum_volume.py
@@ -113,7 +113,7 @@ explain the problem on which it's based, and run the protocol to compute it!
 # pairs of qubits. (When the number of qubits is odd, the bottom-most qubit is
 # idle while the SU(4) operations run on the pairs. However, it will still be
 # incorporated by way of the permutations.) These circuits satisfy the criteria
-# in item 1 --- they have well-defined structure, and it is clear how they can be
+# in item 1 — they have well-defined structure, and it is clear how they can be
 # scaled to different sizes.
 #
 # As for the compilation rules of item 2, to compute quantum volume we're
@@ -197,7 +197,7 @@ print(f"Heavy output probability = {heavy_output_prob}")
 # probabilities that are roughly all the same, as noise will reduce the
 # probabilities to the uniform distribution.
 #
-# The heavy output generation problem quantifies this --- for our family of
+# The heavy output generation problem quantifies this — for our family of
 # random circuits, do we obtain heavy outputs at least 2/3 of the time on
 # average?  Furthermore, do we obtain this with high confidence? This is the
 # basis for quantum volume. Looking back at the criteria for our benchmarks, for
@@ -254,7 +254,7 @@ print(f"Heavy output probability = {heavy_output_prob}")
 # To see this more concretely, suppose we have a 20-qubit device and find that
 # we get heavy outputs reliably for up to depth-4 circuits on any set of 4
 # qubits, then the quantum volume is :math:`\log_2 V_Q = 4`. Quantum volume is
-# incremental, as shown below --- we gradually work our way up to larger
+# incremental, as shown below — we gradually work our way up to larger
 # circuits, until we find something we can't do.  Very loosely, quantum volume
 # is like an effective number of qubits. Even if we have those 20 qubits, only
 # groups of up to 4 of them work well enough together to sample from
@@ -358,7 +358,7 @@ def apply_random_su4_layer(num_qubits):
 
 ##############################################################################
 #
-# Next, let's write a layering method to put the two together --- this is just
+# Next, let's write a layering method to put the two together — this is just
 # for convenience and to highlight the fact that these two methods together
 # make up one layer of the circuit depth.
 #
@@ -441,7 +441,7 @@ print(qml.drawer.tape_text(expanded_tape, wire_order=dev_ideal.wires, show_all_w
 #
 # One last thing we'll need before running our circuits is the machinery to
 # determine the heavy outputs. This is quite an interesting aspect of the
-# protocol --- we're required to compute the heavy outputs classically in order
+# protocol — we're required to compute the heavy outputs classically in order
 # to get the results! As a consequence, it will only be possible to calculate
 # quantum volume for processors up to a certain point before they become too
 # large.
@@ -532,7 +532,7 @@ print(f"Heavy outputs are {heavy_outputs}")
 #
 # Now it's time to run the protocol. First, let's set up our hardware
 # device. We'll use a simulated version of the 5-qubit IBM Lima as an example
-# --- the reported quantum volume according to IBM is :math:`V_Q=8`, so we
+# — the reported quantum volume according to IBM is :math:`V_Q=8`, so we
 # endeavour to reproduce that here. This means that we should be able to run our
 # square circuits reliably on up to :math:`\log_2 V_Q =3` qubits.
 #
@@ -819,7 +819,7 @@ for idx, prob in enumerate(two_sigma_below):
 # computers. By determining the largest square random circuits a processor can
 # run reliably, it provides a measure of the effective number of qubits a
 # processor has. Furthermore, it goes beyond just gauging quality by a number of
-# qubits --- it incorporates many different aspects of a device such as its
+# qubits — it incorporates many different aspects of a device such as its
 # compiler, qubit connectivity, and gate error rates.
 #
 # However, as with any benchmark, it is not without limitations. A key one

--- a/demonstrations/tutorial_backprop.py
+++ b/demonstrations/tutorial_backprop.py
@@ -229,7 +229,7 @@ print(2 * forward_time * params.size)
 # In most classical machine learning settings (where we are training scalar loss functions
 # consisting of a large number of parameters),
 # reverse-mode autodifferentiation is the
-# preferred method of autodifferentiation---the reduction in computational time enables larger and
+# preferred method of autodifferentiation—the reduction in computational time enables larger and
 # more complex models to be successfully trained. The backpropagation algorithm is a particular
 # special-case of reverse-mode autodifferentiation, which has helped lead to the machine learning
 # explosion we see today.
@@ -394,7 +394,7 @@ plt.show()
 # for backpropagation appears much more constant, with perhaps a minute linear increase
 # with :math:`p`. Note that the plots are not perfectly linear, with some 'bumpiness' or
 # noisiness. This is likely due to low-level operating system jitter, and
-# other environmental fluctuations---increasing the number of repeats can help smooth
+# other environmental fluctuations—increasing the number of repeats can help smooth
 # out the plot.
 #
 # For a better comparison, we can scale the time required for computing the quantum

--- a/demonstrations/tutorial_chemical_reactions.py
+++ b/demonstrations/tutorial_chemical_reactions.py
@@ -189,7 +189,7 @@ plt.show()
 # This is the potential energy surface for the dissociation of a hydrogen molecule into
 # two hydrogen atoms. It is a numerical calculation of the same type of plot that was
 # illustrated in the beginning. In a diatomic molecule such as :math:`H_2`, it
-# can be used to obtain the equilibrium bond length --- the distance between the two atoms that
+# can be used to obtain the equilibrium bond length — the distance between the two atoms that
 # minimizes the total electronic energy. This is simply the minimum of the curve. We can also
 # obtain the bond dissociation energy, which is the difference in the energy of the system when
 # the atoms are far apart and the energy at equilibrium. At sufficiently large separations,
@@ -371,7 +371,7 @@ print(f"The activation energy is {activation_energy:.6f} Hartrees")
 #
 # where :math:`k_B` is the Boltzmann constant, :math:`T` is the temperature, and :math:`A` is a
 # pre-exponential factor that can be determined empirically for each reaction. Crucially, the rate at which
-# a chemical reaction occurs depends exponentially on the activation energy computed from the PES --- this is a good reminder of the importance
+# a chemical reaction occurs depends exponentially on the activation energy computed from the PES — this is a good reminder of the importance
 # of performing highly-accurate calculations in quantum chemistry!
 #
 # For example, let's calculate the ratio of reaction rates when the temperature is doubled. We have

--- a/demonstrations/tutorial_chemical_reactions.py
+++ b/demonstrations/tutorial_chemical_reactions.py
@@ -12,7 +12,7 @@ Modelling chemical reactions on a quantum computer
 
 *Authors: Varun Rishi and Juan Miguel Arrazola — Posted: 23 July 2021. Last updated: 21 February 2023.*
 
-The term "chemical reaction" is another name for the transformation of molecules -- the breaking and 
+The term "chemical reaction" is another name for the transformation of molecules – the breaking and 
 forming of bonds. They are characterized by an energy barrier that determines
 the likelihood that a reaction takes place. The energy landscapes formed by these barriers are the
 key to understanding how chemical reactions occur, at the deepest possible level.

--- a/demonstrations/tutorial_diffable-mitigation.py
+++ b/demonstrations/tutorial_diffable-mitigation.py
@@ -30,14 +30,14 @@ yield mixed states (see e.g. :doc:`tutorial_noisy_circuits`), we can formally wr
 
 .. math:: f^{⚡}(\theta) := \text{tr}\left[H \Phi(|\psi(\theta)\rangle \langle \psi(\theta)|) \right].
 
-To be able to get the most out of these devices, it is advisable to use quantum error mitigation --- a method of
+To be able to get the most out of these devices, it is advisable to use quantum error mitigation — a method of
 altering and/or post-processing the quantum function :math:`f^{⚡}(\theta)` to improve the result and be closer to the ideal scenario of an error free execution, :math:`f(\theta)`.
 
 Formally, we can treat error mitigation as yet another transform that maps the noisy quantum function :math:`f^{⚡}` to a new, mitigated, quantum function :math:`\tilde{f}`,
 
 .. math:: \text{mitigate}: f^{⚡} \mapsto \tilde{f}.
 
-In order to run our VQA with our mitigated quantum function, we need to ensure that :math:`\tilde{f}` is differentiable --- both formally and practically in our implementation.
+In order to run our VQA with our mitigated quantum function, we need to ensure that :math:`\tilde{f}` is differentiable — both formally and practically in our implementation.
 PennyLane now provides one such differentiable quantum error mitigation technique with `zero noise extrapolation` (ZNE), which can be used and differentiated in simulation and on hardware.
 Thus, we can improve the estimates of observables without breaking the differentiable workflow of our variational algorithm.
 We will briefly introduce these functionalities and afterwards go more in depth to explore what happens under the hood.
@@ -177,7 +177,7 @@ plt.show()
 # ------------------------------------------------------------
 #
 # We will now use mitigation while we optimize the parameters of our variational circuit to obtain the ground state of the Hamiltonian 
-# --- this is the variational quantum eigensolving (VQE), see :doc:`tutorial_vqe`.
+# — this is the variational quantum eigensolving (VQE), see :doc:`tutorial_vqe`.
 # Then, we will compare VQE optimization runs for  the ideal, noisy, and mitigated QNodes and see that the mitigated one comes close to the ideal (zero noise) results,
 # whereas the noisy execution is further off.
 

--- a/demonstrations/tutorial_doubly_stochastic.py
+++ b/demonstrations/tutorial_doubly_stochastic.py
@@ -76,7 +76,7 @@ expectation values.
 
 Putting these two results together, `Sweke et al. (2019) <https://arxiv.org/abs/1910.01155>`__
 show that samples of the expectation value fed into the parameter-shift rule provide
-unbiased estimators of the quantum gradient---resulting in a form of stochastic gradient descent
+unbiased estimators of the quantum gradient—resulting in a form of stochastic gradient descent
 (referred to as QSGD). Moreover, they show that convergence of the stochastic gradient
 descent is guaranteed in sufficiently simplified settings, even in the case where the number
 of shots is 1!
@@ -271,7 +271,7 @@ print(
 # To perform "doubly stochastic" gradient descent, we simply apply the stochastic
 # gradient descent approach from above, but in addition also uniformly sample
 # a subset of the terms for the Hamiltonian expectation at each optimization step.
-# This inserts another element of stochasticity into the system---all the while
+# This inserts another element of stochasticity into the system—all the while
 # convergence continues to be guaranteed!
 #
 # Let's create a QNode that randomly samples a single term from the above
@@ -320,7 +320,7 @@ for _ in range(250):
 ##############################################################################
 # During doubly stochastic gradient descent, we are sampling from terms of the
 # analytic cost function, so it is not entirely instructive to plot the cost
-# versus optimization step---partial sums of the terms in the Hamiltonian
+# versus optimization step—partial sums of the terms in the Hamiltonian
 # may have minimum energy below the ground state energy of the total Hamiltonian.
 # Nevertheless, we can keep track of the cost value moving average during doubly
 # stochastic gradient descent as an indicator of convergence.

--- a/demonstrations/tutorial_general_parshift.py
+++ b/demonstrations/tutorial_general_parshift.py
@@ -74,7 +74,7 @@ that depends on a single variational parameter :math:`x`.
 That is, the state may be prepared by any circuit, but we will only allow a single parameter
 in a single operation to enter the circuit.
 For this we will use a handy gate structure that allows us to tune the complexity of the
-operation --- and thus of the cost function.
+operation — and thus of the cost function.
 More concretely, we initialize a qubit register in a random state :math:`|\psi\rangle`
 and apply a layer of Pauli-:math:`Z` rotations ``RZ`` to all qubits, where all rotations are parametrized by the *same* angle :math:`x`.
 We then measure the expectation value of a random Hermitian observable :math:`B` in the created
@@ -120,7 +120,7 @@ def random_observable(N, seed):
 # Now let's set up a "cost function generator", namely a function that will create the
 # ``cost`` function we discussed above, using :math:`|\psi\rangle` as initial state and
 # measuring the expectation value of :math:`B`. This generator has the advantage that
-# we can quickly create the cost function for various numbers of qubits --- and therefore
+# we can quickly create the cost function for various numbers of qubits — and therefore
 # cost functions with different complexity.
 #
 # We will use the default qubit simulator with its JAX backend and also will rely
@@ -426,7 +426,7 @@ plt.show()
 #
 #   E(x_\mu) = a_0 + \sum_{\ell=1}^R a_{\ell}\cos(\ell x_\mu)+b_{\ell}\sin(\ell x_\mu)
 #
-# with the---now irregular---sampling points :math:`x_\mu`.
+# with the—now irregular—sampling points :math:`x_\mu`.
 # For this, we set up the matrix
 #
 # .. math ::

--- a/demonstrations/tutorial_haar_measure.py
+++ b/demonstrations/tutorial_haar_measure.py
@@ -44,12 +44,12 @@ Measure
 -------
 
 `Measure theory <https://en.wikipedia.org/wiki/Measure_(mathematics)>`__ is a
-branch of mathematics that studies things that are measurable---think length,
+branch of mathematics that studies things that are measurable—think length,
 area, or volume, but generalized to mathematical spaces and even higher
 dimensions. Loosely, the measure tells you about how "stuff" is distributed and
 concentrated in a mathematical set or space. An intuitive way to understand
 the measure is to think about a sphere. An arbitrary point on a sphere can be
-parametrized by three numbers---depending on what you're doing, you may use
+parametrized by three numbers—depending on what you're doing, you may use
 Cartesian coordinates :math:`(x, y, z)`, or it may be more convenient to use
 spherical coordinates :math:`(\rho, \phi, \theta)`.
 
@@ -104,7 +104,7 @@ differently depending on where they are in the space. While we need to know the
 measure to properly integrate over the sphere, knowledge of the measure also
 gives us the means to perform another important task, that of sampling points in
 the space uniformly at random. We can't simply sample each parameter from the
-uniform distribution over its domain---as we experienced already, this doesn't
+uniform distribution over its domain—as we experienced already, this doesn't
 take into account how the sphere is spread out over space. The measure describes
 the distribution of each parameter and gives a recipe for sampling them in order
 to obtain something properly uniform.
@@ -146,7 +146,7 @@ integral with respect to the Haar measure, like so:
 As with the measure term of the sphere, :math:`d\mu_N` itself can be broken down
 into components depending on individual parameters.  While the Haar
 measure can be defined for every dimension :math:`N`, the mathematical form gets
-quite hairy for larger dimensions---in general, an :math:`N`-dimensional unitary
+quite hairy for larger dimensions—in general, an :math:`N`-dimensional unitary
 requires at least :math:`N^2 - 1` parameters, which is a lot to keep track of!
 Therefore we'll start with the case of a single qubit :math:`(N=2)`, then show
 how things generalize.
@@ -159,7 +159,7 @@ continue our comparison to spheres by visualizing single-qubit states on the
 Bloch sphere. As expressed above, the measure provides a recipe for sampling
 elements of the unitary group in a properly uniform manner, given the structure
 of the group. One useful consequence of this is that it provides a method to
-sample quantum *states* uniformly at random---we simply generate Haar-random
+sample quantum *states* uniformly at random—we simply generate Haar-random
 unitaries, and apply them to a fixed basis state such as :math:`\vert 0\rangle`.
 
 We'll see how this works in good time. First, we'll take a look at what happens
@@ -406,7 +406,7 @@ plot_bloch_sphere(haar_bloch_vectors)
 # transformation; and the third term depends on the parameters in the other
 # :math:`SU(N-1)` transformation.
 #
-# :math:`SU(2)` is the "base case" of the recursion---we simply have the Haar measure
+# :math:`SU(2)` is the "base case" of the recursion—we simply have the Haar measure
 # as expressed above.
 #
 # |
@@ -541,11 +541,11 @@ plot_bloch_sphere(qr_haar_bloch_vectors)
 # function.
 #
 # Now, it's clear that this method works, but it is also important to
-# understand *why* it works.  Step 1 is fairly straightforward---the base of our
+# understand *why* it works.  Step 1 is fairly straightforward—the base of our
 # samples is a matrix full of complex values chosen from a typical
 # distribution. This isn't enough by itself, since unitary matrices also
-# have constraints---their rows and columns must be orthonormal.
-# These constraints are where step 2 comes in---the outcome of a generic
+# have constraints—their rows and columns must be orthonormal.
+# These constraints are where step 2 comes in—the outcome of a generic
 # QR decomposition consists of an *orthonormal* matrix :math:`Q`, and and upper
 # triangular matrix :math:`R`. Since our original matrix was complex-valued, we end
 # up with a :math:`Q` that is in fact already unitary. But why not stop there? Why
@@ -567,7 +567,7 @@ plot_bloch_sphere(qr_haar_bloch_vectors)
 #
 #    Use the ``qr_haar`` function above to generate random unitaries and construct
 #    a distribution of their eigenvalues. Then, comment out the lines for steps 3 and
-#    4 and do the same---you'll find that the distribution is no longer uniform.
+#    4 and do the same—you'll find that the distribution is no longer uniform.
 #    Check out reference [#Mezzadri2006]_ for additional details and examples.
 
 ######################################################################
@@ -662,7 +662,7 @@ plot_bloch_sphere(qr_haar_bloch_vectors)
 # increasing the dimension :math:`N` also makes the deviation exponentially less
 # likely.
 #
-# Now, this result seems unrelated to quantum states---it concerns higher-
+# Now, this result seems unrelated to quantum states—it concerns higher-
 # dimensional spheres. However, recall that a quantum state vector is a complex
 # vector whose squared values sum to 1, similar to vectors on a sphere. If you
 # "unroll" a quantum state vector of dimension :math:`N = 2^n` by stacking its
@@ -729,13 +729,13 @@ plot_bloch_sphere(qr_haar_bloch_vectors)
 # Conclusion
 # ----------
 #
-# The Haar measure plays an important role in quantum computing---anywhere
+# The Haar measure plays an important role in quantum computing—anywhere
 # you might be dealing with sampling random circuits, or averaging over
 # all possible unitary operations, you'll want to do so with respect
 # to the Haar measure.
 #
 # There are two important aspects of this that we have yet to touch upon,
-# however. The first is whether it is efficient to sample from the Haar measure---given
+# however. The first is whether it is efficient to sample from the Haar measure—given
 # that the number of parameters to keep track of is exponential in the
 # number of qubits, certainly not. But a more interesting question is do we
 # *need* to always sample from the full Haar measure?  The answer to this is

--- a/demonstrations/tutorial_implicit_diff_susceptibility.py
+++ b/demonstrations/tutorial_implicit_diff_susceptibility.py
@@ -594,7 +594,7 @@ print(qml.about())
 # its ground-state has certain properties. It is also possible to perhaps look
 # at this inverse-design of the Hamiltonian as a control problem. Implicit
 # differentiation in the classical setting allows defining a new type of
-# neural network layer --- implicit layers such as neural ODEs. In a similar
+# neural network layer — implicit layers such as neural ODEs. In a similar
 # way, we hope this demo the inspires creation of new architectures for quantum
 # neural networks, perhaps a quantum version of neural ODEs or quantum implicit
 # layers.

--- a/demonstrations/tutorial_kernels_module.py
+++ b/demonstrations/tutorial_kernels_module.py
@@ -301,7 +301,7 @@ def kernel_circuit(x1, x2, params):
 
 ##############################################################################
 # The kernel function itself is now obtained by looking at the probability
-# of observing the all-zero state at the end of the kernel circuit -- because
+# of observing the all-zero state at the end of the kernel circuit – because
 # of the ordering in ``qml.probs``, this is the first entry:
 
 

--- a/demonstrations/tutorial_learning_few_data.py
+++ b/demonstrations/tutorial_learning_few_data.py
@@ -223,7 +223,7 @@ def pooling_layer(weights, wires):
 
 ##############################################################################
 # We can construct a QCNN by combining both layers and using an arbitrary unitary to model
-# a dense layer. It will take a set of features --- the image --- as input, encode these features using
+# a dense layer. It will take a set of features — the image — as input, encode these features using
 # an embedding map, apply rounds of convolutional and pooling layers, and eventually output the
 # desired measurement statistics of the circuit.
 

--- a/demonstrations/tutorial_measurement_optimize.py
+++ b/demonstrations/tutorial_measurement_optimize.py
@@ -23,14 +23,14 @@ other quantum algorithms such as the :doc:`Quantum Approximate Optimization Algo
 
 To scale VQE beyond the regime of classical computation, however, we need to solve for the
 ground state of increasingly larger molecules. A consequence is that the number of
-measurements we need to make on the quantum hardware also grows polynomially---a huge bottleneck,
+measurements we need to make on the quantum hardware also grows polynomially—a huge bottleneck,
 especially when quantum hardware access is limited and expensive.
 
 To mitigate this 'measurement problem', a plethora of recent research dropped over the course of
 2019 and 2020 [#yen2020]_ [#izmaylov2019]_ [#huggins2019]_ [#gokhale2020]_ [#verteletskyi2020]_ ,
 exploring potential strategies to minimize the number of measurements required. In fact, by grouping
 commuting terms of the Hamiltonian, we can significantly reduce the number of
-measurements needed---in some cases, reducing the number of measurements by up to 90%!
+measurements needed—in some cases, reducing the number of measurements by up to 90%!
 
 .. figure:: /demonstrations/measurement_optimize/grouping.png
     :width: 90%
@@ -148,7 +148,7 @@ def cost_circuit(params):
 
 ##############################################################################
 # If we evaluate this cost function, we can see that it corresponds to 15 different
-# QNodes under the hood---one per expectation value:
+# QNodes under the hood—one per expectation value:
 
 params = np.random.normal(0, np.pi, len(singles) + len(doubles))
 with qml.Tracker(dev) as tracker:  # track the number of executions
@@ -429,7 +429,7 @@ print(rotated_probs)
 
 ##############################################################################
 # We're not quite there yet; we have only calculated the probabilities of the variational circuit
-# rotated into the shared eigenbasis---the :math:`|\langle \phi_n |\psi\rangle|^2`. To recover the
+# rotated into the shared eigenbasis—the :math:`|\langle \phi_n |\psi\rangle|^2`. To recover the
 # *expectation values* of the two QWC observables from the probabilities, recall that we need one
 # final piece of information: their eigenvalues :math:`\lambda_{A, n}` and :math:`\lambda_{B, n}`.
 #
@@ -518,11 +518,11 @@ print(new_obs)
 # other solutions that require three complete subgraphs. If we were to go with this solution,
 # we would be able to measure the expectation value of the Hamiltonian using two circuit evaluations.
 #
-# This problem---finding the minimum number of complete subgraphs of a graph---is actually quite well
+# This problem—finding the minimum number of complete subgraphs of a graph—is actually quite well
 # known in graph theory, where it is referred to as the `minimum clique cover problem
 # <https://en.wikipedia.org/wiki/Clique_cover>`__ (with 'clique' being another term for a complete subgraph).
 #
-# Unfortunately, that's where our good fortune ends---the minimum clique cover problem is known to
+# Unfortunately, that's where our good fortune ends—the minimum clique cover problem is known to
 # be `NP-hard <https://en.wikipedia.org/wiki/NP-hardness>`__, meaning there is no known (classical)
 # solution to finding the optimum/minimum clique cover in polynomial time.
 #
@@ -699,7 +699,7 @@ obs_groupings = qml.pauli.group_observables(terms, grouping_type='qwc', method='
 rotations, measurements = qml.pauli.diagonalize_qwc_groupings(obs_groupings)
 
 ##############################################################################
-# However, this isn't strictly necessary---recall previously that the QNode
+# However, this isn't strictly necessary—recall previously that the QNode
 # has the capability to *automatically* measure qubit-wise commuting observables!
 
 dev = qml.device("default.qubit", wires=4)
@@ -773,7 +773,7 @@ print("Number of required measurements after optimization:", len(groups))
 # measurement optimization techniques (QAOA being a prime example).
 #
 # So the next time you are working on a variational quantum algorithm and the number
-# of measurements required begins to explode---stop, take a deep breath 😤, and consider grouping
+# of measurements required begins to explode—stop, take a deep breath 😤, and consider grouping
 # and optimizing your measurements.
 
 ##############################################################################

--- a/demonstrations/tutorial_multiclass_classification.py
+++ b/demonstrations/tutorial_multiclass_classification.py
@@ -255,7 +255,7 @@ def split_data(feature_vecs, Y):
 # In the training procedure, we begin by first initializing randomly the parameters
 # we wish to learn (variational circuit weights and classical bias). As these are
 # the variables we wish to optimize, we set the ``requires_grad`` flag to ``True``. We use
-# minibatch training---the average loss for a batch of samples is computed, and the
+# minibatch training—the average loss for a batch of samples is computed, and the
 # optimization step is based on this. Total training time with the default parameters
 # is roughly 15 minutes.
 

--- a/demonstrations/tutorial_noisy_circuit_optimization.py
+++ b/demonstrations/tutorial_noisy_circuit_optimization.py
@@ -27,7 +27,7 @@ Background
 Quantum pure-state simulators are great and readily available in
 a number of quantum software packages.
 They allow us to experiment, prototype, test, and validate algorithms
-and research ideas---up to a certain number of qubits, at least.
+and research ideas—up to a certain number of qubits, at least.
 
 But present-day hardware is not ideal. We're forced to confront
 decoherence, bit flips, amplitude damping, and so on. Does the

--- a/demonstrations/tutorial_noisy_circuits.py
+++ b/demonstrations/tutorial_noisy_circuits.py
@@ -42,7 +42,7 @@ We're putting the N in NISQ.
 #   a rotation by an angle :math:`\phi+\epsilon` instead of :math:`\phi`.
 #
 # * **Incoherent noise** is more problematic: it originates from a quantum computer
-#   becoming entangled with the environment, resulting in mixed states --- probability
+#   becoming entangled with the environment, resulting in mixed states — probability
 #   distributions over different pure states. Incoherent noise thus leads to outputs that are
 #   always random, regardless of what basis we measure in.
 #

--- a/demonstrations/tutorial_quantum_analytic_descent.py
+++ b/demonstrations/tutorial_quantum_analytic_descent.py
@@ -202,7 +202,7 @@ line2 = ax.plot(
 # Although conceptually simple, building an exact model would require exponentially many resources, and that's a no-go.
 # What can we do, then?
 # The authors of QAD propose building an imperfect model.
-# This makes *all* the difference---they use a classical model that is accurate only in
+# This makes *all* the difference—they use a classical model that is accurate only in
 # a region close to a given reference point, and that delivers good results for the optimization!
 #
 # Function expansions
@@ -629,7 +629,7 @@ mapped_model = lambda params: model_cost(params, *past_coeffs[2])
 plot_cost_and_model(circuit, mapped_model, past_parameters[2])
 
 ###############################################################################
-# **Iteration 3:** Both the model and the original cost function now show a minimum close to our parameter position--- Quantum Analytic Descent converged.
+# **Iteration 3:** Both the model and the original cost function now show a minimum close to our parameter position— Quantum Analytic Descent converged.
 # Note how the larger deviations of the model close to the boundaries are not a problem at all because we only use the model in the central area
 # in which both the original energy and the model form a convex bowl and the deviation plateaus at zero.
 #

--- a/demonstrations/tutorial_quantum_analytic_descent.py
+++ b/demonstrations/tutorial_quantum_analytic_descent.py
@@ -63,7 +63,7 @@ VQEs give rise to trigonometric cost functions
 ----------------------------------------------
 
 When we talk about VQEs we have a quantum circuit with :math:`n` qubits in mind, which are typically initialized in the base state :math:`|0\rangle`.
-The body of the circuit is a *variational form* :math:`V(\boldsymbol{\theta})` -- a fixed architecture of quantum gates parametrized by an array of real-valued parameters :math:`\boldsymbol{\theta}\in\mathbb{R}^m`.
+The body of the circuit is a *variational form* :math:`V(\boldsymbol{\theta})` – a fixed architecture of quantum gates parametrized by an array of real-valued parameters :math:`\boldsymbol{\theta}\in\mathbb{R}^m`.
 After the variational form, the circuit ends with the measurement of a chosen observable
 :math:`\mathcal{M}`, based on the problem
 we are trying to solve.
@@ -298,7 +298,7 @@ line2 = ax.plot(
 #
 # In PennyLane, computing the gradient of a cost function with respect to an array of parameters can be easily done
 # with the `parameter-shift rule <https://pennylane.ai/qml/glossary/parameter_shift.html>`_.
-# By iterating the rule, we can obtain the second derivatives -- the Hessian (see for example [#higher_order_diff]_).
+# By iterating the rule, we can obtain the second derivatives – the Hessian (see for example [#higher_order_diff]_).
 # Let us implement a function that does just that and prepares the coefficients :math:`E^{(A/B/C/D)}`:
 
 
@@ -623,7 +623,7 @@ mapped_model = lambda params: model_cost(params, *past_coeffs[1])
 plot_cost_and_model(circuit, mapped_model, past_parameters[1])
 
 ###############################################################################
-# **Iteration 2:** Now we observe the model better resembles the original landscape. In addition, the minimum of the model is within the displayed range -- we're getting closer.
+# **Iteration 2:** Now we observe the model better resembles the original landscape. In addition, the minimum of the model is within the displayed range – we're getting closer.
 
 mapped_model = lambda params: model_cost(params, *past_coeffs[2])
 plot_cost_and_model(circuit, mapped_model, past_parameters[2])

--- a/demonstrations/tutorial_quantum_natural_gradient.py
+++ b/demonstrations/tutorial_quantum_natural_gradient.py
@@ -40,9 +40,9 @@ of variational quantum algorithms have used gradient-free classical optimization
 methods, such as the Nelder-Mead algorithm. However, the parameter-shift rule
 (as implemented in PennyLane) allows the user to automatically compute
 analytic gradients of quantum circuits. This opens up the possibility to train
-quantum computing hardware using gradient descent---the same method used to train
+quantum computing hardware using gradient descent—the same method used to train
 deep learning models.
-Though one caveat has surfaced with gradient descent --- how do we choose the optimal
+Though one caveat has surfaced with gradient descent — how do we choose the optimal
 step size for our variational quantum algorithms, to ensure successful and
 efficient optimization?
 

--- a/demonstrations/tutorial_rosalin.py
+++ b/demonstrations/tutorial_rosalin.py
@@ -35,8 +35,8 @@ Background
 
 While a large number of papers in variational quantum algorithms focus on the
 choice of circuit ansatz, cost function, gradient computation, or initialization method,
-the optimization strategy---an important component affecting both convergence time and
-quantum resource dependence---is not as frequently considered. Instead, common
+the optimization strategy—an important component affecting both convergence time and
+quantum resource dependence—is not as frequently considered. Instead, common
 'out-of-the-box' classical optimization techniques, such as gradient-free
 methods (COBLYA, Nelder-Mead), gradient-descent, and Hessian-free methods (L-BFGS) tend to be used.
 
@@ -379,7 +379,7 @@ plt.show()
 # ~~~~~~~~~~~~~~~~~~~~~~
 #
 # Let's now modify iCANS above to incorporate weighted random sampling of Hamiltonian
-# terms --- the Rosalin frugal shot optimizer.
+# terms — the Rosalin frugal shot optimizer.
 #
 # Rosalin takes several hyper-parameters:
 #

--- a/demonstrations/tutorial_rotoselect.py
+++ b/demonstrations/tutorial_rotoselect.py
@@ -142,7 +142,7 @@ dev = qml.device("default.qubit", shots=1000, wires=2)
 #
 # |
 #
-# Next, we set up a circuit with a fixed ansatz structure---which will later be subject to change---and encode
+# Next, we set up a circuit with a fixed ansatz structure—which will later be subject to change—and encode
 # the Hamiltonian into a cost function. The structure is shown in the figure above.
 
 

--- a/demonstrations/tutorial_spsa.py
+++ b/demonstrations/tutorial_spsa.py
@@ -118,7 +118,7 @@ randomly generated using a zero-mean distribution. In most cases, the Rademacher
 distribution is used, meaning each parameter is simultaneously perturbed by
 either :math:`\pm c_k`.
 
-It is this perturbation that makes SPSA robust to noise --- since every
+It is this perturbation that makes SPSA robust to noise — since every
 parameter is already being shifted, additional shifts due to noise are less
 likely to hinder the optimization process. In a sense, noise gets "absorbed"
 into the already-stochastic process. This is highlighted in the figure below,

--- a/demonstrations/tutorial_stochastic_parameter_shift.py
+++ b/demonstrations/tutorial_stochastic_parameter_shift.py
@@ -33,7 +33,7 @@ i) The circuit's gates have free parameters
 ii) Expectation values of measurements are built up from samples
 
 These two ingredients allow one circuit to actually represent an entire *family of circuits*.
-An objective function---encapsulating some problem-specific goal---is built from the expectation values,
+An objective function—encapsulating some problem-specific goal—is built from the expectation values,
 and the circuit's free parameters are progressively tuned to optimize this function.
 At each step, the circuit has the same gate layout, but slightly different parameters, making
 this approach promising to run on constrained near-term devices.
@@ -86,7 +86,7 @@ Now, how do we actually obtain the numerical values of the gradient necessary fo
 
 This is where the parameter-shift rule [#li2016]_ [#mitarai2018]_ [#schuld2018]_ enters the story.
 In short, the parameter-shift rule says that for
-many gates of interest---including all single-qubit gates---we can obtain the value of the derivative
+many gates of interest—including all single-qubit gates—we can obtain the value of the derivative
 :math:`\nabla_\theta \langle \hat{A}(\theta) \rangle` by subtracting two related
 circuit evaluations:
 
@@ -178,7 +178,7 @@ plt.show()
 # and that they match the values provided by the :func:`~pennylane.grad`
 # function.
 #
-# The parameter-shift works really nicely for many gates---like the rotation
+# The parameter-shift works really nicely for many gates—like the rotation
 # gate we used in our example above. But it does have constraints. There are
 # some technical conditions that, if a gate satisfies them, we can guarantee
 # it has a parameter-shift rule [#schuld2018]_. Concretely, the

--- a/demonstrations/tutorial_tn_circuits.py
+++ b/demonstrations/tutorial_tn_circuits.py
@@ -33,7 +33,7 @@ Tensors are multi-dimensional arrays of numbers.
 Intuitively, they can be interpreted as a
 generalization of scalars, vectors, and matrices. 
 Tensors can be described by their rank, indices, and the dimension of the indices.
-The rank is the number of indices in a tensor --- a scalar has 
+The rank is the number of indices in a tensor — a scalar has 
 rank zero, a vector has rank one, and a matrix has rank two.
 The dimension of an index is the number of values that index can take.
 For example, a vector with three elements has one index that can take three

--- a/demonstrations/tutorial_unitary_designs.py
+++ b/demonstrations/tutorial_unitary_designs.py
@@ -83,7 +83,7 @@ uniformly at random on the sphere, evaluating the function at those points, and
 computing their average value. That will always work, and it will get us close,
 but it will not be exact.
 
-In fact, both of those approaches may be overkill in some special cases---if the
+In fact, both of those approaches may be overkill in some special cases—if the
 terms in the polynomial have the same degree of at most :math:`t`, you can
 compute the average **exactly** over the sphere using only a small set of points
 rather than integrating over the entire sphere.  That set of points is called a
@@ -275,7 +275,7 @@ print(cube_average)
 # -----------------------------------
 #
 # Unitary designs come into play in applications that require randomization, or
-# sampling of random unitaries---essentially, they can be used as a stand-in for
+# sampling of random unitaries—essentially, they can be used as a stand-in for
 # the Haar measure. The way in which the unitaries are used in the application may
 # place restrictions on the value of :math:`t` that is required; arguably the most
 # common is the unitary 2-design.
@@ -318,13 +318,13 @@ print(cube_average)
 #     \bar{F}(\Lambda, V) = \int_{\mathcal{U}} d\mu(U) \langle 0 | U^\dagger V^\dagger \Lambda(U |0\rangle \langle 0| U^\dagger) V U |0\rangle.
 # 
 # This is known as *twirling* the channel :math:`\Lambda`. Computing the average
-# fidelity in this way would be a nightmare---we'd have to compute the fidelity
+# fidelity in this way would be a nightmare—we'd have to compute the fidelity
 # with respect to an infinite number of states!
 # 
 # However, consider the expression in the integral above. We have an inner product
 # involving two instances of :math:`U`, and two instances of
 # :math:`U^\dagger`. This means that the expression is a polynomial of degree 2 in
-# both the elements of :math:`U` and its complex conjugates---this matches exactly
+# both the elements of :math:`U` and its complex conjugates—this matches exactly
 # the definition of a unitary 2-design. This means that if we can find a set of
 # :math:`K` unitaries that form a 2-design, we can compute the average fidelity
 # using only a finite set of initial states:
@@ -417,7 +417,7 @@ single_qubit_cliffords = [
 # specified by only a small set of generators (in fact, only one more
 # than is needed for the single-qubit case). Together, :math:`H`, :math:`S`, and
 # CNOT (on every possible qubit or pair of qubits) generate the :math:`n`-qubit
-# group. Be careful though---the size of the group increases exponentially. The
+# group. Be careful though—the size of the group increases exponentially. The
 # 2-qubit group alone has 11520 elements! The size can be worked out in a manner
 # analogous to that we used above in the single qubit case: by looking at the
 # combinatorics of the possible ways the gates can map Paulis with only

--- a/demonstrations/tutorial_unitary_designs.py
+++ b/demonstrations/tutorial_unitary_designs.py
@@ -725,7 +725,7 @@ print(f"Clifford mean fidelity    = {clifford_fid_mean}")
 # .. [#Seberry]
 #
 #    J. Seberry and M. Yamada (1992) *Hadamard matrices, sequences, and block
-#    designs.* Contemporary Design Theory -- A Collection of Surveys
+#    designs.* Contemporary Design Theory – A Collection of Surveys
 #    (D. J. Stinson and J. Dinitz, Eds.), John Wiley and Sons, 431-560.
 #    `(PDF) <http://mathscinet.ru/files/YamadaSeberry1992.pdf>`__.
 #

--- a/demonstrations/tutorial_univariate_qvr.py
+++ b/demonstrations/tutorial_univariate_qvr.py
@@ -242,7 +242,7 @@ os.system("covalent start")
 # If you run into any out-of-memory issues with Dask when running this notebook,
 # Try reducing the number of workers and making a specific memory request. I.e.:
 # os.system("covalent start -m "2GiB" -n 2")
-# try covalent --help for more info
+# try covalent –help for more info
 time.sleep(2)  # give the Dask cluster some time to launch
 
 

--- a/glossary/quantum_differentiable_programming.rst
+++ b/glossary/quantum_differentiable_programming.rst
@@ -25,7 +25,7 @@ but the fundamental structure of the program doesn't change.
 
 In contrast, more recent approaches use a "define-by-run" scheme, in which there
 is no underlying assumption to how the model is structured. The models are
-composed of parameterized function blocks, and the structure is dynamic---it may
+composed of parameterized function blocks, and the structure is dynamic—it may
 change depending on the input data, yet still remains trainable and
 differentiable.  A critical aspect of this is that it holds true even in the
 presence of classical control flow such as for loops and if statements. These
@@ -90,7 +90,7 @@ Numerical differentiation
 Symbolic differentation may not be always be possible when a function falls
 outside the set of implementated rules. It may also be very computationally
 complex. An alternative in these situations is to compute an approximation to
-the derivative numerically --- this is something that can *always* be
+the derivative numerically — this is something that can *always* be
 done. There exist `a variety of such numerical methods
 <https://en.wikipedia.org/wiki/Numerical_differentiation>`_, a common one being
 the finite difference method. For this method the derivative is computed by

--- a/glossary/quantum_feature_map.rst
+++ b/glossary/quantum_feature_map.rst
@@ -28,7 +28,7 @@ called feature vectors.
 
     A feature map can transform data into a space where it is easier to process.
 
-In general :math:`\cal{F}` is just a vector space --- a *quantum feature map*
+In general :math:`\cal{F}` is just a vector space — a *quantum feature map*
 :math:`\phi : \cal{X} \rightarrow \cal{F}` is a feature map where the vector
 space :math:`\cal{F}` is a Hilbert space and the feature vectors are quantum
 states. The map transforms :math:`x \rightarrow |\phi(x)\rangle` by way of a


### PR DESCRIPTION
We've had some issues with the conversion of triple and double hyphens to em and en dashes, so I've simply swapped them to their Unicode counterparts.