### PR TITLE
Quantum computing category

### DIFF
--- a/demonstrations/ahs_aquila.metadata.json
+++ b/demonstrations/ahs_aquila.metadata.json
@@ -7,7 +7,7 @@
     ],
     "dateOfPublication": "2023-05-16T00:00:00",
     "dateOfLastModification": "2023-05-16T00:00:00",
-    "categories": ["Quantum Hardware", "Devices and Performance"],
+    "categories": ["Quantum Hardware", "Devices and Performance", "Quantum Computing"],
     "tags": [],
     "previewImages": [
          {

--- a/demonstrations/demonstrations_categories.metadata.json
+++ b/demonstrations/demonstrations_categories.metadata.json
@@ -25,13 +25,18 @@
         "description": "Here you will discover and learn how to use many of the devices offered by PennyLane. From built-in devices and their different interfaces to external devices."
     },
     {
+        "title": "Quantum Computing",
+        "urlFragment": "quantum-computing",
+        "description": "Explore the applications of PennyLane to general quantum computing tasks such as benchmarking and characterizing quantum processors."
+    },
+    {
         "title": "Quantum Hardware",
         "urlFragment": "quantum-hardware",
         "description": "In this section you will learn the different technologies to build quantum computers. We will make use of our different devices to explore these concepts."
     },
     {
-        "title": "Algorithms and Techniques",
-        "urlFragment": "algorithms-and-techniques",
+        "title": "Algorithms",
+        "urlFragment": "algorithms",
         "description": "This category will be focused on showing different fundamental algorithms of quantum computing. Here you will also find advanced techniques such as circuit cutting."
     }
 ]

