### PR TITLE
Replace `QubitStateVector` to `StatePrep`

### DIFF
--- a/demonstrations/tutorial_apply_qsvt.py
+++ b/demonstrations/tutorial_apply_qsvt.py
@@ -341,7 +341,7 @@ normalized_x = target_x / norm_x
 
 @qml.qnode(qml.device("default.qubit", wires=["ancilla1", "ancilla2", 0, 1, 2]))
 def linear_system_solver_circuit(phi):
-    qml.QubitStateVector(normalized_b, wires=[1, 2])
+    qml.StatePrep(normalized_b, wires=[1, 2])
     real_u(A.T, phi)  # invert the singular values of A transpose to get A^-1
     return qml.state()
 

--- a/demonstrations/tutorial_general_parshift.py
+++ b/demonstrations/tutorial_general_parshift.py
@@ -143,7 +143,7 @@ def make_cost(N, seed):
     @qml.qnode(dev, interface="jax")
     def cost(x):
         """Cost function on N qubits with N frequencies."""
-        qml.QubitStateVector(random_state(N, seed), wires=dev.wires)
+        qml.StatePrep(random_state(N, seed), wires=dev.wires)
         for w in dev.wires:
             qml.RZ(x, wires=w, id="x")
         return qml.expval(qml.Hermitian(random_observable(N, seed), wires=dev.wires))

--- a/demonstrations/tutorial_mbqc.py
+++ b/demonstrations/tutorial_mbqc.py
@@ -162,7 +162,7 @@ dev = qml.device("lightning.qubit", wires=2)
 @qml.qnode(dev, interface="autograd")
 def one_bit_teleportation(input_state):
     # Prepare the input state
-    qml.QubitStateVector(input_state, wires=0)
+    qml.StatePrep(input_state, wires=0)
 
     # Prepare the cluster state
     qml.Hadamard(wires=1)
@@ -305,7 +305,7 @@ dev = qml.device("lightning.qubit", wires=1)
 @qml.qnode(dev, interface="autograd")
 def RZ(theta, input_state):
     # Prepare the input state
-    qml.QubitStateVector(input_state, wires=0)
+    qml.StatePrep(input_state, wires=0)
 
     # Perform the Rz rotation
     qml.RZ(theta, wires=0)
@@ -326,7 +326,7 @@ mbqc_dev = qml.device("lightning.qubit", wires=2)
 @qml.qnode(mbqc_dev, interface="autograd")
 def RZ_MBQC(theta, input_state):
     # Prepare the input state
-    qml.QubitStateVector(input_state, wires=0)
+    qml.StatePrep(input_state, wires=0)
 
     # Prepare the cluster state
     qml.Hadamard(wires=1)
@@ -367,7 +367,7 @@ dev = qml.device("lightning.qubit", wires=1)
 @qml.qnode(dev, interface="autograd")
 def RX(theta, input_state):
     # Prepare the input state
-    qml.QubitStateVector(input_state, wires=0)
+    qml.StatePrep(input_state, wires=0)
 
     # Perform the Rz rotation
     qml.RX(theta, wires=0)
@@ -382,7 +382,7 @@ mbqc_dev = qml.device("lightning.qubit", wires=3)
 @qml.qnode(mbqc_dev, interface="autograd")
 def RX_MBQC(theta, input_state):
     # Prepare the input state
-    qml.QubitStateVector(input_state, wires=0)
+    qml.StatePrep(input_state, wires=0)
 
     # Prepare the cluster state
     qml.Hadamard(wires=1)
@@ -447,7 +447,7 @@ dev = qml.device("lightning.qubit", wires=2)
 @qml.qnode(dev, interface="autograd")
 def CNOT(input_state):
     # Prepare the input state
-    qml.QubitStateVector(input_state, wires=[0, 1])
+    qml.StatePrep(input_state, wires=[0, 1])
     qml.CNOT(wires=[0, 1])
 
     return qml.density_matrix(wires=[0, 1])
@@ -459,7 +459,7 @@ mbqc_dev = qml.device("lightning.qubit", wires=4)
 @qml.qnode(mbqc_dev, interface="autograd")
 def CNOT_MBQC(input_state):
     # Prepare the input state
-    qml.QubitStateVector(input_state, wires=[0, 1])
+    qml.StatePrep(input_state, wires=[0, 1])
 
     # Prepare the cluster state
     qml.Hadamard(wires=2)

--- a/demonstrations/tutorial_ml_classical_shadows.py
+++ b/demonstrations/tutorial_ml_classical_shadows.py
@@ -181,7 +181,7 @@ dev_exact = qml.device("default.qubit", wires=num_qubits) # for exact simulation
 
 def circuit(psi, observables):
     psi = psi / np.linalg.norm(psi) # normalize the state
-    qml.QubitStateVector(psi, wires=range(num_qubits))
+    qml.StatePrep(psi, wires=range(num_qubits))
     return [qml.expval(o) for o in observables]
 
 circuit_exact = qml.QNode(circuit, dev_exact)

--- a/demonstrations/tutorial_qgrnn.py
+++ b/demonstrations/tutorial_qgrnn.py
@@ -485,7 +485,7 @@ nx.draw(new_ising_graph)
 def qgrnn(weights, bias, time=None):
 
     # Prepares the low energy state in the two registers
-    qml.QubitStateVector(np.kron(low_energy_state, low_energy_state), wires=reg1 + reg2)
+    qml.StatePrep(np.kron(low_energy_state, low_energy_state), wires=reg1 + reg2)
 
     # Evolves the first qubit register with the time-evolution circuit to
     # prepare a piece of quantum data

--- a/demonstrations/tutorial_variational_classifier.py
+++ b/demonstrations/tutorial_variational_classifier.py
@@ -336,7 +336,7 @@ print("amplitude vector: ", np.real(dev.state))
 ##############################################################################
 # Note that the ``default.qubit`` simulator provides a shortcut to
 # ``statepreparation`` with the command
-# ``qml.QubitStateVector(x, wires=[0, 1])``. However, some devices may not
+# ``qml.StatePrep(x, wires=[0, 1])``. However, some devices may not
 # support an arbitrary state-preparation routine.
 #
 # Since we are working with only 2 qubits now, we need to update the layer


### PR DESCRIPTION
**Title:**
As a part of the recent update to support mid-circuit state preparation operations, we renamed the `qml.QubitStateVector` class to `qml.StatePrep`. It's not officially deprecated, but this change will ensure the latest functionality its reflected in the demos. 

**Summary:**
Simple find and replace `QubitStateVector` --> `StatePrep`
