### PR TITLE
Updated scheduled builds to use the CI workflow version from their own respective branches

### DIFF
--- a/.github/workflows/build-branch-dev.yml
+++ b/.github/workflows/build-branch-dev.yml
@@ -12,7 +12,9 @@ concurrency:
 
 jobs:
   build_dev:
-    uses: ./.github/workflows/build-branch.yml
+    # Referencing the actions using the remote-call URL as we do not want to use the local copy of the called
+    # workflow, but instead want to use the version of the workflow on the @dev branch
+    uses: PennyLaneAI/qml/.github/workflows/build-branch.yml@dev
     with:
       branch: dev
       num_workers: '10'

--- a/.github/workflows/build-branch-master.yml
+++ b/.github/workflows/build-branch-master.yml
@@ -12,7 +12,9 @@ concurrency:
 
 jobs:
   build_master:
-    uses: ./.github/workflows/build-branch.yml
+    # Referencing the actions using the remote-call URL as we do not want to use the local copy of the called
+    # workflow, but instead want to use the version of the workflow on the @master branch
+    uses: PennyLaneAI/qml/.github/workflows/build-branch.yml@master
     with:
       branch: master
       num_workers: '10'


### PR DESCRIPTION
**Title:** Updated scheduled builds to use the CI workflow version from their own respective branches

**Summary:**
This PR fixes a bug that was introduced in #884 

Description of issue
Scheduled builds with local reference in `uses` key always triggers a version of a workflow from the default branch of the repository.

Since the dependency upgrade and removal of sitemap generation has only happened in dev, when the workflow version from master attempts to build the demos in the dev branch, files are missing and the build fails:
https://github.com/PennyLaneAI/qml/actions/runs/5844140578/job/15846931188#step:21:28

Promoting the changes from dev to master would resolve the error, but that is a more bandaid error since we will need to test a lot more changes in the dev branch moving forward before they are promoted to master. So a proper solution has to be put in place.

Though letting the entire CI pass was deemed outside of scope, the scheduled build workflow was triggered from this branch, and it used the dev reference properly for the dev build as can be seen here:
- Workflow => https://github.com/PennyLaneAI/qml/actions/runs/5858967638
- File => https://github.com/PennyLaneAI/qml/actions/runs/5844140578/workflow


**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**
