### PR TITLE
Fixes to metadata

### DIFF
--- a/demonstrations/ahs_aquila.metadata.json
+++ b/demonstrations/ahs_aquila.metadata.json
@@ -21,6 +21,7 @@
      "references": [
          {
             "id": "Semeghini",
+            "type": "article",
             "title": "Probing topological spin liquids on a programmable quantum simulator",
             "authors": "G. Semeghini, H. Levine, A. Keesling, S. Ebadi, T.T. Wang, D. Bluvstein, R. Verresen, H. Pichler, M. Kalinowski, R. Samajdar, A. Omran, S. Sachdev, A. Vishwanath, M. Greiner, V. Vuletic, M.D. Lukin",
             "year": "2021",
@@ -29,6 +30,7 @@
          },
          {
             "id": "Lienhard",
+            "type": "article",
             "title": "Observing the Space- and Time-Dependent Growth of Correlations in Dynamically Tuned Synthetic Ising Models with Antiferromagnetic Interactions",
             "authors": "V. Lienhard, S. de Léséleuc, D. Barredo, T. Lahaye, A. Browaeys, M. Schuler, L.-P. Henry, A.M. Läuchli",
             "year": "2018",
@@ -37,14 +39,15 @@
          },
          {
             "id": "BraketDevGuide",
+            "type": "webpage",
             "title": "Hello AHS: Run your first Analog Hamiltonian Simulation",
             "authors": "Amazon Web Services: Amazon Braket",
-            "year": "",
             "journal": "",
             "url": "https://docs.aws.amazon.com/braket/latest/developerguide/braket-get-started-hello-ahs.html"
          },
          {
             "id": "Asthana2022",
+            "type": "article",
             "title": "AWS Quantum Technologies Blog: Realizing quantum spin liquid phase on an analog Hamiltonian Rydberg simulator",
             "authors": "Alexander Keesling, Eric Kessler, and Peter Komar",
             "year": "2021",

--- a/demonstrations/function_fitting_qsp.metadata.json
+++ b/demonstrations/function_fitting_qsp.metadata.json
@@ -22,6 +22,8 @@
     "canonicalURL": "/qml/demos/function_fitting_qsp",
     "references": [
         {
+            "id": "Martyn2021",
+            "type": "article",
             "title": "A Grand Unification of Quantum Algorithms",
             "authors": "John M. Martyn, Zane M. Rossi, Andrew K. Tan, Isaac L. Chuang",
             "year": "2021",

--- a/demonstrations/gbs.metadata.json
+++ b/demonstrations/gbs.metadata.json
@@ -27,6 +27,7 @@
     "references": [
         {
             "id": "Arute2019",
+            "type": "article",
             "title": "Quantum supremacy using a programmable superconducting processor",
             "authors": "Arute, F., Arya, K., Babbush, R., et al.",
             "year": "2019",
@@ -35,6 +36,7 @@
         },
         {
             "id": "Zhong2020",
+            "type": "article",
             "title": "Quantum computational advantage using photons",
             "authors": "Zhong, H.-S., Wang, H., Deng, Y.-H., et al.",
             "year": "2020",
@@ -44,6 +46,7 @@
         },
         {
             "id": "hamilton2017",
+            "type": "article",
             "title": "Gaussian boson sampling",
             "authors": "Craig S. Hamilton, Regina Kruse, Linda Sansoni, Sonja Barkhofen, Christine Silberhorn, and Igor Jex",
             "year": "2017",
@@ -53,6 +56,7 @@
         },
         {
             "id": "aaronson2013",
+            "type": "article",
             "title": "The computational complexity of linear optics",
             "authors": "Scott Aaronson and Alex Arkhipov",
             "year": "2013",
@@ -62,6 +66,7 @@
         },
         {
             "id": "Bourassa2020",
+            "type": "article",
             "title": "Blueprint for a scalable photonic fault-tolerant quantum computer",
             "authors": "Bourassa, J. E., Alexander, R. N., Vasmer, et al.",
             "year": "2020",

--- a/demonstrations/ibm_pennylane.metadata.json
+++ b/demonstrations/ibm_pennylane.metadata.json
@@ -11,8 +11,8 @@
             "id": "mark_nicholas_jones"
         }
     ],
-    "dateOfPublication": "2023-06-20T00:00:00",
-    "dateOfLastModification": "2023-06-20T00:00:00",
+    "dateOfPublication": "2023-06-20T00:00:00+00:00",
+    "dateOfLastModification": "2023-06-20T00:00:00+00:00",
     "categories": [
         "Devices and Performance"
     ],

--- a/demonstrations/qnspsa.metadata.json
+++ b/demonstrations/qnspsa.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "Gacon2021",
+            "type": "article",
             "title": "Simultaneous perturbation stochastic approximation of the quantum fisher information",
             "authors": "Gacon, J., Zoufal, C., Carleo, G., & Woerner, S.",
             "year": "2021",
@@ -32,12 +33,14 @@
         },
         {
             "id": "SPSA",
+            "type": "webpage",
             "title": "Simultaneous perturbation stochastic approximation",
             "year": "2022",
             "url": "https://en.wikipedia.org/wiki/Simultaneous_perturbation_stochastic_approximation"
         },
         {
             "id": "Stokes2020",
+            "type": "article",
             "title": "Quantum natural gradient",
             "authors": "Stokes, J., Izaac, J., Killoran, N., & Carleo, G.",
             "year": "2020",
@@ -47,12 +50,14 @@
         },
         {
             "id": "FS",
+            "type": "webpage",
             "title": "Fubini–Study metric",
             "year": "2022",
             "url": "https://en.wikipedia.org/wiki/Fubini%E2%80%93Study_metric"
         },
         {
             "id": "Yamamoto2019",
+            "type": "article",
             "title": "On the natural gradient for variational quantum eigensolver",
             "authors": "Yamamoto, N.",
             "year": "2019",
@@ -62,6 +67,7 @@
         },
         {
             "id": "Spall1997",
+            "type": "article",
             "title": "Accelerated second-order stochastic optimization using only function measurements",
             "authors": "Spall, J. C.",
             "year": "1997",

--- a/demonstrations/qsim_beyond_classical.metadata.json
+++ b/demonstrations/qsim_beyond_classical.metadata.json
@@ -24,6 +24,7 @@
     "references": [
         {
             "id": "Arute2019",
+            "type": "article",
             "title": "Quantum supremacy using a programmable superconducting processor",
             "authors": "Arute, F., Arya, K., Babbush, R. et al.",
             "year": "2019",
@@ -33,6 +34,7 @@
         },
         {
             "id": "Arute2019sup",
+            "type": "article",
             "title": "Supplementary information for \"Quantum supremacy using a programmable superconducting processor\"",
             "authors": "Arute, F., Arya, K., Babbush, R. et al.",
             "year": "2019",
@@ -42,6 +44,7 @@
         },
         {
             "id": "Martinis2020",
+            "type": "article",
             "title": "Quantum supremacy using a programmable superconducting processor",
             "authors": "Martinis, John M. et al.",
             "year": "2020",
@@ -51,6 +54,7 @@
         },
         {
             "id": "Boixo2018",
+            "type": "article",
             "title": "Characterizing quantum supremacy in near-term devices.",
             "authors": "Boixo, S., Isakov, S.V., Smelyanskiy, V.N. et al.",
             "year": "2018",
@@ -60,9 +64,10 @@
         },
         {
             "id": "Sohaib2019",
+            "type": "article",
             "title": "Unpacking the Quantum Supremacy Benchmark with Python",
             "authors": "Sohaib, Alam M. and Zeng, W.",
-            "year": "",
+            "year": "2019",
             "url": "https://medium.com/@sohaib.alam/unpacking-the-quantum-supremacy-benchmark-with-python-67a46709d"
         }
     ],

--- a/demonstrations/quantum_volume.metadata.json
+++ b/demonstrations/quantum_volume.metadata.json
@@ -24,14 +24,19 @@
     "references": [
         {
             "id": "top500",
+            "type": "website",
+            "title": "Top500",
             "url": "https://www.top500.org/"
         },
         {
             "id": "linpack",
+            "type": "webpage",
+            "title": "The Linpack Benchmark",
             "url": "https://www.top500.org/project/linpack/"
         },
         {
             "id": "cross",
+            "type": "article",
             "title": "Validating quantum computers using randomized model circuits",
             "authors": "Cross, A. W., Bishop, L. S., Sheldon, S., Nation, P. D., & Gambetta, J. M.",
             "year": "2019",
@@ -40,6 +45,7 @@
         },
         {
             "id": "robin",
+            "type": "article",
             "title": "A volumetric framework for quantum computer benchmarks",
             "authors": "Blume-Kohout, R., & Young, K. C.",
             "year": "2020",
@@ -48,6 +54,7 @@
         },
         {
             "id": "aaronson",
+            "type": "article",
             "title": "Complexity-theoretic foundations of quantum supremacy experiments.",
             "authors": "Aaronson, S., & Chen, L.",
             "doi": "10.48550/arXiv.1612.05903",
@@ -55,12 +62,14 @@
         },
         {
             "id": "cmu",
+            "type": "other",
             "title": "CMU course: Quantum Computation and Quantum Information 2018.",
             "authors": "O'Donnell, R.",
             "url": "https://www.cs.cmu.edu/~odonnell/quantum18/lecture25.pdf"
         },
         {
             "id": "qv64",
+            "type": "article",
             "title": "Demonstration of quantum volume 64 on a superconducting quantum computing system.",
             "authors": "Jurcevic et al.",
             "doi": "10.48550/arXiv.2008.08571",
@@ -68,14 +77,21 @@
         },
         {
             "id": "honeywell",
+            "type": "article",
+            "title": "Achieving Quantum Volume 128 On The Honeywell Quantum Computer",
+            "year": "2020",
             "url": "https://www.honeywell.com/en-us/newsroom/news/2020/09/achieving-quantum-volume-128-on-the-honeywell-quantum-computer"
         },
         {
             "id": "ionq",
+            "type": "article",
+            "title": "IonQ Unveils World's Most Powerful Quantum Computer",
+            "year": "2020",
             "url": "https://www.prnewswire.com/news-releases/ionq-unveils-worlds-most-powerful-quantum-computer-301143782.html"
         },
         {
             "id": "sabre",
+            "type": "article",
             "title": "Tackling the qubit mapping problem for nisq-era quantum devices",
             "authors": "Li, G., Ding, Y., & Xie, Y.",
             "year": "2019",

--- a/demonstrations/spsa.metadata.json
+++ b/demonstrations/spsa.metadata.json
@@ -27,6 +27,7 @@
     "references": [
         {
             "id": "spall_overview",
+            "type": "article",
             "title": "An Overview of the Simultaneous Perturbation Method for Efficient Optimization",
             "authors": "James C. Spall",
             "year": "1998",
@@ -34,6 +35,7 @@
         },
         {
             "id": "spall_implementation",
+            "type": "article",
             "title": "Implementation of the simultaneous perturbation algorithm for stochastic optimization",
             "authors": "J. C. Spall",
             "year": "1998",
@@ -46,6 +48,7 @@
         },
         {
             "id": "spall_hessian",
+            "type": "article",
             "title": "Adaptive stochastic approximation by the simultaneous perturbation method",
             "authors": "J. C. Spall",
             "year": "2020",

--- a/demonstrations/tutorial_adaptive_circuits.metadata.json
+++ b/demonstrations/tutorial_adaptive_circuits.metadata.json
@@ -27,6 +27,7 @@
     "references": [
         {
             "id": "peruzzo2014",
+            "type": "article",
             "title": "A variational eigenvalue solver on a photonic quantum processor",
             "authors": "Alberto Peruzzo, Jarrod McClean, et al.",
             "year": "2014",
@@ -36,6 +37,7 @@
         },
         {
             "id": "yudong2019",
+            "type": "article",
             "title": "Quantum Chemistry in the Age of Quantum Computing",
             "authors": "Yudong Cao, Jonathan Romero, et al.",
             "year": "2019",
@@ -45,6 +47,7 @@
         },
         {
             "id": "romero2017",
+            "type": "article",
             "title": "Strategies for quantum computing molecular energies using the unitary coupled cluster ansatz",
             "authors": "J. Romero, R. Babbush, et al.",
             "doi": "10.48550/arXiv.1701.02691",
@@ -52,14 +55,16 @@
         },
         {
             "id": "givenstutorial",
-            "title": "",
-            "authors": "",
-            "year": "",
+            "type": "article",
+            "title": "Givens rotations for quantum chemistry",
+            "authors": "Juan Miguel Arrazola",
+            "year": "2021",
             "journal": "",
             "url": "https://pennylane.ai/qml/demos/tutorial_givens_rotations.html"
         },
         {
             "id": "grimsley2019",
+            "type": "article",
             "title": "An adaptive variational algorithm for exact molecular simulations on a quantum computer",
             "authors": "Harper R. Grimsley, Sophia E. Economou, Edwin Barnes, Nicholas J. Mayhall",
             "year": "2019",

--- a/demonstrations/tutorial_adjoint_diff.metadata.json
+++ b/demonstrations/tutorial_adjoint_diff.metadata.json
@@ -22,7 +22,8 @@
     "canonicalURL": "/qml/demos/tutorial_adjoint_diff",
     "references": [
         {
-            "id": "",
+            "id": "Jones2020",
+            "type": "article",
             "title": "Efficient calculation of gradients in classical simulations of variational quantum algorithms",
             "authors": "Jones and Gacon",
             "year": "2020",
@@ -31,7 +32,8 @@
             "url": "https://arxiv.org/abs/2009.02823"
         },
         {
-            "id": "",
+            "id": "Luo2019",
+            "type": "article",
             "title": "Yao.jl: Extensible, efficient framework for quantum algorithm design",
             "authors": "Xiu-Zhe Luo, Jin-Guo Liu, Pan Zhang, and Lei Wang",
             "year": "2019",

--- a/demonstrations/tutorial_barren_gadgets.metadata.json
+++ b/demonstrations/tutorial_barren_gadgets.metadata.json
@@ -27,6 +27,7 @@
     "references": [
         {
             "id": "cichy2022",
+            "type": "article",
             "title": "A perturbative gadget for delaying the onset of barren plateaus in variational quantum algorithms.",
             "authors": "Cichy, S., Faehrmann, P.K., Khatri, S., Eisert, J.",
             "year": "2022",
@@ -36,6 +37,7 @@
         },
         {
             "id": "cerezo2021",
+            "type": "article",
             "title": "Cost function dependent barren plateaus in shallow parametrized quantum circuits.",
             "authors": "Cerezo, M., Sone, A., Volkoff, T. et al.",
             "year": "2021",

--- a/demonstrations/tutorial_barren_plateaus.metadata.json
+++ b/demonstrations/tutorial_barren_plateaus.metadata.json
@@ -22,7 +22,8 @@
     "canonicalURL": "/qml/demos/tutorial_barren_plateaus",
     "references": [
         {
-            "id": "",
+            "id": "Dauphin2014",
+            "type": "article",
             "title": "Identifying and attacking the saddle point problem in high-dimensional non-convex optimization",
             "authors": "Dauphin, Yann N., et al.",
             "year": "2014",
@@ -30,7 +31,8 @@
             "url": ""
         },
         {
-            "id": "",
+            "id": "McClean2018",
+            "type": "article",
             "title": "Barren plateaus in quantum neural network training landscapes",
             "authors": "McClean, Jarrod R., et al.",
             "year": "2018",
@@ -38,7 +40,8 @@
             "url": ""
         },
         {
-            "id": "",
+            "id": "Grant2019",
+            "type": "article",
             "title": "An initialization strategy for addressing barren plateaus in parametrized quantum circuits",
             "authors": "Grant, Edward, et al.",
             "year": "2019",

--- a/demonstrations/tutorial_chemical_reactions.metadata.json
+++ b/demonstrations/tutorial_chemical_reactions.metadata.json
@@ -26,6 +26,7 @@
     "references": [
         {
             "id": "motta2020",
+            "type": "article",
             "title": "A Tale of Colliding Electrons: Boosting the Accuracy of Chemical Simulations on Quantum Computers",
             "authors": "Mario Motta, Tanvi Gujarati, and Julia Rice",
             "year": "2020",

--- a/demonstrations/tutorial_classical_kernels.metadata.json
+++ b/demonstrations/tutorial_classical_kernels.metadata.json
@@ -23,25 +23,28 @@
     "references": [
         {
             "id": "QEK",
+            "type": "article",
             "title": "Training Quantum Embedding Kernels on Near-Term Quantum Computers",
             "authors": "Thomas Hubregtsen, David Wierichs, Elies Gil-Fuster, Peter-Jan HS Derks, Paul K Faehrmann, Johannes Jakob Meyer",
-            "year": "",
+            "year": "2021",
             "journal": "arXiv preprint",
             "url": "https://arxiv.org/abs/2105.02276"
         },
         {
             "id": "Fourier",
+            "type": "article",
             "title": "The effect of data encoding on the expressive power of variational quantum machine learning models",
             "authors": "Maria Schuld, Ryan Sweke, Johannes Jakob Meyer",
-            "year": "",
+            "year": "2021",
             "journal": "Phys. Rev. A",
             "url": "https://journals.aps.org/pra/abstract/10.1103/PhysRevA.103.032430"
         },
         {
             "id": "qkernels",
+            "type": "article",
             "title": "Supervised quantum machine learning models are kernel methods",
             "authors": "Maria Schuld",
-            "year": "",
+            "year": "2021",
             "journal": "arXiv preprint",
             "url": "https://arxiv.org/abs/2101.11020"
         }

--- a/demonstrations/tutorial_classical_shadows.metadata.json
+++ b/demonstrations/tutorial_classical_shadows.metadata.json
@@ -26,6 +26,7 @@
     "references": [
         {
             "id": "Mauro2003",
+            "type": "article",
             "title": "Quantum Tomography",
             "authors": "G. Mauro D’Ariano, Matteo G.A. Paris, Massimiliano F. Sacchi",
             "year": "2003",
@@ -34,6 +35,7 @@
         },
         {
             "id": "Huang2020",
+            "type": "article",
             "title": "Predicting many properties of a quantum system from very few measurements",
             "authors": "Huang, Hsin-Yuan, Richard Kueng, and John Preskill",
             "year": "2020",
@@ -42,9 +44,10 @@
         },
         {
             "id": "Gottesman1997",
+            "type": "article",
             "title": "Stabilizer Codes and Quantum Error Correction",
             "authors": "Gottesman, Daniel",
-            "year": "",
+            "year": "1997",
             "journal": "",
             "url": "https://arxiv.org/abs/quant-ph/9705052"
         }

--- a/demonstrations/tutorial_classically_boosted_vqe.metadata.json
+++ b/demonstrations/tutorial_classically_boosted_vqe.metadata.json
@@ -26,6 +26,7 @@
     "references": [
         {
             "id": "Radin2021",
+            "type": "article",
             "title": "Classically-Boosted Variational Quantum Eigensolver",
             "authors": "M. D. Radin",
             "year": "2021",

--- a/demonstrations/tutorial_coherent_vqls.metadata.json
+++ b/demonstrations/tutorial_coherent_vqls.metadata.json
@@ -22,7 +22,8 @@
     "canonicalURL": "/qml/demos/tutorial_coherent_vqls",
     "references": [
         {
-            "id": "",
+            "id": "BravoPrieto2019",
+            "type": "article",
             "title": "Variational Quantum Linear Solver: A Hybrid Algorithm for Linear Systems",
             "authors": "Carlos Bravo-Prieto, Ryan LaRose, Marco Cerezo, Yigit Subasi, Lukasz Cincio, Patrick J. Coles",
             "year": "2019",
@@ -30,7 +31,8 @@
             "url": "https://arxiv.org/abs/1909.05820"
         },
         {
-            "id": "",
+            "id": "Kothari2014",
+            "type": "phdthesis",
             "title": "Efficient algorithms in quantum query complexity",
             "authors": "Robin Kothari",
             "year": "2014",

--- a/demonstrations/tutorial_data_reuploading_classifier.metadata.json
+++ b/demonstrations/tutorial_data_reuploading_classifier.metadata.json
@@ -22,7 +22,8 @@
     "canonicalURL": "/qml/demos/tutorial_data_reuploading_classifier",
     "references": [
         {
-            "id": "",
+            "id": "PerezSalinas2019",
+            "type": "article",
             "title": "Data re-uploading for a universal quantum classifier",
             "authors": "Pérez-Salinas, Adrián, et al.",
             "year": "2019",
@@ -30,7 +31,8 @@
             "url": ""
         },
         {
-            "id": "",
+            "id": "Kingma2014",
+            "type": "article",
             "title": "Adam: A method for stochastic optimization",
             "authors": "Kingma, Diederik P., and Ba, J.",
             "year": "2014",
@@ -38,7 +40,8 @@
             "url": ""
         },
         {
-            "id": "",
+            "id": "Liu1989",
+            "type": "article",
             "title": "On the limited memory BFGS method for large scale optimization.",
             "authors": "Liu, Dong C., and Nocedal, J.",
             "year": "1989",

--- a/demonstrations/tutorial_diffable-mitigation.metadata.json
+++ b/demonstrations/tutorial_diffable-mitigation.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "DiffableTransforms",
+            "type": "article",
             "title": "Quantum computing with differentiable quantum transforms",
             "authors": "Olivia Di Matteo, Josh Izaac, Tom Bromley, Anthony Hayes, Christina Lee, Maria Schuld, Antal Száva, Chase Roberts, Nathan Killoran",
             "year": "2021",
@@ -31,6 +32,7 @@
         },
         {
             "id": "VAQEM",
+            "type": "article",
             "title": "VAQEM: A Variational Approach to Quantum Error Mitigation",
             "authors": "Gokul Subramanian Ravi, Kaitlin N. Smith, Pranav Gokhale, Andrea Mari, Nathan Earnest, Ali Javadi-Abhari, Frederic T. Chong",
             "year": "2021",

--- a/demonstrations/tutorial_diffable_shadows.metadata.json
+++ b/demonstrations/tutorial_diffable_shadows.metadata.json
@@ -24,6 +24,7 @@
     "references": [
         {
             "id": "Huang2020",
+            "type": "article",
             "title": "Predicting Many Properties of a Quantum System from Very Few Measurements",
             "authors": "Hsin-Yuan Huang, Richard Kueng, John Preskill",
             "year": "2020",
@@ -32,6 +33,7 @@
         },
         {
             "id": "Huang2021",
+            "type": "article",
             "title": "Efficient estimation of Pauli observables by derandomization",
             "authors": "Hsin-Yuan Huang, Richard Kueng, John Preskill",
             "year": "2021",
@@ -40,6 +42,7 @@
         },
         {
             "id": "Yen",
+            "type": "article",
             "title": "Deterministic improvements of quantum measurements with grouping of compatible operators, non-local transformations, and covariance estimates",
             "authors": "Tzu-Ching Yen, Aadithya Ganeshram, Artur F. Izmaylov",
             "year": "2022",

--- a/demonstrations/tutorial_differentiable_HF.metadata.json
+++ b/demonstrations/tutorial_differentiable_HF.metadata.json
@@ -23,18 +23,19 @@
     "references": [
         {
             "id": "arrazola2021",
+            "type": "article",
             "title": "Differentiable quantum computational chemistry with PennyLane",
             "authors": "Juan Miguel Arrazola, Soran Jahangiri, Alain Delgado, Jack Ceroni et al.",
-            "year": "",
+            "year": "2021",
             "journal": "",
             "url": "https://arxiv.org/abs/2111.09967"
         },
         {
             "id": "szabo1996",
+            "type": "book",
             "title": "Modern Quantum Chemistry: Introduction to Advanced Electronic Structure Theory",
             "authors": "Attila Szabo, Neil S. Ostlund",
             "year": "1996",
-            "journal": "",
             "publisher": "Dover Publications",
             "url": ""
         }

--- a/demonstrations/tutorial_doubly_stochastic.metadata.json
+++ b/demonstrations/tutorial_doubly_stochastic.metadata.json
@@ -22,7 +22,8 @@
     "canonicalURL": "/qml/demos/tutorial_doubly_stochastic",
     "references": [
         {
-            "id": "",
+            "id": "Sweke2019",
+            "type": "article",
             "title": "Stochastic gradient descent for hybrid quantum-classical optimization",
             "authors": "Ryan Sweke, Frederik Wilde, Johannes Jakob Meyer, Maria Schuld, Paul K. Fährmann, Barthélémy Meynard-Piganeau, Jens Eisert",
             "year": "2019",

--- a/demonstrations/tutorial_equivariant_graph_embedding.metadata.json
+++ b/demonstrations/tutorial_equivariant_graph_embedding.metadata.json
@@ -5,8 +5,8 @@
             "id": "maria_schuld"
         }
     ],
-    "dateOfPublication": "2023-07-13T00:00:00",
-    "dateOfLastModification": "2023-07-13T00:00:00",
+    "dateOfPublication": "2023-07-13T00:00:00+00:00",
+    "dateOfLastModification": "2023-07-13T00:00:00+00:00",
     "categories": [
         "Quantum Machine Learning"
     ],
@@ -26,21 +26,21 @@
     "canonicalURL": "/qml/demos/tutorial_equivariant_graph_embedding",
     "references": [
         {
-            "id": "",
+            "id": "Skolik2022",
+            "type": "article",
             "title": "Equivariant quantum circuits for learning on weighted graphs",
             "authors": "Andrea Skolik, Michele Cattelan, Sheir Yarkoni,Thomas Baeck and Vedran Dunjko",
             "year": "2022",
             "journal": "",
-            "doi": "",
             "url": "https://arxiv.org/abs/2205.06109"
         },
         {
-            "id": "",
+            "id": "Nguyen",
+            "type": "article",
             "title": "Theory for Equivariant Quantum Neural Networks.",
             "authors": "Quynh T. Nguyen, Louis Schatzki, Paolo Braccia, Michael Ragone, Patrick J. Coles, Frédéric Sauvage, Martín Larocca and Marco Cerezo",
             "year": "2022",
             "journal": "",
-            "doi": "",
             "url": "https://arxiv.org/abs/2210.08566"
         }
     ],

--- a/demonstrations/tutorial_error_mitigation.metadata.json
+++ b/demonstrations/tutorial_error_mitigation.metadata.json
@@ -27,6 +27,7 @@
     "references": [
         {
             "id": "proctor2020measuring",
+            "type": "article",
             "title": "Measuring the Capabilities of Quantum Computers",
             "authors": "T. Proctor, K. Rudinger, K. Young, E. Nielsen, R. Blume-Kohout",
             "year": "2020",
@@ -35,6 +36,7 @@
         },
         {
             "id": "temme2017error",
+            "type": "article",
             "title": "Error Mitigation for Short-Depth Quantum Circuits",
             "authors": "K. Temme, S. Bravyi, J. M. Gambetta",
             "year": "2017",
@@ -43,6 +45,7 @@
         },
         {
             "id": "li2017efficient",
+            "type": "article",
             "title": "Efficient Variational Quantum Simulator Incorporating Active Error Minimization",
             "authors": "Y. Li, S. C. Benjamin",
             "year": "2017",
@@ -51,6 +54,7 @@
         },
         {
             "id": "giurgica2020digital",
+            "type": "article",
             "title": "Digital zero noise extrapolation for quantum error mitigation",
             "authors": "T. Giurgica-Tiron, Y. Hindy, R. LaRose, A. Mari, W. J. Zeng",
             "year": "2020",

--- a/demonstrations/tutorial_expressivity_fourier_series.metadata.json
+++ b/demonstrations/tutorial_expressivity_fourier_series.metadata.json
@@ -26,6 +26,7 @@
     "references": [
         {
             "id": "schuld2020",
+            "type": "article",
             "title": "The effect of data encoding on the expressive power of variational quantum machine learning models.",
             "authors": "Maria Schuld, Ryan Sweke, and Johannes Jakob Meyer",
             "year": "2020",

--- a/demonstrations/tutorial_falqon.metadata.json
+++ b/demonstrations/tutorial_falqon.metadata.json
@@ -25,7 +25,8 @@
     "canonicalURL": "/qml/demos/tutorial_falqon",
     "references": [
         {
-            "id": "",
+            "id": "Magann2021",
+            "type": "article",
             "title": "Feedback-based quantum optimization",
             "authors": "Magann, A. B., Rudinger, K. M., Grace, M. D., & Sarovar, M.",
             "year": "2021",

--- a/demonstrations/tutorial_fermionic_operators.metadata.json
+++ b/demonstrations/tutorial_fermionic_operators.metadata.json
@@ -5,8 +5,8 @@
             "id": "soran_jahangiri"
         }
     ],
-    "dateOfPublication": "2023-06-27T00:00:00",
-    "dateOfLastModification": "2023-06-27T00:00:00",
+    "dateOfPublication": "2023-06-27T00:00:00+00:00",
+    "dateOfLastModification": "2023-06-27T00:00:00+00:00",
     "categories": [
         "Quantum Chemistry"
     ],
@@ -31,11 +31,11 @@
     "references": [
         {
             "id": "surjan",
+            "type": "book",
             "title": "Second Quantized Approach to Quantum Chemistry",
             "authors": "Peter R. Surjan",
             "year": "1989",
             "publisher": "Springer-Verlag",
-            "doi": "",
             "url": ""
         }
     ],

--- a/demonstrations/tutorial_gbs.metadata.json
+++ b/demonstrations/tutorial_gbs.metadata.json
@@ -26,6 +26,7 @@
     "references": [
         {
             "id": "Arute2019",
+            "type": "article",
             "title": "Quantum supremacy using a programmable superconducting processor",
             "authors": "Arute, F., Arya, K., Babbush, R., et al.",
             "year": "2019",
@@ -34,6 +35,7 @@
         },
         {
             "id": "Zhong2020",
+            "type": "article",
             "title": "Quantum computational advantage using photons",
             "authors": "Zhong, H.-S., Wang, H., Deng, Y.-H., et al.",
             "year": "2020",
@@ -43,6 +45,7 @@
         },
         {
             "id": "hamilton2017",
+            "type": "article",
             "title": "Gaussian boson sampling",
             "authors": "Craig S. Hamilton, Regina Kruse, Linda Sansoni, Sonja Barkhofen, Christine Silberhorn, and Igor Jex",
             "year": "2017",
@@ -52,6 +55,7 @@
         },
         {
             "id": "aaronson2013",
+            "type": "article",
             "title": "The computational complexity of linear optics",
             "authors": "Scott Aaronson and Alex Arkhipov",
             "year": "2013",
@@ -61,6 +65,7 @@
         },
         {
             "id": "Bourassa2020",
+            "type": "article",
             "title": "Blueprint for a scalable photonic fault-tolerant quantum computer",
             "authors": "Bourassa, J. E., Alexander, R. N., Vasmer, et al.",
             "year": "2020",

--- a/demonstrations/tutorial_general_parshift.metadata.json
+++ b/demonstrations/tutorial_general_parshift.metadata.json
@@ -23,41 +23,46 @@
     "references": [
         {
             "id": "GenPar",
+            "type": "article",
             "title": "General parameter-shift rules for quantum gradients",
             "authors": "David Wierichs, Josh Izaac, Cody Wang, Cedric Yen-Yu Lin",
-            "year": "",
+            "year": "2021",
             "journal": "",
             "url": "https://arxiv.org/abs/2107.12390"
         },
         {
             "id": "CalcPQC",
+            "type": "article",
             "title": "Calculus on parameterized quantum circuits",
             "authors": "Javier Gil Vidal, Dirk Oliver Theis",
-            "year": "",
+            "year": "2018",
             "journal": "",
             "url": "https://arxiv.org/abs/1812.06323"
         },
         {
             "id": "Rotosolve",
+            "type": "article",
             "title": "Structure optimization for parameterized quantum circuits",
             "authors": "Mateusz Ostaszewski, Edward Grant, Marcello Benedetti",
-            "year": "",
+            "year": "2019",
             "journal": "",
             "url": "https://arxiv.org/abs/1905.09692"
         },
         {
             "id": "AlgeShift",
+            "type": "article",
             "title": "Analytic gradients in variational quantum algorithms: Algebraic extensions of the parameter-shift rule to general unitary transformations",
             "authors": "Artur F. Izmaylov, Robert A. Lang, Tzu-Ching Yen",
-            "year": "",
+            "year": "2021",
             "journal": "",
             "url": "https://arxiv.org/abs/2107.08131"
         },
         {
             "id": "GenDiffRules",
+            "type": "article",
             "title": "Generalized quantum circuit differentiation rules",
             "authors": "Oleksandr Kyriienko, Vincent E. Elfving",
-            "year": "",
+            "year": "2021",
             "journal": "",
             "url": "https://arxiv.org/abs/2108.01218"
         }

--- a/demonstrations/tutorial_geometric_qml.metadata.json
+++ b/demonstrations/tutorial_geometric_qml.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "Bronstein2021",
+            "type": "article",
             "title": "Geometric Deep Learning: Grids, Groups, Graphs, Geodesics, and Gauges",
             "authors": "Michael M. Bronstein, Joan Bruna, Taco Cohen, Petar Veličković",
             "year": "2021",
@@ -31,6 +32,7 @@
         },
         {
             "id": "Nguyen2022",
+            "type": "article",
             "title": "Theory for Equivariant Quantum Neural Networks",
             "authors": "Quynh T. Nguyen, Louis Schatzki, Paolo Braccia, Michael Ragone, Patrick J. Coles, Frédéric Sauvage, Martín Larocca, and M. Cerezo",
             "year": "2022",
@@ -39,6 +41,7 @@
         },
         {
             "id": "Meyer2022",
+            "type": "article",
             "title": "Exploiting symmetry in variational quantum machine learning",
             "authors": "Johannes Jakob Meyer, Marian Mularski, Elies Gil-Fuster, Antonio Anna Mele, Francesco Arzani, Alissa Wilms, Jens Eisert",
             "year": "2022",

--- a/demonstrations/tutorial_givens_rotations.metadata.json
+++ b/demonstrations/tutorial_givens_rotations.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "anselmetti",
+            "type": "article",
             "title": "Local, Expressive, Quantum-Number-Preserving VQE Ansatze for Fermionic Systems",
             "authors": "G-L. R. Anselmetti, D. Wierichs, C. Gogolin, Christian, and R. M. Parrish",
             "year": "2021",
@@ -31,6 +32,7 @@
         },
         {
             "id": "barkoutsos",
+            "type": "article",
             "title": "Quantum algorithms for electronic structure calculations: Particle-hole Hamiltonian and optimized wave-function expansions",
             "authors": "P. KL. Barkoutsos, Panagiotis, et al.",
             "year": "2018",
@@ -39,6 +41,7 @@
         },
         {
             "id": "arrazola",
+            "type": "article",
             "title": "Universal quantum circuits for quantum chemistry",
             "authors": "J. M. Arrazola, O. Di Matteo, N. Quesada, S. Jahangiri, A. Delgado, N. Killoran",
             "year": "2021",

--- a/demonstrations/tutorial_grovers_algorithm.metadata.json
+++ b/demonstrations/tutorial_grovers_algorithm.metadata.json
@@ -5,8 +5,8 @@
             "id": "ludmila_botelho"
         }
     ],
-    "dateOfPublication": "2023-07-03T00:00:00",
-    "dateOfLastModification": "2023-07-03T00:00:00",
+    "dateOfPublication": "2023-07-03T00:00:00+00:00",
+    "dateOfLastModification": "2023-07-03T00:00:00+00:00",
     "categories": [
         "Getting Started", 
         "Algorithms", 

--- a/demonstrations/tutorial_haar_measure.metadata.json
+++ b/demonstrations/tutorial_haar_measure.metadata.json
@@ -24,6 +24,7 @@
     "references": [
         {
             "id": "NandC2000",
+            "type": "book",
             "title": "Quantum Computation and Quantum Information",
             "authors": "M. A. Nielsen, and I. L. Chuang",
             "year": "2000",
@@ -33,6 +34,7 @@
         },
         {
             "id": "deGuise2018",
+            "type": "article",
             "title": "Simple factorization of unitary transformations",
             "authors": "H. de Guise, O. Di Matteo, and L. L. Sánchez-Soto",
             "year": "2018",
@@ -41,6 +43,7 @@
         },
         {
             "id": "Clements2016",
+            "type": "article",
             "title": "Optimal design for universal multiport interferometers",
             "authors": "W. R. Clements, P. C. Humphreys, B. J. Metcalf, W. S. Kolthammer, and I. A. Walmsley",
             "year": "2016",
@@ -49,6 +52,7 @@
         },
         {
             "id": "Reck1994",
+            "type": "article",
             "title": "Experimental realization of any discrete unitary operator",
             "authors": "M. Reck, A. Zeilinger, H. J. Bernstein, and P. Bertani",
             "year": "1994",
@@ -57,6 +61,7 @@
         },
         {
             "id": "Mezzadri2006",
+            "type": "article",
             "title": "How to generate random matrices from the classical compact groups",
             "authors": "F. Mezzadri",
             "year": "2006",
@@ -65,6 +70,7 @@
         },
         {
             "id": "Meckes2014",
+            "type": "book",
             "title": "The Random Matrix Theory of the Classical Compact Groups",
             "authors": "E. Meckes",
             "year": "2019",
@@ -73,6 +79,7 @@
         },
         {
             "id": "Gerken2013",
+            "type": "article",
             "title": "Measure concentration: Levy's Lemma",
             "authors": "M. Gerken",
             "year": "2013",
@@ -80,6 +87,7 @@
         },
         {
             "id": "Hayden2006",
+            "type": "article",
             "title": "Aspects of generic entanglement",
             "authors": "P. Hayden, D. W. Leung, and A. Winter",
             "year": "2006",
@@ -91,6 +99,7 @@
         },
         {
             "id": "McClean2018",
+            "type": "article",
             "title": "Barren plateaus in quantum neural network training landscapes",
             "authors": "J. R. McClean, S. Boixo, V. N. Smelyanskiy, R. Babbush, and H. Neven",
             "year": "2018",
@@ -100,6 +109,7 @@
         },
         {
             "id": "Holmes2021",
+            "type": "article",
             "title": "Connecting ansatz expressibility to gradient magnitudes and barren plateaus",
             "authors": "Z. Holmes, K. Sharma, M. Cerezo, and P. J. Coles",
             "year": "2021",

--- a/demonstrations/tutorial_here_comes_the_sun.metadata.json
+++ b/demonstrations/tutorial_here_comes_the_sun.metadata.json
@@ -27,6 +27,7 @@
     "references": [
         {
             "id": "vatan",
+            "type": "article",
             "title": "Optimal Quantum Circuits for General Two-Qubit Gates",
             "authors": "Farrokh Vatan and Colin Williams",
             "year": "2003",
@@ -36,6 +37,7 @@
         },
         {
             "id": "wiersema",
+            "type": "article",
             "title": "Here comes the SU(N): multivariate quantum gates and gradients",
             "authors": "R. Wiersema, D. Lewis, D. Wierichs, J. F. Carrasquilla, and N. Killoran",
             "year": "2023",
@@ -45,6 +47,7 @@
         },
         {
             "id": "banchi",
+            "type": "article",
             "title": "Measuring Analytic Gradients of General Quantum Evolution with the Stochastic Parameter Shift Rule.",
             "authors": "Leonardo Banchi and Gavin E. Crooks",
             "year": "2021",

--- a/demonstrations/tutorial_implicit_diff_susceptibility.metadata.json
+++ b/demonstrations/tutorial_implicit_diff_susceptibility.metadata.json
@@ -26,6 +26,7 @@
     "references": [
         {
             "id": "Paradis2004",
+            "type": "article",
             "title": "Fermat and the Quadrature of the Folium of Descartes",
             "authors": "Jaume Paradís, Josep Pla & Pelegrí Viader",
             "year": "2004",
@@ -35,6 +36,7 @@
         },
         {
             "id": "Ahmed2022",
+            "type": "article",
             "title": "Implicit differentiation of variational quantum algorithms",
             "authors": "Shahnawaz Ahmed, Nathan Killoran, Juan Felipe Carrasquilla Álvarez",
             "year": "2022",
@@ -43,6 +45,7 @@
         },
         {
             "id": "Blondel2021",
+            "type": "article",
             "title": "Efficient and modular implicit differentiation",
             "authors": "Mathieu Blondel, Quentin Berthet, Marco Cuturi, Roy Frostig, Stephan Hoyer, Felipe Llinares-López, Fabian Pedregosa, Jean-Philippe Vert ",
             "year": "2021",
@@ -51,6 +54,7 @@
         },
         {
             "id": "implicitlayers",
+            "type": "webpage",
             "title": "Deep Implicit Layers - Neural ODEs, Deep Equilibirum Models, and Beyond",
             "authors": "Zico Kolter, David Duvenaud, Matt Johnson",
             "year": "2021",
@@ -59,6 +63,7 @@
         },
         {
             "id": "Matteo2021",
+            "type": "article",
             "title": "Quantum computing fidelity susceptibility using automatic differentiation",
             "authors": "Olivia Di Matteo, R. M. Woloshyn",
             "year": "2022",
@@ -67,6 +72,7 @@
         },
         {
             "id": "Chang2003",
+            "type": "article",
             "title": "The analytic domain in the implicit function theorem.",
             "authors": "Chang, Hung-Chieh, Wei He, and Nagabhushana Prabhu",
             "year": "2003",

--- a/demonstrations/tutorial_intro_qsvt.metadata.json
+++ b/demonstrations/tutorial_intro_qsvt.metadata.json
@@ -28,6 +28,7 @@
     "references": [
         {
             "id": "qsvt",
+            "type": "article",
             "title": "Quantum singular value transformation and beyond: exponential improvements for quantum matrix arithmetics",
             "authors": "András Gilyén, Yuan Su, Guang Hao Low, Nathan Wiebe",
             "year": "2019",
@@ -37,6 +38,7 @@
         },
         {
             "id": "lintong",
+            "type": "article",
             "title": "Near-optimal ground state preparation",
             "authors": "Lin, Lin, and Yu Tong",
             "year": "2020",
@@ -46,6 +48,7 @@
         },
         {
             "id": "unification",
+            "type": "article",
             "title": "Grand Unification of Quantum Algorithms",
             "authors": "John M. Martyn, Zane M. Rossi, Andrew K. Tan, and Isaac L. Chuang",
             "year": "2021",

--- a/demonstrations/tutorial_isingmodel_PyTorch.metadata.json
+++ b/demonstrations/tutorial_isingmodel_PyTorch.metadata.json
@@ -22,7 +22,8 @@
     "canonicalURL": "/qml/demos/tutorial_isingmodel_PyTorch",
     "references": [
         {
-            "id": "",
+            "id": "Schuld2018",
+            "type": "article",
             "title": "Supervised Learning with Quantum Computers.",
             "authors": "Maria Schuld and Francesco Petruccione",
             "year": "2018",
@@ -31,7 +32,8 @@
             "url": ""
         },
         {
-            "id": "",
+            "id": "Lucas2014",
+            "type": "article",
             "title": "Ising formulations of many NP problems.",
             "authors": "Andrew Lucas",
             "year": "2014",
@@ -39,7 +41,8 @@
             "url": "https://arxiv.org/pdf/1302.5843"
         },
         {
-            "id": "",
+            "id": "Kochenberger2014",
+            "type": "article",
             "title": "The Unconstrained Binary Quadratic Programming Problem: A Survey.",
             "authors": "Gary Kochenberger et al.",
             "year": "2014",

--- a/demonstrations/tutorial_kernels_module.metadata.json
+++ b/demonstrations/tutorial_kernels_module.metadata.json
@@ -38,6 +38,7 @@
     "references": [
         {
             "id": "Training_QEKs",
+            "type": "article",
             "title": "Training Quantum Embedding Kernels on Near-Term Quantum Computers.",
             "authors": "Thomas Hubregtsen, David Wierichs, Elies Gil-Fuster, Peter-Jan H. S. Derks, Paul K. Faehrmann, and Johannes Jakob Meyer",
             "year": "2021",
@@ -46,6 +47,7 @@
         },
         {
             "id": "Alignment",
+            "type": "article",
             "title": "An overview of kernel alignment and its applications.",
             "authors": "Wang, Tinghua, Dongyan Zhao, and Shengfeng Tian",
             "year": "2015",

--- a/demonstrations/tutorial_learning_few_data.metadata.json
+++ b/demonstrations/tutorial_learning_few_data.metadata.json
@@ -29,6 +29,7 @@
     "references": [
         {
             "id": "CaroGeneralization",
+            "type": "article",
             "title": "Generalization in quantum machine learning from few training data",
             "authors": "Matthias C. Caro, Hsin-Yuan Huang, M. Cerezo, Kunal Sharma, Andrew Sornborger, Lukasz Cincio, Patrick J. Coles",
             "year": "2021",
@@ -37,6 +38,7 @@
         },
         {
             "id": "DLBook",
+            "type": "book",
             "title": "Deep Learning",
             "authors": "Ian Goodfellow, Yoshua Bengio and Aaron Courville",
             "year": "2016",
@@ -45,6 +47,7 @@
         },
         {
             "id": "NamkoongVariance",
+            "type": "article",
             "title": "Variance-based regularization with convex objectives.",
             "authors": "Hongseok Namkoong and John C. Duchi",
             "year": "2017",
@@ -53,6 +56,7 @@
         },
         {
             "id": "CongQuantumCNN",
+            "type": "article",
             "title": "Quantum Convolutional Neural Networks",
             "authors": "Iris Cong, Soonwon Choi, Mikhail D. Lukin",
             "year": "2018",
@@ -61,6 +65,7 @@
         },
         {
             "id": "LeNailNNSVG",
+            "type": "article",
             "title": "NN-SVG: Publication-Ready Neural Network Architecture Schematics",
             "authors": "Alexander LeNail",
             "year": "2019",

--- a/demonstrations/tutorial_learning_from_experiments.metadata.json
+++ b/demonstrations/tutorial_learning_from_experiments.metadata.json
@@ -22,7 +22,8 @@
     "canonicalURL": "/qml/demos/tutorial_learning_from_experiments",
     "references": [
         {
-            "id": "",
+            "id": "Huang2021",
+            "type": "article",
             "title": "Quantum advantage in learning from experiments",
             "authors": "Hsin-Yuan Huang et al.",
             "year": "2021",
@@ -31,7 +32,8 @@
             "url": "https://arxiv.org/pdf/2112.00778.pdf"
         },
         {
-            "id": "",
+            "id": "Chen2021",
+            "type": "article",
             "title": "Exponential separations between learning with and without quantum memory",
             "authors": "Sitan Chen, Jordan Cotler, Hsin-Yuan Huang, Jerry Li",
             "year": "2021",

--- a/demonstrations/tutorial_local_cost_functions.metadata.json
+++ b/demonstrations/tutorial_local_cost_functions.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "Cerezo2020",
+            "type": "article",
             "title": "Cost-Function-Dependent Barren Plateaus in Shallow Quantum Neural Networks",
             "authors": "Cerezo, M., Sone, A., Volkoff, T., Cincio, L., and Coles, P.",
             "year": "2020",

--- a/demonstrations/tutorial_mbqc.metadata.json
+++ b/demonstrations/tutorial_mbqc.metadata.json
@@ -27,6 +27,7 @@
     "references": [
         {
             "id": "OneWay2001",
+            "type": "article",
             "title": "A One-Way Quantum Computer",
             "authors": "Robert Raussendorf and Hans J. Briegel",
             "year": "2001",
@@ -35,6 +36,7 @@
         },
         {
             "id": "MBQCRealization",
+            "type": "article",
             "title": "Realizations of Measurement Based Quantum Computing",
             "authors": "Swapnil Nitin Shah",
             "year": "2021",
@@ -43,6 +45,7 @@
         },
         {
             "id": "XanaduBlueprint",
+            "type": "article",
             "title": "Blueprint for a Scalable Photonic Fault-Tolerant Quantum Computer",
             "authors": "J. Eli Bourassa, Rafael N. Alexander, Michael Vasmer, Ashlesha Patil, Ilan Tzitrin, Takaya Matsuura, Daiqin Su, Ben Q. Baragiola, Saikat Guha, Guillaume Dauphinais, Krishna K. Sabapathy, Nicolas C. Menicucci, and Ish Dhand",
             "year": "2021",
@@ -51,6 +54,7 @@
         },
         {
             "id": "XanaduPassiveArchitecture",
+            "type": "article",
             "title": "Fault-Tolerant Quantum Computation with Static Linear Optics",
             "authors": "Ilan Tzitrin, Takaya Matsuura, Rafael N. Alexander, Guillaume Dauphinais, J. Eli Bourassa, Krishna K. Sabapathy, Nicolas C. Menicucci, and Ish Dhand",
             "year": "2021",
@@ -62,6 +66,7 @@
         },
         {
             "id": "ShorQEC1995",
+            "type": "article",
             "title": "Scheme for reducing decoherence in quantum computer memory",
             "authors": "Peter W. Shor",
             "year": "1995",
@@ -72,6 +77,7 @@
         },
         {
             "id": "LatticeSurgeryRaussendorf2018",
+            "type": "article",
             "title": "Lattice Surgery on the Raussendorf Lattice",
             "authors": "Daniel Herr, Alexandru Paler, Simon J. Devitt and Franco Nori",
             "year": "2018",
@@ -80,6 +86,7 @@
         },
         {
             "id": "FowlerSurfaceCode",
+            "type": "article",
             "title": "Surface codes: Towards practical large-scale quantum computation",
             "authors": "Austin G. Fowler, Matteo Mariantoni, John M. Martinis, Andrew N. Cleland",
             "year": "2012",
@@ -88,6 +95,7 @@
         },
         {
             "id": "GoogleQEC2022",
+            "type": "article",
             "title": "Suppressing quantum errors by scaling a surface code logical qubit",
             "authors": "Google Quantum AI",
             "year": "2022",
@@ -96,6 +104,7 @@
         },
         {
             "id": "CV-MBQC",
+            "type": "article",
             "title": "Universal Quantum Computation with Continuous-Variable Cluster States",
             "authors": "Nicolas C. Menicucci, Peter van Loock, Mile Gu, Christian Weedbrook, Timothy C. Ralph, and Michael A. Nielsen",
             "year": "2006",
@@ -104,6 +113,7 @@
         },
         {
             "id": "DiVincenzo",
+            "type": "article",
             "title": "The Physical Implementation of Quantum Computation",
             "authors": "David P. DiVincenzo",
             "year": "2000",
@@ -112,6 +122,7 @@
         },
         {
             "id": "Furusawa1998",
+            "type": "article",
             "title": "Unconditional Quantum Teleportation",
             "authors": "A. Furusawa, J. L. Sørensen, S. L. Braunstein, C. A. Fuchs,H. J. Kimble, E. S. Polzik",
             "year": "1998",
@@ -122,6 +133,7 @@
         },
         {
             "id": "Nielsen1998",
+            "type": "article",
             "title": "Complete quantum teleportation using nuclear magnetic resonance",
             "authors": "M. A. Nielsen, E. Knill & R. Laflamme",
             "year": "1998",
@@ -131,6 +143,7 @@
         },
         {
             "id": "Hermans2022",
+            "type": "article",
             "title": "Qubit teleportation between non-neighbouring nodes in a quantum network",
             "authors": "S. L. N. Hermans, M. Pompili, H. K. C. Beukers, S. Baier, J. Borregaard & R. Hanson",
             "year": "2022",
@@ -139,6 +152,7 @@
         },
         {
             "id": "Riebe2004",
+            "type": "article",
             "title": "Deterministic quantum teleportation with atoms",
             "authors": "M. Riebe, H. Häffner, C. F. Roos, W. Hänsel, J. Benhelm, G. P. T. Lancaster, T. W. Körber, C. Becher, F. Schmidt-Kaler, D. F. V. James & R. Blatt",
             "year": "2002",
@@ -147,6 +161,7 @@
         },
         {
             "id": "FoliatedQuantumCodes",
+            "type": "article",
             "title": "Foliated Quantum Codes",
             "authors": "A. Bolt, G. Duclos-Cianci, D. Poulin, T. M. Stace",
             "year": "2016",
@@ -155,6 +170,7 @@
         },
         {
             "id": "MagicStates",
+            "type": "article",
             "title": "Universal quantum computation with ideal Clifford gates and noisy ancillas",
             "authors": "Sergey Bravyi and Alexei Kitaev",
             "year": "2004",
@@ -163,6 +179,7 @@
         },
         {
             "id": "QuantumTeleportation",
+            "type": "article",
             "title": "Multi-party entanglement in graph states",
             "authors": "M. Hein, J. Eisert and H.J. Briegel",
             "year": "2003",
@@ -171,6 +188,7 @@
         },
         {
             "id": "OpticalQuantumComputing",
+            "type": "article",
             "title": "Optical quantum computing",
             "authors": "Jeremy L. O'Brien",
             "year": "2007",
@@ -181,6 +199,7 @@
         },
         {
             "id": "FowlerPolyestimate",
+            "type": "article",
             "title": "Polyestimate: instantaneous open source surface code analysis",
             "authors": "Austin G. Fowler",
             "year": "2013",
@@ -189,6 +208,7 @@
         },
         {
             "id": "EntanglementGraphStates",
+            "type": "article",
             "title": "Entanglement in Graph States and its Applications",
             "authors": "M. Hein, W. Dür, J. Eisert, R. Raussendorf, M. Van den Nest, H.J. Briegel",
             "year": "2006",
@@ -197,6 +217,7 @@
         },
         {
             "id": "PersistentEntanglement",
+            "type": "article",
             "title": "Persistent Entanglement in Arrays of Interacting Particles",
             "authors": "Hans J. Briegel and Robert Raussendorf",
             "year": "2001",
@@ -205,6 +226,7 @@
         },
         {
             "id": "UniversalFTMBQC",
+            "type": "article",
             "title": "Universal fault-tolerant measurement-based quantum computation",
             "authors": "Benjamin J. Brown, Sam Roberts",
             "year": "2018",

--- a/demonstrations/tutorial_measurement_optimize.metadata.json
+++ b/demonstrations/tutorial_measurement_optimize.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "peruzzo2014",
+            "type": "article",
             "title": "A variational eigenvalue solver on a photonic quantum processor",
             "authors": "Alberto Peruzzo, Jarrod McClean, et al.",
             "year": "2014",
@@ -31,6 +32,7 @@
         },
         {
             "id": "yen2020",
+            "type": "article",
             "title": "Measuring all compatible operators in one series of single-qubit measurements using unitary transformations.",
             "authors": "Tzu-Ching Yen, Vladyslav Verteletskyi, and Artur F. Izmaylov",
             "year": "2020",
@@ -39,6 +41,7 @@
         },
         {
             "id": "izmaylov2019",
+            "type": "article",
             "title": "Unitary partitioning approach to the measurement problem in the variational quantum eigensolver method.",
             "authors": "Artur F. Izmaylov et al.",
             "year": "2019",
@@ -47,6 +50,7 @@
         },
         {
             "id": "huggins2019",
+            "type": "article",
             "title": "Efficient and noise resilient measurements for quantum chemistry on near-term quantum computers.",
             "authors": "William J. Huggins et al.",
             "year": "2019",
@@ -55,6 +59,7 @@
         },
         {
             "id": "gokhale2020",
+            "type": "article",
             "title": "Minimizing state preparations in variational quantum eigensolver by partitioning into commuting families.",
             "authors": "Pranav Gokhale et al.",
             "year": "2019",
@@ -63,6 +68,7 @@
         },
         {
             "id": "verteletskyi2020",
+            "type": "article",
             "title": "Measurement optimization in the variational quantum eigensolver using a minimum clique cover.",
             "authors": "Vladyslav Verteletskyi, Tzu-Ching Yen, and Artur F. Izmaylov",
             "year": "2020",

--- a/demonstrations/tutorial_mitigation_advantage.metadata.json
+++ b/demonstrations/tutorial_mitigation_advantage.metadata.json
@@ -28,6 +28,7 @@
     "references": [
         {
             "id": "ibm",
+            "type": "article",
             "title": "Evidence for the utility of quantum computing before fault tolerance",
             "authors": "Youngseok Kim, Andrew Eddins, Sajant Anand, Ken Xuan Wei, Ewout van den Berg, Sami Rosenblatt, Hasan Nayfeh, Yantao Wu, Michael Zaletel, Kristan Temme & Abhinav Kandala",
             "year": "2023",
@@ -37,6 +38,7 @@
         },
         {
             "id": "PEC",
+            "type": "article",
             "title": "Probabilistic error cancellation with sparse Pauli-Lindblad models on noisy quantum processors",
             "authors": "Ewout van den Berg, Zlatko K. Minev, Abhinav Kandala, Kristan Temme",
             "year": "2022",

--- a/demonstrations/tutorial_ml_classical_shadows.metadata.json
+++ b/demonstrations/tutorial_ml_classical_shadows.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "preskill",
+            "type": "article",
             "title": "Provably efficient machine learning for quantum many-body problems",
             "authors": "H. Y. Huang, R. Kueng, G. Torlai, V. V. Albert, J. Preskill",
             "year": "2021",
@@ -31,6 +32,7 @@
         },
         {
             "id": "neurtangkernel",
+            "type": "article",
             "title": "Neural tangent kernel: Convergence and generalization in neural networks",
             "authors": "A. Jacot, F. Gabriel, and C. Hongler",
             "year": "2018",

--- a/demonstrations/tutorial_mol_geo_opt.metadata.json
+++ b/demonstrations/tutorial_mol_geo_opt.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "jensenbook",
+            "type": "book",
             "title": "Introduction to computational chemistry",
             "authors": "F. Jensen",
             "year": "2016",
@@ -31,6 +32,7 @@
         },
         {
             "id": "seeley2012",
+            "type": "article",
             "title": "The Bravyi-Kitaev transformation for quantum computation of electronic structure",
             "authors": "Jacob T. Seeley, Martin J. Richard, Peter J. Love",
             "year": "2012",
@@ -39,6 +41,7 @@
         },
         {
             "id": "kohanoff2006",
+            "type": "book",
             "title": "Electronic structure calculations for solids and molecules: theory and computational methods",
             "authors": "Jorge Kohanoff",
             "year": "2006",
@@ -47,6 +50,7 @@
         },
         {
             "id": "qchemcircuits",
+            "type": "article",
             "title": "Universal quantum circuits for quantum chemistry",
             "authors": "J.M. Arrazola, O. Di Matteo, N. Quesada, S. Jahangiri, A. Delgado, N. Killoran",
             "year": "2021",
@@ -55,6 +59,7 @@
         },
         {
             "id": "ref_gamess",
+            "type": "article",
             "title": "General atomic and molecular electronic structure system",
             "authors": "M.W. Schmidt, K.K. Baldridge, J.A. Boatz, S.T. Elbert, M.S. Gordon, J.H. Jensen, S. Koseki, N. Matsunaga, K.A. Nguyen, S.Su, et al.",
             "year": "1993",
@@ -63,6 +68,7 @@
         },
         {
             "id": "geo_opt_paper",
+            "type": "article",
             "title": "Variational quantum algorithm for molecular geometry optimization",
             "authors": "A. Delgado, J.M. Arrazola, S. Jahangiri, Z. Niu, J. Izaac, C. Roberts, N. Killoran",
             "year": "2021",
@@ -71,6 +77,7 @@
         },
         {
             "id": "pulay",
+            "type": "article",
             "title": "Analytical derivative methods in quantum chemistry",
             "authors": "P. Pulay",
             "year": "1987",

--- a/demonstrations/tutorial_multiclass_classification.metadata.json
+++ b/demonstrations/tutorial_multiclass_classification.metadata.json
@@ -7,7 +7,7 @@
     ],
     "dateOfPublication": "2020-04-09T00:00:00+00:00",
     "dateOfLastModification": "2021-01-28T00:00:00+00:00",
-    "categories": [],
+    "categories": ["Algorithms"],
     "tags": [],
     "previewImages": [
         {

--- a/demonstrations/tutorial_neutral_atoms.metadata.json
+++ b/demonstrations/tutorial_neutral_atoms.metadata.json
@@ -28,6 +28,7 @@
     "references": [
         {
             "id": "Aquila2022",
+            "type": "webpage",
             "title": "Aquila, our 256-qubit quantum processor.",
             "authors": "Quera",
             "year": "2023",
@@ -36,6 +37,7 @@
         },
         {
             "id": "DiVincenzo2000",
+            "type": "article",
             "title": "The Physical Implementation of Quantum Computation.",
             "authors": "DiVincenzo",
             "year": "2000",
@@ -44,6 +46,7 @@
         },
         {
             "id": "Tweezers1985",
+            "type": "article",
             "title": "Observation of a single-beam gradient force optical trap for dielectric particles.",
             "authors": "A. Ashkin, J. M. Dziedzic, J. E. Bjorkholm, and Steven Chu.",
             "year": "1986",
@@ -52,6 +55,7 @@
         },
         {
             "id": "AtomComputing",
+            "type": "webpage",
             "title": "Quantum Computing Technology.",
             "authors": "Atom Computing",
             "year": "2023",
@@ -60,6 +64,7 @@
         },
         {
             "id": "Neutral2020",
+            "type": "article",
             "title": "Quantum computing with neutral atoms.",
             "authors": "L. Henriet, et al.",
             "year": "2020",
@@ -68,6 +73,7 @@
         },
         {
             "id": "Pulser2022",
+            "type": "article",
             "title": "Pulser: An open-source package for the design of pulse sequences in programmable neutral-atom arrays.",
             "authors": "H. Silverio et al.",
             "year": "2022",
@@ -76,6 +82,7 @@
         },
         {
             "id": "Morgado2011",
+            "type": "article",
             "title": "Quantum simulation and computing with Rydberg-interacting qubits",
             "authors": "M. Morgado and S. Whitlock.",
             "year": "2021",
@@ -84,6 +91,7 @@
         },
         {
             "id": "NeutralHardware2023",
+            "type": "article",
             "title": "Neutral Atom Quantum Computing Hardware: Performance and End-User Perspective.",
             "authors": "K. Wintersperger et al.",
             "year": "2023",

--- a/demonstrations/tutorial_noisy_circuit_optimization.metadata.json
+++ b/demonstrations/tutorial_noisy_circuit_optimization.metadata.json
@@ -23,14 +23,16 @@
     "references": [
         {
             "id": "arute2019",
+            "type": "article",
             "title": "Quantum supremacy using a programmable superconducting processor.",
             "authors": "Frank Arute et al.",
-            "year": "",
+            "year": "2019",
             "journal": "Nature",
             "url": ""
         },
         {
             "id": "meyer2020",
+            "type": "article",
             "title": "A variational toolbox for quantum multi-parameter estimation.",
             "authors": "Johannes Jakob Meyer, Johannes Borregaard, and Jens Eisert",
             "year": "2020",

--- a/demonstrations/tutorial_noisy_circuits.metadata.json
+++ b/demonstrations/tutorial_noisy_circuits.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "johannes",
+            "type": "article",
             "title": "A variational toolbox for quantum multi-parameter estimation.",
             "authors": "Johannes Jakob Meyer, Johannes Borregaard, and Jens Eisert",
             "year": "2020",

--- a/demonstrations/tutorial_pasqal.metadata.json
+++ b/demonstrations/tutorial_pasqal.metadata.json
@@ -24,6 +24,7 @@
     "references": [
         {
             "id": "barredo2017",
+            "type": "article",
             "title": "Synthetic three-dimensional atomic structures assembled atom by atom.",
             "authors": "Daniel Barredo, Vincent Lienhard, Sylvain de Leseleuc, Thierry Lahaye, and Antoine Browaeys",
             "year": "2017",

--- a/demonstrations/tutorial_photonics.metadata.json
+++ b/demonstrations/tutorial_photonics.metadata.json
@@ -24,6 +24,7 @@
     "references": [
         {
             "id": "DiVincenzo2000",
+            "type": "article",
             "title": "The Physical Implementation of Quantum Computation",
             "authors": "D. DiVincenzo",
             "year": "2000",
@@ -32,6 +33,7 @@
         },
         {
             "id": "Weedbrook2012",
+            "type": "article",
             "title": "Gaussian Quantum Information",
             "authors": "C. Weedbrook, et al.",
             "year": "2012",
@@ -40,6 +42,7 @@
         },
         {
             "id": "Sabouri2021",
+            "type": "article",
             "title": "Thermo Optical Phase Shifter With Low Thermal Crosstalk for SOI Strip Waveguide",
             "authors": "S. Sabouri, et al.",
             "year": "2021",
@@ -50,6 +53,7 @@
         },
         {
             "id": "Paris1996",
+            "type": "article",
             "title": "Displacement operator by beam splitter",
             "authors": "M. Paris",
             "year": "1996",
@@ -58,6 +62,7 @@
         },
         {
             "id": "Braunstein2005",
+            "type": "article",
             "title": "Quantum information with continuous variables",
             "authors": "S. Braunstein, P. van Loock",
             "year": "2005",
@@ -66,6 +71,7 @@
         },
         {
             "id": "Hamilton2017",
+            "type": "article",
             "title": "Gaussian Boson Sampling",
             "authors": "C. Hamilton, et al.",
             "year": "2017",
@@ -74,6 +80,7 @@
         },
         {
             "id": "Zhong2020",
+            "type": "article",
             "title": "Quantum computational advantage using photons",
             "authors": "H.S. Zhong, et al.",
             "year": "2020",
@@ -82,6 +89,7 @@
         },
         {
             "id": "Madsen2020",
+            "type": "article",
             "title": "Quantum computational advantage with a programmable photonic processor",
             "authors": "L. Madsen, et al.",
             "year": "2022",
@@ -90,6 +98,7 @@
         },
         {
             "id": "Tzitrin2020",
+            "type": "article",
             "title": "Progress towards practical qubit computation using approximate Gottesman-Kitaev-Preskill codes",
             "authors": "I. Tzitrin, et al.",
             "year": "2020",
@@ -98,6 +107,7 @@
         },
         {
             "id": "Bourassa2021",
+            "type": "article",
             "title": "Blueprint for a Scalable Photonic Fault-Tolerant Quantum Computer",
             "authors": "E. Bourassa, et al.",
             "year": "2021",

--- a/demonstrations/tutorial_pulse_programming101.metadata.json
+++ b/demonstrations/tutorial_pulse_programming101.metadata.json
@@ -28,6 +28,7 @@
     "references": [
         {
             "id": "Mitei",
+            "type": "article",
             "title": "Gate-free state preparation for fast variational quantum eigensolver simulations: ctrl-VQE",
             "authors": "Oinam Romesh Meitei, Bryan T. Gard, George S. Barron, David P. Pappas, Sophia E. Economou, Edwin Barnes, Nicholas J. Mayhall",
             "year": "2020",
@@ -36,6 +37,7 @@
         },
         {
             "id": "Sheldon2016",
+            "type": "article",
             "title": "Procedure for systematically tuning up crosstalk in the cross resonance gate",
             "authors": "Sarah Sheldon, Easwar Magesan, Jerry M. Chow, Jay M. Gambetta",
             "year": "2016",
@@ -44,6 +46,7 @@
         },
         {
             "id": "Leng2022",
+            "type": "article",
             "title": "Differentiable Analog Quantum Computing for Optimization and Control",
             "authors": "Jiaqi Leng, Yuxiang Peng, Yi-Ling Qiao, Ming Lin, Xiaodi Wu",
             "year": "2022",
@@ -52,6 +55,7 @@
         },
         {
             "id": "Asthana2022",
+            "type": "article",
             "title": "Minimizing state preparation times in pulse-level variational molecular simulations",
             "authors": "Ayush Asthana, Chenxu Liu, Oinam Romesh Meitei, Sophia E. Economou, Edwin Barnes, Nicholas J. Mayhall",
             "year": "2022",
@@ -60,6 +64,7 @@
         },
         {
             "id": "Russell2016",
+            "type": "article",
             "title": "Quantum Control Landscapes Are Almost Always Trap Free",
             "authors": "Benjamin Russell, Herschel Rabitz, Rebing Wu",
             "year": "2016",

--- a/demonstrations/tutorial_qft_arithmetics.metadata.json
+++ b/demonstrations/tutorial_qft_arithmetics.metadata.json
@@ -23,9 +23,10 @@
     "references": [
         {
             "id": "Draper2000",
+            "type": "article",
             "title": "Addition on a Quantum Computer",
             "authors": "Thomas G. Draper",
-            "year": "",
+            "year": "2000",
             "journal": "",
             "url": "https://arxiv.org/abs/quant-ph/0008033"
         }

--- a/demonstrations/tutorial_qgrnn.metadata.json
+++ b/demonstrations/tutorial_qgrnn.metadata.json
@@ -22,7 +22,8 @@
     "canonicalURL": "/qml/demos/tutorial_qgrnn",
     "references": [
         {
-            "id": "",
+            "id": "Verdon2019",
+            "type": "article",
             "title": "Quantum Graph Neural Networks",
             "authors": "Verdon, G., McCourt, T., Luzhnica, E., Singh, V., Leichenauer, S., & Hidary, J.",
             "year": "2019",

--- a/demonstrations/tutorial_quantum_analytic_descent.metadata.json
+++ b/demonstrations/tutorial_quantum_analytic_descent.metadata.json
@@ -26,22 +26,25 @@
     "references": [
         {
             "id": "QAD",
+            "type": "article",
             "title": "Quantum Analytic Descent",
             "authors": "Balint Koczor, Simon Benjamin",
-            "year": "",
+            "year": "2020",
             "journal": "",
             "url": "https://arxiv.org/abs/2008.13774"
         },
         {
             "id": "Rotosolve",
+            "type": "article",
             "title": "Structure optimization for parameterized quantum circuits",
             "authors": "Mateusz Ostaszewski, Edward Grant, Marcello Benedetti",
-            "year": "",
+            "year": "2019",
             "journal": "",
             "url": "https://arxiv.org/abs/1905.09692"
         },
         {
             "id": "higher_order_diff",
+            "type": "article",
             "title": "Estimating the gradient and higher-order derivatives on quantum hardware",
             "authors": "Andrea Mari, Thomas R. Bromley, Nathan Killoran",
             "year": "2021",

--- a/demonstrations/tutorial_quantum_chemistry.metadata.json
+++ b/demonstrations/tutorial_quantum_chemistry.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "yudong2019",
+            "type": "article",
             "title": "Quantum Chemistry in the Age of Quantum Computing",
             "authors": "Yudong Cao, Jonathan Romero, et al.",
             "year": "2019",
@@ -31,6 +32,7 @@
         },
         {
             "id": "BornOpp1927",
+            "type": "article",
             "title": "Quantum Theory of the Molecules",
             "authors": "M. Born, J.R. Oppenheimer",
             "year": "1927",
@@ -39,6 +41,7 @@
         },
         {
             "id": "pople1977",
+            "type": "article",
             "title": "Self‐consistent molecular orbital methods. XVIII. Constraints and stability in Hartree–Fock theory",
             "authors": "Rolf Seeger, John Pople",
             "year": "1977",
@@ -47,14 +50,16 @@
         },
         {
             "id": "ref_integrals",
+            "type": "article",
             "title": "Fundamentals of Molecular Integrals Evaluation",
             "authors": "J.T. Fermann, E.F. Valeev",
-            "year": "",
+            "year": "2020",
             "journal": "",
             "url": "https://arxiv.org/abs/2007.12057"
         },
         {
             "id": "seeley2012",
+            "type": "article",
             "title": "The Bravyi-Kitaev transformation for quantum computation of electronic structure",
             "authors": "Jacob T. Seeley, Martin J. Richard, Peter J. Love",
             "year": "2012",
@@ -63,6 +68,7 @@
         },
         {
             "id": "truhlar2018",
+            "type": "article",
             "title": "Automatic Selection of an Active Space for Calculating Electronic Excitation Spectra by MS-CASPT2 or MC-PDFT",
             "authors": "J.J. Bao, S.S. Dong, L. Gagliardi, D.G. Truhlar",
             "year": "2018",

--- a/demonstrations/tutorial_quantum_circuit_cutting.metadata.json
+++ b/demonstrations/tutorial_quantum_circuit_cutting.metadata.json
@@ -29,6 +29,7 @@
     "references": [
         {
             "id": "Peng2019",
+            "type": "article",
             "title": "Simulating Large Quantum Circuits on a Small Quantum Computer",
             "authors": "T. Peng, A. Harrow, M. Ozols, and X. Wu",
             "year": "2019",
@@ -37,6 +38,7 @@
         },
         {
             "id": "Lowe2022",
+            "type": "article",
             "title": "Fast quantum circuit cutting with randomized measurements",
             "authors": "A. Lowe et al.",
             "year": "2022",

--- a/demonstrations/tutorial_quantum_gans.metadata.json
+++ b/demonstrations/tutorial_quantum_gans.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "goodfellow2014",
+            "type": "article",
             "title": "Generative Adversarial Networks",
             "authors": "Ian J. Goodfellow et al.",
             "year": "2014",
@@ -31,6 +32,7 @@
         },
         {
             "id": "huang2020",
+            "type": "article",
             "title": "Experimental Quantum Generative Adversarial Networks for Image Generation",
             "authors": "He-Liang Huang et al.",
             "year": "2020",

--- a/demonstrations/tutorial_quantum_metrology.metadata.json
+++ b/demonstrations/tutorial_quantum_metrology.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "meyer2020",
+            "type": "article",
             "title": "A variational toolbox for quantum multi-parameter estimation.",
             "authors": "Johannes Jakob Meyer, Johannes Borregaard, Jens Eisert",
             "year": "2020",

--- a/demonstrations/tutorial_quantum_natural_gradient.metadata.json
+++ b/demonstrations/tutorial_quantum_natural_gradient.metadata.json
@@ -22,7 +22,8 @@
     "canonicalURL": "/qml/demos/tutorial_quantum_natural_gradient",
     "references": [
         {
-            "id": "",
+            "id": "Amari1998",
+            "type": "article",
             "title": "Natural gradient works efficiently in learning.",
             "authors": "Shun-Ichi Amari",
             "year": "1998",
@@ -30,7 +31,8 @@
             "url": "https://www.mitpressjournals.org/doi/abs/10.1162/089976698300017746"
         },
         {
-            "id": "",
+            "id": "Stokes2019",
+            "type": "article",
             "title": "Quantum Natural Gradient.",
             "authors": "James Stokes, Josh Izaac, Nathan Killoran, Giuseppe Carleo",
             "year": "2019",
@@ -38,7 +40,8 @@
             "url": "https://arxiv.org/abs/1909.02108"
         },
         {
-            "id": "",
+            "id": "Harrow2019",
+            "type": "article",
             "title": "Low-depth gradient measurements can improve convergence in variational hybrid quantum-classical algorithms.",
             "authors": "Aram Harrow and John Napp",
             "year": "2019",
@@ -46,7 +49,8 @@
             "url": "https://arxiv.org/abs/1901.05374"
         },
         {
-            "id": "",
+            "id": "Yamamoto2019",
+            "type": "article",
             "title": "On the natural gradient for variational quantum eigensolver.",
             "authors": "Naoki Yamamoto",
             "year": "2019",

--- a/demonstrations/tutorial_quantum_transfer_learning.metadata.json
+++ b/demonstrations/tutorial_quantum_transfer_learning.metadata.json
@@ -22,7 +22,8 @@
     "canonicalURL": "/qml/demos/tutorial_quantum_transfer_learning",
     "references": [
         {
-            "id": "",
+            "id": "Mari2019",
+            "type": "article",
             "title": "Transfer learning in hybrid classical-quantum neural networks",
             "authors": "Andrea Mari, Thomas R. Bromley, Josh Izaac, Maria Schuld, and Nathan Killoran",
             "year": "2019",
@@ -30,7 +31,8 @@
             "url": ""
         },
         {
-            "id": "",
+            "id": "Raina2007",
+            "type": "article",
             "title": "Self-taught learning:  transfer learning from unlabeled data",
             "authors": "Rajat Raina, Alexis Battle, Honglak Lee, Benjamin Packer, and Andrew Y Ng",
             "year": "2007",
@@ -38,7 +40,8 @@
             "url": ""
         },
         {
-            "id": "",
+            "id": "He2016",
+            "type": "article",
             "title": "Deep residual learning for image recognition",
             "authors": "Kaiming He, Xiangyu Zhang, Shaoqing ren and Jian Sun",
             "year": "2016",
@@ -46,7 +49,8 @@
             "url": ""
         },
         {
-            "id": "",
+            "id": "Bergholm2018",
+            "type": "article",
             "title": "PennyLane: Automatic differentiation of hybrid quantum-classical computations",
             "authors": "Ville Bergholm, Josh Izaac, Maria Schuld, Christian Gogolin, Carsten Blank, Keri McKiernan, and Nathan Killoran",
             "year": "2018",

--- a/demonstrations/tutorial_quanvolution.metadata.json
+++ b/demonstrations/tutorial_quanvolution.metadata.json
@@ -22,7 +22,8 @@
     "canonicalURL": "/qml/demos/tutorial_quanvolution",
     "references": [
         {
-            "id": "",
+            "id": "Henderson2019",
+            "type": "article",
             "title": "Quanvolutional Neural Networks: Powering Image Recognition with Quantum Circuits.",
             "authors": "Maxwell Henderson, Samriddhi Shakya, Shashindra Pradhan, Tristan Cook",
             "year": "2019",

--- a/demonstrations/tutorial_qubit_tapering.metadata.json
+++ b/demonstrations/tutorial_qubit_tapering.metadata.json
@@ -26,17 +26,19 @@
     "references": [
         {
             "id": "bravyi2017",
+            "type": "article",
             "title": "Tapering off qubits to simulate fermionic Hamiltonians",
             "authors": "Sergey Bravyi, Jay M. Gambetta, Antonio Mezzacapo, Kristan Temme",
-            "year": "",
+            "year": "2017",
             "journal": "",
             "url": "https://arxiv.org/abs/1701.08213"
         },
         {
             "id": "setia2019",
+            "type": "article",
             "title": "Reducing qubit requirements for quantum simulation using molecular point group symmetries",
             "authors": "Kanav Setia, Richard Chen, Julia E. Rice, Antonio Mezzacapo, Marco Pistoia, James Whitfield",
-            "year": "",
+            "year": "2019",
             "journal": "",
             "url": "https://arxiv.org/abs/1910.14644"
         }

--- a/demonstrations/tutorial_qutrits_bernstein_vazirani.metadata.json
+++ b/demonstrations/tutorial_qutrits_bernstein_vazirani.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "bv",
+            "type": "article",
             "title": "Quantum Complexity Theory",
             "authors": "Ethan Bernstein, Umesh Vazirani",
             "year": "1997",
@@ -33,9 +34,10 @@
         },
         {
             "id": "toffoli_qutrits",
+            "type": "article",
             "title": "Implementing a Ternary Decomposition of the Toffoli Gate on Fixed-FrequencyTransmon Qutrits",
             "authors": "Alexey Galda, Michael Cubeddu, Naoki Kanazawa, Prineha Narang, Nathan Earnest-Noble",
-            "year": "",
+            "year": "2021",
             "journal": "",
             "url": "https://arxiv.org/pdf/2109.00558.pdf"
         }

--- a/demonstrations/tutorial_resource_estimation.metadata.json
+++ b/demonstrations/tutorial_resource_estimation.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "vonburg2021",
+            "type": "article",
             "title": "Quantum computing enhanced computational catalysis",
             "authors": "Vera von Burg, Guang Hao Low, Thomas Haner, Damian S. Steiger, et al.",
             "year": "2021",
@@ -31,6 +32,7 @@
         },
         {
             "id": "lee2021",
+            "type": "article",
             "title": "Even More Efficient Quantum Computations of Chemistry Through Tensor Hypercontraction",
             "authors": "Joonho Lee, Dominic W. Berry, Craig Gidney, William J. Huggins, et al.",
             "year": "2021",
@@ -39,15 +41,16 @@
         },
         {
             "id": "zini2023",
+            "type": "article",
             "title": "Quantum simulation of battery materials using ionic pseudopotentials",
             "authors": "Modjtaba Shokrian Zini, Alain Delgado, Roberto dos Reis, et al.",
             "year": "2023",
             "journal": "arXiv:2302.07981",
-            "doi": "",
             "url": "https://arxiv.org/abs/2302.07981"
         },
         {
             "id": "delgado2022",
+            "type": "article",
             "title": "Simulating key properties of lithium-ion batteries with a fault-tolerant quantum computer",
             "authors": "Alain Delgado, Pablo A. M. Casares, Roberto dos Reis, Modjtaba Shokrian Zini, et al.",
             "year": "2022",

--- a/demonstrations/tutorial_rosalin.metadata.json
+++ b/demonstrations/tutorial_rosalin.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "arrasmith2020",
+            "type": "article",
             "title": "Operator Sampling for Shot-frugal Optimization in Variational Algorithms.",
             "authors": "Andrew Arrasmith, Lukasz Cincio, Rolando D. Somma, and Patrick J. Coles",
             "year": "2020",
@@ -31,6 +32,7 @@
         },
         {
             "id": "stokes2019",
+            "type": "article",
             "title": "Quantum Natural Gradient.",
             "authors": "James Stokes, Josh Izaac, Nathan Killoran, and Giuseppe Carleo",
             "year": "2019",
@@ -39,6 +41,7 @@
         },
         {
             "id": "sweke2019",
+            "type": "article",
             "title": "Stochastic gradient descent for hybrid quantum-classical optimization.",
             "authors": "Ryan Sweke, Frederik Wilde, Johannes Jakob Meyer, Maria Schuld, Paul K. Fährmann, Barthélémy Meynard-Piganeau, and Jens Eisert",
             "year": "2019",
@@ -47,6 +50,7 @@
         },
         {
             "id": "kubler2020",
+            "type": "article",
             "title": "An Adaptive Optimizer for Measurement-Frugal Variational Algorithms.",
             "authors": "Jonas M. Kübler, Andrew Arrasmith, Lukasz Cincio, and Patrick J. Coles",
             "year": "2020",

--- a/demonstrations/tutorial_rotoselect.metadata.json
+++ b/demonstrations/tutorial_rotoselect.metadata.json
@@ -22,7 +22,8 @@
     "canonicalURL": "/qml/demos/tutorial_rotoselect",
     "references": [
         {
-            "id": "",
+            "id": "Ostaszewski2019",
+            "type": "article",
             "title": "Quantum circuit structure learning.",
             "authors": "Mateusz Ostaszewski, Edward Grant, Marcello Bendetti",
             "year": "2019",

--- a/demonstrations/tutorial_sc_qubits.metadata.json
+++ b/demonstrations/tutorial_sc_qubits.metadata.json
@@ -24,6 +24,7 @@
     "references": [
         {
             "id": "Google2019",
+            "type": "article",
             "title": "Quantum supremacy using a programmable superconducting processor",
             "authors": "Arute, F., Arya, K., Babbush, R. et al.",
             "year": "2019",
@@ -32,14 +33,16 @@
         },
         {
             "id": "IBM2021",
+            "type": "article",
             "title": "IBM Unveils Breakthrough 127-Qubit Quantum Processor",
             "authors": "",
-            "year": "",
+            "year": "2021",
             "journal": "",
             "url": "https://newsroom.ibm.com/2021-11-16-IBM-Unveils-Breakthrough-127-Qubit-Quantum-Processor"
         },
         {
             "id": "DiVincenzo2000",
+            "type": "article",
             "title": "The Physical Implementation of Quantum Computation",
             "authors": "D. DiVincenzo",
             "year": "2000",
@@ -48,6 +51,7 @@
         },
         {
             "id": "Bergou2021",
+            "type": "book",
             "title": "Quantum Information Processing",
             "authors": "Bergou, J., Hillery, M., and Saffman, M.",
             "year": "2021",
@@ -56,6 +60,7 @@
         },
         {
             "id": "Blais2021",
+            "type": "article",
             "title": "Circuit quantum electrodynamics",
             "authors": "Blais, A., Grimsmo, A., Girvin, S., and Walraff, A.",
             "year": "2021",
@@ -64,6 +69,7 @@
         },
         {
             "id": "Schuch2003",
+            "type": "article",
             "title": "Natural two-qubit gate for quantum computation using the XY interaction",
             "authors": "Schuch, N., Siewert, J.",
             "year": "2003",
@@ -72,6 +78,7 @@
         },
         {
             "id": "Rigetti2003",
+            "type": "article",
             "title": "Fully microwave-tunable universal gates in superconducting qubits with linear couplings and fixed transition frequencies",
             "authors": "Rigetti, C., Devoret, M.",
             "year": "2009",
@@ -80,9 +87,10 @@
         },
         {
             "id": "IBMHex2021",
+            "type": "article",
             "title": "The IBM Quantum heavy hex lattice",
             "authors": "",
-            "year": "",
+            "year": "2021",
             "journal": "",
             "url": "https://research.ibm.com/blog/heavy-hex-lattice"
         }

--- a/demonstrations/tutorial_spsa.metadata.json
+++ b/demonstrations/tutorial_spsa.metadata.json
@@ -26,6 +26,7 @@
     "references": [
         {
             "id": "spall_overview",
+            "type": "article",
             "title": "An Overview of the Simultaneous Perturbation Method for Efficient Optimization",
             "authors": "James C. Spall",
             "year": "1998",
@@ -34,6 +35,7 @@
         },
         {
             "id": "spall_implementation",
+            "type": "article",
             "title": "Implementation of the simultaneous perturbation algorithm for stochastic optimization",
             "authors": "J. C. Spall",
             "year": "1998",
@@ -46,6 +48,7 @@
         },
         {
             "id": "spall_hessian",
+            "type": "article",
             "title": "Adaptive stochastic approximation by the simultaneous perturbation method",
             "authors": "J. C. Spall",
             "year": "2020",
@@ -58,6 +61,7 @@
         },
         {
             "id": "qnspsa",
+            "type": "article",
             "title": "Simultaneous Perturbation Stochastic Approximation of the Quantum Fisher Information",
             "authors": "J. Gacon, C. Zoufal, G. Carleo, and S. Woerner",
             "year": "2021",

--- a/demonstrations/tutorial_stochastic_parameter_shift.metadata.json
+++ b/demonstrations/tutorial_stochastic_parameter_shift.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "banchi2020",
+            "type": "article",
             "title": "Measuring Analytic Gradients of General Quantum Evolution with the Stochastic Parameter Shift Rule.",
             "authors": "Leonardo Banchi and Gavin E. Crooks",
             "year": "2020",
@@ -31,6 +32,7 @@
         },
         {
             "id": "li2016",
+            "type": "article",
             "title": "Hybrid Quantum-Classical Approach to Quantum Optimal Control.",
             "authors": "Jun Li, Xiaodong Yang, Xinhua Peng, and Chang-Pu Sun",
             "year": "2016",
@@ -39,6 +41,7 @@
         },
         {
             "id": "mitarai2018",
+            "type": "article",
             "title": "Quantum Circuit Learning",
             "authors": "Kosuke Mitarai, Makoto Negoro, Masahiro Kitagawa, and Keisuke Fujii",
             "year": "2020",
@@ -47,6 +50,7 @@
         },
         {
             "id": "schuld2018",
+            "type": "article",
             "title": "Evaluating analytic gradients on quantum hardware.",
             "authors": "Maria Schuld, Ville Bergholm, Christian Gogolin, Josh Izaac, and Nathan Killoran",
             "year": "2019",

--- a/demonstrations/tutorial_testing_symmetry.metadata.json
+++ b/demonstrations/tutorial_testing_symmetry.metadata.json
@@ -27,7 +27,8 @@
     "canonicalURL": "/qml/demos/tutorial_testing_symmetry",
     "references": [
         {
-            "id": "",
+            "id": "LaBorde2022",
+            "type": "article",
             "title": "Quantum Algorithms for Testing Hamiltonian Symmetry",
             "authors": "LaBorde, M. L and Wilde, M.M.",
             "year": "2022",

--- a/demonstrations/tutorial_tn_circuits.metadata.json
+++ b/demonstrations/tutorial_tn_circuits.metadata.json
@@ -32,15 +32,17 @@
     "references": [
         {
             "id": "huggins",
-            "title": "",
+            "type": "article",
+            "title": "Towards quantum machine learning with tensor networks",
             "authors": "W. Huggins, P. Patil, B. Mitchell, K. B. Whaley, and E. M. Stoudenmire",
-            "year": "",
+            "year": "2019",
             "journal": "Quantum Science and Technology",
             "url": "http://dx.doi.org/10.1088/2058-9565/aaea94"
         },
         {
             "id": "orus",
-            "title": "",
+            "type": "article",
+            "title": "A practical introduction to tensor networks: Matrix product states and projected entangled pair states",
             "authors": "R. Orús",
             "year": "2014",
             "journal": "Annals of Physics",

--- a/demonstrations/tutorial_toric_code.metadata.json
+++ b/demonstrations/tutorial_toric_code.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "Kitaev2003",
+            "type": "article",
             "title": "Fault-tolerant quantum computation by anyons.",
             "authors": "Kitaev, A. Yu",
             "year": "2003",
@@ -32,6 +33,7 @@
         },
         {
             "id": "surface_codes",
+            "type": "article",
             "title": "Surface codes: Towards practical large-scale quantum computation.",
             "authors": "Fowler, Austin G., et al.",
             "year": "2012",
@@ -41,6 +43,7 @@
         },
         {
             "id": "google_paper",
+            "type": "article",
             "title": "Realizing topologically ordered states on a quantum processor.",
             "authors": "Satzinger, K. J., et al.",
             "year": "2021",
@@ -49,6 +52,7 @@
         },
         {
             "id": "savary_balents",
+            "type": "article",
             "title": "Quantum spin liquids: a review.",
             "authors": "Savary, Lucile, and Leon Balents",
             "year": "2016",
@@ -57,6 +61,7 @@
         },
         {
             "id": "Resende",
+            "type": "article",
             "title": "A pedagogical overview on 2D and 3D Toric Codes and the origin of their topological orders.",
             "authors": "Araujo de Resende, M. F.",
             "year": "2020",

--- a/demonstrations/tutorial_trapped_ions.metadata.json
+++ b/demonstrations/tutorial_trapped_ions.metadata.json
@@ -24,6 +24,7 @@
     "references": [
         {
             "id": "DiVincenzo2000",
+            "type": "article",
             "title": "The Physical Implementation of Quantum Computation",
             "authors": "D. DiVincenzo",
             "year": "2000",
@@ -32,6 +33,7 @@
         },
         {
             "id": "Paul1953",
+            "type": "article",
             "title": "Ein neues Massenspektrometer ohne Magnetfeld",
             "authors": "W. Paul, H. Steinwedel",
             "year": "1953",
@@ -40,6 +42,7 @@
         },
         {
             "id": "CiracZoller",
+            "type": "article",
             "title": "Quantum Computations with Cold Trapped Ions",
             "authors": "J. Cirac, P. Zoller",
             "year": "1995",
@@ -48,6 +51,7 @@
         },
         {
             "id": "Malinowski",
+            "type": "article",
             "title": "Unitary and Dissipative Trapped-​Ion Entanglement Using Integrated Optics",
             "authors": "M. Malinowski",
             "year": "2021",
@@ -56,6 +60,7 @@
         },
         {
             "id": "NandC2000",
+            "type": "book",
             "title": "Quantum Computation and Quantum Information",
             "authors": "M. A. Nielsen, and I. L. Chuang",
             "year": "2000",
@@ -64,6 +69,7 @@
         },
         {
             "id": "Hughes2020",
+            "type": "article",
             "title": "Benchmarking a High-Fidelity Mixed-Species Entangling Gate",
             "authors": "A. Hughes, V. Schafer, K. Thirumalai, et al.",
             "year": "2020",
@@ -72,6 +78,7 @@
         },
         {
             "id": "Bergou2021",
+            "type": "book",
             "title": "Quantum Information Processing",
             "authors": "J. Bergou, M. Hillery, and M. Saffman",
             "year": "2021",
@@ -80,6 +87,7 @@
         },
         {
             "id": "Molmer1999",
+            "type": "article",
             "title": "Multi-particle entanglement of hot trapped ions",
             "authors": "A. Sørensen, K. Mølmer",
             "year": "1999",
@@ -88,6 +96,7 @@
         },
         {
             "id": "Brown2019",
+            "type": "article",
             "title": "Handling leakage with subsystem codes",
             "authors": "M. Brown, M. Newman, and K. Brown",
             "year": "2019",
@@ -96,6 +105,7 @@
         },
         {
             "id": "Monroe2014",
+            "type": "article",
             "title": "Large scale modular quantum computer architecture with atomic memory and photonic interconnects",
             "authors": "C. Monroe, R. Ruassendorf, A Ruthven, et al.",
             "year": "2019",
@@ -104,6 +114,7 @@
         },
         {
             "id": "QCCD2002",
+            "type": "article",
             "title": "Architecture for a large-scale ion-trap quantum computer",
             "authors": "D. Kielpinski, C. Monroe, and D. Wineland",
             "year": "2002",
@@ -112,6 +123,7 @@
         },
         {
             "id": "Amini2010",
+            "type": "article",
             "title": "Toward scalable ion traps for quantum information processing",
             "authors": "J. Amini, H. Uys, J. Wesenberg, et al.",
             "year": "2010",
@@ -120,6 +132,7 @@
         },
         {
             "id": "Pino2021",
+            "type": "article",
             "title": "Demonstration of the trapped-ion quantum CCD computer architecture",
             "authors": "J. Pino, J. Dreiling, J, C, Figgatt, et al.",
             "year": "2021",
@@ -128,6 +141,7 @@
         },
         {
             "id": "Blumel2021",
+            "type": "article",
             "title": "Efficient Stabilized Two-Qubit Gates on a Trapped-Ion Quantum Computer",
             "authors": "R. Blumel, N. Grzesiak, N. Nguyen, et al.",
             "year": "2021",
@@ -136,6 +150,7 @@
         },
         {
             "id": "Niffenegger2020",
+            "type": "article",
             "title": "Integrated multi-wavelength control of an ion qubit",
             "authors": "R. Niffenegger, J. Stuart, C.Sorace-Agaskar, et al.",
             "year": "2020",

--- a/demonstrations/tutorial_unitary_designs.metadata.json
+++ b/demonstrations/tutorial_unitary_designs.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "Handbook",
+            "type": "book",
             "title": "Handbook of Combinatorial Designs, Second Edition",
             "authors": "C. J. Colbourn and J. H. Dinitz",
             "year": "2006",
@@ -31,6 +32,7 @@
         },
         {
             "id": "Delsarte",
+            "type": "article",
             "title": "Spherical Codes and Designs",
             "authors": "P. Delsarte, J.M. Goethals, J.J. Seidel",
             "year": "1977",
@@ -39,6 +41,7 @@
         },
         {
             "id": "sph4design",
+            "type": "article",
             "title": "New spherical 4-designs",
             "authors": "R. H. Hardin and N. J. A. Sloane",
             "year": "1992",
@@ -47,6 +50,7 @@
         },
         {
             "id": "Ambainis",
+            "type": "article",
             "title": "Quantum t-designs: t-wise independence in the quantum world.",
             "authors": "A. Ambainis and J. Emerson",
             "year": "2007",
@@ -55,6 +59,7 @@
         },
         {
             "id": "Klappenecker",
+            "type": "article",
             "title": "Mutually unbiased bases, spherical designs, and frames.",
             "authors": "A. Klappenecker and M. Roetteler",
             "year": "2005",
@@ -64,6 +69,7 @@
         },
         {
             "id": "Dankert",
+            "type": "article",
             "title": "Exact and Approximate Unitary 2-Designs: Constructions and Applications.",
             "authors": "C. Dankert, R. Cleve, J. Emerson, and E. Levine",
             "year": "2009",
@@ -72,6 +78,7 @@
         },
         {
             "id": "DankertThesis",
+            "type": "article",
             "title": "Efficient Simulation of Random Quantum States and Operators.",
             "authors": "C. Dankert",
             "year": "2005",
@@ -80,6 +87,7 @@
         },
         {
             "id": "Gross",
+            "type": "article",
             "title": "Evenly distributed unitaries: on the structure of unitary designs",
             "authors": "D. Gross, K. Audenaert, and J. Eisert",
             "year": "2007",
@@ -88,6 +96,7 @@
         },
         {
             "id": "Roy",
+            "type": "article",
             "title": "Unitary designs and codes",
             "authors": "A. Roy and A. J. Scott",
             "year": "2009",
@@ -96,6 +105,7 @@
         },
         {
             "id": "Bannai",
+            "type": "article",
             "title": "On the explicit constructions of certain unitary t-designs.",
             "authors": "E. Bannai, M. Nakahara, D. Zhao, and Y. Zhu",
             "year": "2019",
@@ -104,6 +114,7 @@
         },
         {
             "id": "Nakata",
+            "type": "article",
             "title": "Quantum circuits for exact unitary t-designs and applications to higher-order randomized benchmarking.",
             "authors": "Y. Nakata et al.",
             "year": "2021",
@@ -112,6 +123,7 @@
         },
         {
             "id": "PQC",
+            "type": "article",
             "title": "Private Quantum Channels",
             "authors": "A. Ambainis, M. Mosca, A. Tapp, and R. de Wolf",
             "year": "2000",
@@ -120,6 +132,7 @@
         },
         {
             "id": "Seberry",
+            "type": "article",
             "title": "Hadamard matrices, sequences, and block designs.",
             "authors": "J. Seberry and M. Yamada",
             "year": "1992",
@@ -128,6 +141,7 @@
         },
         {
             "id": "Gaeta",
+            "type": "article",
             "title": "Discrete phase-space approach to mutually orthogonal Latin squares",
             "authors": "M. Gaeta, O. Di Matteo, A. B. Klimov, and H. de Guise",
             "year": "2014",

--- a/demonstrations/tutorial_univariate_qvr.metadata.json
+++ b/demonstrations/tutorial_univariate_qvr.metadata.json
@@ -30,6 +30,7 @@
     "references": [
         {
             "id": "Baker2022",
+            "type": "article",
             "title": "Quantum Variational Rewinding for Time Series Anomaly Detection.",
             "authors": "Baker, Jack S. et al.",
             "year": "2022",
@@ -38,6 +39,7 @@
         },
         {
             "id": "Stone1932",
+            "type": "article",
             "title": "On one-parameter unitary groups in Hilbert space.",
             "authors": "Stone, Marshall H.",
             "year": "1932",
@@ -47,15 +49,17 @@
         },
         {
             "id": "Welch2014",
+            "type": "article",
             "title": "Efficient quantum circuits for diagonal unitaries without ancillas",
             "authors": "Welch, Jonathan et al.",
-            "year": "",
+            "year": "2014",
             "journal": "New Journal of Physics",
             "doi": "10.1088/1367-2630/16/3/033040",
             "url": "https://doi.org/10.1088/1367-2630/16/3/033040"
         },
         {
             "id": "Cîrstoiu2020",
+            "type": "article",
             "title": "Variational fast forwarding for quantum simulation beyond the coherence time",
             "authors": "Cîrstoiu, Cristina et al.",
             "year": "2020",

--- a/demonstrations/tutorial_vqe.metadata.json
+++ b/demonstrations/tutorial_vqe.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "peruzzo2014",
+            "type": "article",
             "title": "A variational eigenvalue solver on a photonic quantum processor",
             "authors": "Alberto Peruzzo, Jarrod McClean et al.",
             "year": "2014",
@@ -31,6 +32,7 @@
         },
         {
             "id": "seeley2012",
+            "type": "article",
             "title": "The Bravyi-Kitaev transformation for quantum computation of electronic structure",
             "authors": "Jacob T. Seeley, Martin J. Richard, Peter J. Love",
             "year": "2012",

--- a/demonstrations/tutorial_vqe_qng.metadata.json
+++ b/demonstrations/tutorial_vqe_qng.metadata.json
@@ -29,6 +29,7 @@
     "references": [
         {
             "id": "stokes2019",
+            "type": "article",
             "title": "Quantum Natural Gradient",
             "authors": "Stokes, James, et al.",
             "year": "2019",
@@ -37,6 +38,7 @@
         },
         {
             "id": "yamamoto2019",
+            "type": "article",
             "title": "On the natural gradient for variational quantum eigensolver",
             "authors": "Yamamoto, Naoki",
             "year": "2019",
@@ -45,6 +47,7 @@
         },
         {
             "id": "peruzzo2014",
+            "type": "article",
             "title": "A variational eigenvalue solver on a photonic quantum processor",
             "authors": "Alberto Peruzzo, Jarrod McClean et al.",
             "year": "2014",

--- a/demonstrations/tutorial_vqe_spin_sectors.metadata.json
+++ b/demonstrations/tutorial_vqe_spin_sectors.metadata.json
@@ -23,6 +23,7 @@
     "references": [
         {
             "id": "peruzzo2014",
+            "type": "article",
             "title": "A variational eigenvalue solver on a photonic quantum processor",
             "authors": "A. Peruzzo, J. McClean et al.",
             "year": "2014",
@@ -31,6 +32,7 @@
         },
         {
             "id": "qchemcircuits",
+            "type": "article",
             "title": "Universal quantum circuits for quantum chemistry",
             "authors": "J.M. Arrazola, O. Di Matteo, N. Quesada, S. Jahangiri, A. Delgado, N. Killoran.",
             "year": "2021",

--- a/demonstrations/tutorial_vqls.metadata.json
+++ b/demonstrations/tutorial_vqls.metadata.json
@@ -22,7 +22,8 @@
     "canonicalURL": "/qml/demos/tutorial_vqls",
     "references": [
         {
-            "id": "",
+            "id": "BravoPrieto2019",
+            "type": "article",
             "title": "Variational Quantum Linear Solver: A Hybrid Algorithm for Linear Systems.",
             "authors": "Carlos Bravo-Prieto, Ryan LaRose, Marco Cerezo, Yigit Subasi, Lukasz Cincio, Patrick J. Coles",
             "year": "2019",

--- a/demonstrations/tutorial_vqt.metadata.json
+++ b/demonstrations/tutorial_vqt.metadata.json
@@ -22,7 +22,8 @@
     "canonicalURL": "/qml/demos/tutorial_vqt",
     "references": [
         {
-            "id": "",
+            "id": "Verdon2019",
+            "type": "article",
             "title": "Quantum Hamiltonian-Based Models and the Variational Quantum Thermalizer Algorithm",
             "authors": "Verdon, G., Marks, J., Nanda, S., Leichenauer, S., & Hidary, J.",
             "year": "2019",

--- a/demonstrations/tutorial_zx_calculus.metadata.json
+++ b/demonstrations/tutorial_zx_calculus.metadata.json
@@ -27,6 +27,7 @@
     "references": [
         {
             "id": "Coecke",
+            "type": "article",
             "title": "Interacting Quantum Observables: Categorical Algebra and Diagrammatics.",
             "authors": "Bob Coecke and Ross Duncan.",
             "year": "2008",
@@ -36,25 +37,27 @@
         },
         {
             "id": "PyZX",
+            "type": "webpage",
             "title": "PyZX GitHub.",
             "authors": "John van de Wetering.",
-            "year": "",
+            "year": "2018",
             "publisher": "",
             "journal": "",
             "url": "https://github.com/Quantomatic/pyzx"
         },
         {
             "id": "Backens2018",
+            "type": "article",
             "title": "ZH: A Complete Graphical Calculus for Quantum Computations Involving Classical Non-linearity",
             "authors": "Miriam Backens and Aleks Kissinger",
             "year": "2018",
             "publisher": "",
             "journal": "",
-            "doi": "",
             "url": "https://arxiv.org/pdf/1805.02175.pdf"
         },
         {
             "id": "East2021",
+            "type": "article",
             "title": "AKLT-states as ZX-diagrams: diagrammatic reasoning for quantum states.",
             "authors": "Richard D. P. East, John van de Wetering, Nicholas Chancellor and Adolfo G. Grushin.",
             "year": "2021",
@@ -64,6 +67,7 @@
         },
         {
             "id": "JvdW2020",
+            "type": "article",
             "title": "ZX-calculus for the working quantum computer scientist.",
             "authors": "John van de Wetering.",
             "year": "2020",
@@ -73,6 +77,7 @@
         },
         {
             "id": "Zhao2021",
+            "type": "article",
             "title": "Analyzing the barren plateau phenomenon in training quantum neural networks with the ZX-calculus.",
             "authors": "Chen Zhao and Xiao-Shan Gao.",
             "year": "2021",
@@ -82,6 +87,7 @@
         },
         {
             "id": "Wang2022",
+            "type": "article",
             "title": "Differentiating and Integrating ZX Diagrams with Applications to Quantum Machine Learning.",
             "authors": "Quanlong Wang, Richie Yeung, and Mark Koch.",
             "year": "2022",
@@ -91,6 +97,7 @@
         },
         {
             "id": "Duncan2020",
+            "type": "article",
             "title": "Graph-theoretic Simplification of Quantum Circuits with the ZX-calculus.",
             "authors": "Ross Duncan, Aleks Kissinger, Simon Perdrix, and John van de Wetering.",
             "year": "2020",
@@ -100,6 +107,7 @@
         },
         {
             "id": "Kissinger2021",
+            "type": "article",
             "title": "Reducing T-count with the ZX-calculus.",
             "authors": "Aleks Kissinger and John van de Wetering.",
             "year": "2021",
@@ -109,6 +117,7 @@
         },
         {
             "id": "Beaudrap2021",
+            "type": "article",
             "title": "Circuit Extraction for ZX-diagrams can be #P-hard.",
             "authors": "Niel de Beaudrap, Aleks Kissinger and John van de Wetering.",
             "year": "2021",

--- a/metadata_schemas/demo.metadata.schema.0.1.0.json
+++ b/metadata_schemas/demo.metadata.schema.0.1.0.json
@@ -47,7 +47,7 @@
             "Quantum Hardware"
           ]
         },
-        "minItems": 1
+        "minItems": 0
       },
       "tags": {
         "description": "An array of the tags that the demo has. An empty array is allowed.",

--- a/metadata_schemas/objects/reference.schema.0.1.0.json
+++ b/metadata_schemas/objects/reference.schema.0.1.0.json
@@ -12,7 +12,7 @@
       },
       "type": {
         "description": "The type of this reference.",
-        "enum": ["article", "book", "phdthesis", "preprint", "webpage"]
+        "enum": ["article", "book", "phdthesis", "preprint", "webpage", "website", "other"]
       },
       "title": {
         "description": "The title of the material being referenced.",
@@ -22,7 +22,7 @@
       "authors": {
         "description": "The authors of the paper or book being referenced, as a single string. Names should be comma-separated, and the Oxford comma should be used when there are 3 or more names, and before 'et al.'.",
         "type": "string",
-        "minLength": 2
+        "minLength": 0
       },
       "year": {
         "description": "The year in which the paper or book was published.",
@@ -67,10 +67,8 @@
       }
     },
     "required": [
-      "authors",
       "id",
       "type",
-      "title",
-      "year"
+      "title"
     ]
 }

--- a/metadata_schemas/objects/related.content.schema.0.1.0.json
+++ b/metadata_schemas/objects/related.content.schema.0.1.0.json
@@ -7,7 +7,7 @@
     "properties": {
       "type": {
         "description": "The type of content that this relation refers to. So far, can only be 'demonstration', but this will be expanded in future.",
-        "enum": ["demonstration"]
+        "enum": ["demonstration", "glossary_entry"]
       },
       "id": {
         "description": "The id of the content that this relation refers to. For demos, it's the file name of the demo without the extension - i.e., 'tutorial_haar_measure'.",


### PR DESCRIPTION
This consists of, mostly, just adding "type": "article" to lots of the references, and fixing datetimes.

There are also a few adjustments to the schema to allow for some of the more unusual references that are used.