### PR TITLE
Removed category from supplementary demonstration

### DIFF
--- a/demonstrations/adjoint_diff_benchmarking.metadata.json
+++ b/demonstrations/adjoint_diff_benchmarking.metadata.json
@@ -7,9 +7,7 @@
     ],
     "dateOfPublication": "2021-11-23T00:00:00",
     "dateOfLastModification": "2021-11-23T00:00:00",
-    "categories": [
-        "Getting Started"
-    ],
+    "categories": [],
     "tags": [],
     "previewImages": [
         {


### PR DESCRIPTION
We have one demonstration that is a 'supplementary' article. This one we don't want to appear in the category view, as otherwise we have two demonstrations with the same name, so I've simply removed the category from the metadata file.