--- a/demonstrations/gbs.metadata.json
+++ b/demonstrations/gbs.metadata.json
@@ -11,7 +11,8 @@
     "dateOfPublication": "2020-12-04T00:00:00",
     "dateOfLastModification": "2020-12-04T00:00:00",
     "categories": [
-        "Quantum Hardware"
+        "Quantum Hardware",
+        "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/qsim_beyond_classical.metadata.json
+++ b/demonstrations/qsim_beyond_classical.metadata.json
@@ -8,7 +8,8 @@
     "dateOfPublication": "2020-11-30T00:00:00",
     "dateOfLastModification": "2021-09-10T00:00:00",
     "categories": [
-        "Quantum Hardware"
+        "Quantum Hardware",
+        "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/quantum_volume.metadata.json
+++ b/demonstrations/quantum_volume.metadata.json
@@ -8,7 +8,8 @@
     "dateOfPublication": "2020-12-15T00:00:00",
     "dateOfLastModification": "2021-04-15T00:00:00",
     "categories": [
-        "Quantum Hardware"
+        "Quantum Hardware",
+        "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/tutorial_classical_shadows.metadata.json
+++ b/demonstrations/tutorial_classical_shadows.metadata.json
@@ -11,7 +11,7 @@
     "dateOfPublication": "2021-06-14T00:00:00",
     "dateOfLastModification": "2021-06-14T00:00:00",
     "categories": [
-        "Algorithms and Techniques"
+        "Algorithms"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/tutorial_diffable_shadows.metadata.json
+++ b/demonstrations/tutorial_diffable_shadows.metadata.json
@@ -8,7 +8,8 @@
     "dateOfPublication": "2022-10-07T00:00:00",
     "dateOfLastModification": "2022-10-11T00:00:00",
     "categories": [
-        "Algorithms and Techniques"
+        "Algorithms",
+        "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/tutorial_error_mitigation.metadata.json
+++ b/demonstrations/tutorial_error_mitigation.metadata.json
@@ -11,7 +11,8 @@
     "dateOfPublication": "2021-11-29T00:00:00",
     "dateOfLastModification": "2021-11-29T00:00:00",
     "categories": [
-        "Algorithms and Techniques"
+        "Algorithms",
+        "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/tutorial_haar_measure.metadata.json
+++ b/demonstrations/tutorial_haar_measure.metadata.json
@@ -8,7 +8,8 @@
     "dateOfPublication": "2021-03-22T00:00:00",
     "dateOfLastModification": "2021-03-22T00:00:00",
     "categories": [
-        "Quantum Machine Learning"
+        "Quantum Machine Learning",
+        "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/tutorial_intro_qsvt.metadata.json
+++ b/demonstrations/tutorial_intro_qsvt.metadata.json
@@ -8,7 +8,8 @@
     "dateOfPublication": "2023-05-23T00:00:00",
     "dateOfLastModification": "2023-05-23T00:00:00",
     "categories": [
-        "Algorithms and Techniques"
+        "Algorithms",
+        "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/tutorial_mbqc.metadata.json
+++ b/demonstrations/tutorial_mbqc.metadata.json
@@ -11,7 +11,8 @@
     "dateOfPublication": "2022-12-05T00:00:00",
     "dateOfLastModification": "2022-12-05T00:00:00",
     "categories": [
-        "Quantum Hardware"
+        "Quantum Hardware",
+        "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/tutorial_neutral_atoms.metadata.json
+++ b/demonstrations/tutorial_neutral_atoms.metadata.json
@@ -8,7 +8,8 @@
     "dateOfPublication": "2023-05-30T00:00:00",
     "dateOfLastModification": "2023-05-30T00:00:00",
     "categories": [
-        "Quantum Hardware"
+        "Quantum Hardware",
+        "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/tutorial_pasqal.metadata.json
+++ b/demonstrations/tutorial_pasqal.metadata.json
@@ -8,7 +8,8 @@
     "dateOfPublication": "2020-10-13T00:00:00",
     "dateOfLastModification": "2021-01-21T00:00:00",
     "categories": [
-        "Quantum Hardware"
+        "Quantum Hardware",
+        "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/tutorial_photonics.metadata.json
+++ b/demonstrations/tutorial_photonics.metadata.json
@@ -8,7 +8,8 @@
     "dateOfPublication": "2022-05-31T00:00:00",
     "dateOfLastModification": "2022-06-16T00:00:00",
     "categories": [
-        "Quantum Hardware"
+        "Quantum Hardware",
+        "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/tutorial_pulse_programming101.metadata.json
+++ b/demonstrations/tutorial_pulse_programming101.metadata.json
@@ -8,7 +8,8 @@
     "dateOfPublication": "2023-03-08T00:00:00",
     "dateOfLastModification": "2023-03-08T00:00:00",
     "categories": [
-        "Quantum Hardware"
+        "Quantum Hardware",
+        "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/tutorial_qft_arithmetics.metadata.json
+++ b/demonstrations/tutorial_qft_arithmetics.metadata.json
@@ -8,7 +8,7 @@
     "dateOfPublication": "2022-11-07T00:00:00",
     "dateOfLastModification": "2022-11-07T00:00:00",
     "categories": [
-        "Getting Started", "Algorithms and Techniques"
+        "Getting Started", "Algorithms", "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/tutorial_quantum_circuit_cutting.metadata.json
+++ b/demonstrations/tutorial_quantum_circuit_cutting.metadata.json
@@ -14,7 +14,7 @@
     "dateOfPublication": "2022-09-02T00:00:00",
     "dateOfLastModification": "2022-09-02T00:00:00",
     "categories": [
-        "Algorithms and Techniques"
+        "Algorithms", "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/tutorial_qutrits_bernstein_vazirani.metadata.json
+++ b/demonstrations/tutorial_qutrits_bernstein_vazirani.metadata.json
@@ -8,7 +8,7 @@
     "dateOfPublication": "2023-05-09T00:00:00",
     "dateOfLastModification": "2023-05-09T00:00:00",
     "categories": [
-        "Algorithms and Techniques"
+        "Algorithms", "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/tutorial_sc_qubits.metadata.json
+++ b/demonstrations/tutorial_sc_qubits.metadata.json
@@ -8,7 +8,8 @@
     "dateOfPublication": "2022-03-22T00:00:00",
     "dateOfLastModification": "2022-08-26T00:00:00",
     "categories": [
-        "Quantum Hardware"
+        "Quantum Hardware",
+        "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/tutorial_testing_symmetry.metadata.json
+++ b/demonstrations/tutorial_testing_symmetry.metadata.json
@@ -8,7 +8,8 @@
     "dateOfPublication": "2023-01-24T00:00:00",
     "dateOfLastModification": "2023-01-24T00:00:00",
     "categories": [
-        "Algorithms and Techniques"
+        "Algorithms",
+        "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/tutorial_toric_code.metadata.json
+++ b/demonstrations/tutorial_toric_code.metadata.json
@@ -8,7 +8,7 @@
     "dateOfPublication": "2022-08-08T00:00:00",
     "dateOfLastModification": "2022-08-08T00:00:00",
     "categories": [
-        "Algorithms and Techniques"
+        "Algorithms", "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/tutorial_trapped_ions.metadata.json
+++ b/demonstrations/tutorial_trapped_ions.metadata.json
@@ -8,7 +8,8 @@
     "dateOfPublication": "2021-11-10T00:00:00",
     "dateOfLastModification": "2022-08-26T00:00:00",
     "categories": [
-        "Quantum Hardware"
+        "Quantum Hardware",
+        "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [

--- a/demonstrations/tutorial_unitary_designs.metadata.json
+++ b/demonstrations/tutorial_unitary_designs.metadata.json
@@ -8,7 +8,7 @@
     "dateOfPublication": "2021-09-07T00:00:00",
     "dateOfLastModification": "2021-09-07T00:00:00",
     "categories": [
-        "Quantum Machine Learning"
+        "Quantum Machine Learning", "Quantum Computing"
     ],
     "tags": [],
     "previewImages": [


### PR DESCRIPTION
In this PR I have added again the category `Quantum Computing` , moreover, by suggestion of Juan Miguel, I have simplified the name of the category of `algorithms and techniques` to simply `algorithms`.

In the review pay more attention to the file `demonstrations/demonstrations_categories.metadata.json`. I want to double check that actually with that change is enough