### PR TITLE
fixes W(a) --> U(a) typo

### DIFF
--- a/demonstrations/tutorial_intro_qsvt.py
+++ b/demonstrations/tutorial_intro_qsvt.py
@@ -61,18 +61,18 @@ The answer to our question is encapsulated in a method known as **quantum signal
 If we alternate products of :math:`U(a)` and :math:`S(\phi)`, keeping :math:`a` fixed and varying :math:`\phi`,
 the top-left corner of the resulting matrix is a polynomial transformation of :math:`a`. Mathematically,
 
-.. math:: S(\phi_0)\prod_{k=1}^d W(a) S(\phi_k) = \begin{pmatrix}
+.. math:: S(\phi_0)\prod_{k=1}^d U(a) S(\phi_k) = \begin{pmatrix}
     P(a) & *\\
     * & *
     \end{pmatrix}.
 
 The asterisk :math:`*` is used to indicate that we are not interested in these entries.
 
-The intuition behind this result is that every time we multiply by :math:`W(a)`, its entries are
+The intuition behind this result is that every time we multiply by :math:`U(a)`, its entries are
 transformed to a polynomial of higher degree, and by interleaving signal-processing operators,
 it's possible to tune the coefficients of the polynomial. For example
 
-.. math:: S(-\pi/2) W(a) S(\pi/2) W(a) S(0) = \begin{pmatrix}
+.. math:: S(-\pi/2) U(a) S(\pi/2) U(a) S(0) = \begin{pmatrix}
     2a^2-1 & 0\\
     0 & 2a^2 -1
     \end{pmatrix}.


### PR DESCRIPTION
An operation first defined as U(a) was incorrectly referred to as W(a) afterwards. This fixes the issue