### PR TITLE
No longer build HTML docs for push to master/dev

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,10 +1,6 @@
 name: Build Website
 on:
   pull_request:
-  push:
-    branches:
-      - master
-      - dev
 
 concurrency:
   group: build-docs-${{ github.ref }}

--- a/.github/workflows/update-dev.yml
+++ b/.github/workflows/update-dev.yml
@@ -2,7 +2,7 @@ name: update-dev
 on:
   workflow_run:
     workflows:
-      - Build Website
+      - Build Website - JSON
     types:
       - completed
     branches:


### PR DESCRIPTION
**Title:** No longer build HTML docs for push to master/dev

**Summary:** As part of the new pennylane.ai website release. The Demos will be served by react, which are generated from this repo as JSON. Thus, only need HTML docs being built for PR-previews and not on push to master/dev anymore.

**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**
