### PR TITLE
Add `text` Makefile commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,16 @@ json-norun:
 	@echo
 	@echo "Build finished. The JSON files are in $(BUILDDIR)."
 
+text:
+	$(SPHINXBUILD) -b text "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@echo
+	@echo "Build finished. The text files are in $(BUILDDIR)."
+
+text-norun:
+	$(SPHINXBUILD) -D plot_gallery=0 -b text "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@echo
+	@echo "Build finished. The text files are in $(BUILDDIR)."
+
 download:
 	# make data directories
 	mkdir -p $(DATADIR)


### PR DESCRIPTION
**Title:** Add `text` Makefile commands

**Summary:** Adds new commands: `make text` and `make text-norun`

**Relevant references:** N/A

**Possible Drawbacks:** There are many warning upon generation, but it works for our purposes

**Related GitHub Issues:** N/A

# Verification
Ran the command locally, got text output.
<details><summary>Sample of output</summary>

```

Adaptive circuits
=================

The main idea behind building adaptive circuits is to compute the
gradients with respect to all possible excitation gates and then
select gates based on the magnitude of the computed gradients.

There are different ways to make use of the gradient information and
here we discuss one of these strategies and apply it to compute the
ground state energy of LiH. This method requires constructing the
Hamiltonian and determining all possible excitations, which we can do
with functionality built into PennyLane. But we first need to define
the molecular parameters, including atomic symbols and coordinates.
Note that the atomic coordinates are in Bohr.

   import pennylane as qml
   from pennylane import qchem
   from pennylane import numpy as np
   import time

   symbols = ["Li", "H"]
   geometry = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 2.969280527])
```

</details>
