### PR TITLE
Re-enable JSON CI builds for master

### DIFF
--- a/.github/workflows/build-json.yml
+++ b/.github/workflows/build-json.yml
@@ -2,8 +2,7 @@ name: Build Website - JSON
 on:
   push:
     branches:
-      # TODO: Re-enable before new React demos are live
-      # - master
+      - master
       - dev
 
 concurrency:


### PR DESCRIPTION
**Title:** Re-Enables JSON builds on push to master

**Summary:** As part of phase 3 release of website, we need the JSON builds of QML re-enabled.

**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**
