### PR TITLE
Update PySCF demo to include initial states

### DIFF
--- a/demonstrations/tutorial_qchem_external.metadata.json
+++ b/demonstrations/tutorial_qchem_external.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2023-01-03T00:00:00+00:00",
-    "dateOfLastModification": "2023-01-04T00:00:00+00:00",
+    "dateOfLastModification": "2023-09-21T00:00:00+00:00",
     "categories": [
         "Quantum Chemistry", "Devices and Performance"
     ],

--- a/demonstrations/tutorial_qchem_external.py
+++ b/demonstrations/tutorial_qchem_external.py
@@ -143,7 +143,7 @@ print(f'Estimated number of logical qubits: {algo.qubits}')
 # orbitals. For molecules with a complicated electronic structure, the Hartree-Fock state has does
 # not have a large overlap with the ground state which makes executing quantum algorithms
 # non-efficient.
-
+#
 # Initial states obtained from affordable post-Hartree-Fock calculations can be used to make the
 # quantum workflow more performant. For instance, configuration interaction (CI) and coupled cluster
 # (CC) calculations with single and double (SD) excitations can be performed using PySCF and the

--- a/demonstrations/tutorial_qchem_external.py
+++ b/demonstrations/tutorial_qchem_external.py
@@ -148,9 +148,9 @@ print(f'Estimated number of logical qubits: {algo.qubits}')
 # quantum workflow more performant. For instance, configuration interaction (CI) and coupled cluster
 # (CC) calculations with single and double (SD) excitations can be performed using PySCF and the
 # resulting wave function can be used as the initial state in the quantum algorithm. PennyLane
-# provides the import_state function that takes a PySCF solver object, extracts the wave function
-# and returns a state vector in the computational basis that can be used in a quantum circuit. Let’s
-# look at an example.
+# provides the :func:`~.pennylane.qchem.import_state` function that takes a PySCF solver object,
+# extracts the wave function and returns a state vector in the computational basis that can be used
+# in a quantum circuit. Let’s look at an example.
 #
 # First, we run CCSD calculations for the hydrogen molecule to obtain the solver object.
 

--- a/demonstrations/tutorial_qchem_external.py
+++ b/demonstrations/tutorial_qchem_external.py
@@ -137,12 +137,12 @@ print(f'Estimated number of logical qubits: {algo.qubits}')
 ##############################################################################
 # Importing initial states
 # ------------------------
-# Simulating molecules with quantum algorithms require defining an initial state that should have
-# a none-zero overlap with the molecular ground state. A trivial choice for the initial state is the
+# Simulating molecules with quantum algorithms requires defining an initial state that should have
+# non-zero overlap with the molecular ground state. A trivial choice for the initial state is the
 # Hartree-Fock state which is obtained by putting the electrons in the lowest-energy molecular
-# orbitals. For molecules with a complicated electronic structure, the Hartree-Fock state has does
-# not have a large overlap with the ground state which makes executing quantum algorithms
-# non-efficient.
+# orbitals. For molecules with a complicated electronic structure, the Hartree-Fock state has
+# only a small overlap with the ground state, which makes executing quantum algorithms
+# inefficient.
 #
 # Initial states obtained from affordable post-Hartree-Fock calculations can be used to make the
 # quantum workflow more performant. For instance, configuration interaction (CI) and coupled cluster
@@ -161,8 +161,8 @@ myhf = scf.RHF(mol).run()
 mycc = cc.CCSD(myhf).run()
 
 ##############################################################################
-# Then, we use the :func:`~.pennylane.qchem.import_state` function can now be used to obtain the
-# tate vector.
+# Then, we use the :func:`~.pennylane.qchem.import_state` function to obtain the
+# state vector.
 
 state = qml.qchem.import_state(mycc)
 print(state)

--- a/demonstrations/tutorial_qchem_external.py
+++ b/demonstrations/tutorial_qchem_external.py
@@ -19,9 +19,12 @@ Using PennyLane with PySCF and OpenFermion
 The quantum chemistry module in PennyLane, :mod:`qml.qchem  <pennylane.qchem>`, provides built-in
 methods to compute molecular integrals, solve Hartree-Fock equations, and construct
 `fully-differentiable <https://pennylane.ai/qml/demos/tutorial_differentiable_HF.html>`_ molecular
-Hamiltonians. However, there are many other interesting and widely used quantum chemistry libraries out there. Instead of reinventing the wheel, PennyLane lets you to take advantage of various external resources and libraries to build upon existing research. In this demo we will show you how to integrate PennyLane with `PySCF <https://github.com/sunqm/pyscf>`_ and
-`OpenFermion <https://github.com/quantumlib/OpenFermion>`_ to compute molecular integrals and
-construct molecular Hamiltonians.
+Hamiltonians. However, there are many other interesting and widely used quantum chemistry libraries
+out there. Instead of reinventing the wheel, PennyLane lets you take advantage of various
+external resources and libraries to build upon existing research. In this demo we will show you how
+to integrate PennyLane with `PySCF <https://github.com/sunqm/pyscf>`_ and
+`OpenFermion <https://github.com/quantumlib/OpenFermion>`_ to compute molecular integrals,
+construct molecular Hamiltonians, and import initial states.
 
 Building molecular Hamiltonians
 -------------------------------
@@ -130,6 +133,16 @@ algo = qml.resource.DoubleFactorization(one_mo, two_mo)
 
 print(f'Estimated number of non-Clifford gates: {algo.gates:.2e}')
 print(f'Estimated number of logical qubits: {algo.qubits}')
+
+##############################################################################
+# Importing initial states
+# ------------------------
+# Simulating molecules with quantum algorithms require defining an initial state that should have
+# a none-zero overlap with the molecular ground state. A trivial choice for the initial state is the
+# Hartree-Fock state which is obtained by putting the electrons in the lowest-energy molecular
+# orbitals. For molecules with a complicated electronic structure, the Hartree-Fock state has does
+# not have a large overlap with the ground state which makes executing quantum algorithms
+# non-efficient.
 
 ##############################################################################
 # Conclusions

--- a/demonstrations/tutorial_qchem_external.py
+++ b/demonstrations/tutorial_qchem_external.py
@@ -144,6 +144,33 @@ print(f'Estimated number of logical qubits: {algo.qubits}')
 # not have a large overlap with the ground state which makes executing quantum algorithms
 # non-efficient.
 
+# Initial states obtained from affordable post-Hartree-Fock calculations can be used to make the
+# quantum workflow more performant. For instance, configuration interaction (CI) and coupled cluster
+# (CC) calculations with single and double (SD) excitations can be performed using PySCF and the
+# resulting wave function can be used as the initial state in the quantum algorithm. PennyLane
+# provides the import_state function that takes a PySCF solver object, extracts the wave function
+# and returns a state vector in the computational basis that can be used in a quantum circuit. Let’s
+# look at an example.
+#
+# First, we run CCSD calculations for the hydrogen molecule to obtain the solver object.
+
+from pyscf import gto, scf, cc
+
+mol = gto.M(atom=[['H', (0, 0, 0)], ['H', (0, 0, 0.7)]])
+myhf = scf.RHF(mol).run()
+mycc = cc.CCSD(myhf).run()
+
+##############################################################################
+# Then, we use the :func:`~.pennylane.qchem.import_state` function can now be used to obtain the
+# tate vector.
+
+state = qml.qchem.import_state(mycc)
+print(state)
+
+##############################################################################
+# You can verify that this state is a superposition of the Hartree-Fock state and a doubly-excited
+# state.
+
 ##############################################################################
 # Conclusions
 # -----------
@@ -157,8 +184,10 @@ print(f'Estimated number of logical qubits: {algo.qubits}')
 #    the argument ``method=pyscf`` to the :func:`~.pennylane.qchem.molecular_hamiltonian` function.
 # 2. We can directly use one- and two-electron integrals from PySCF, but we need to convert the
 #    tensor containing the two-electron integrals from chemists' notation to physicists' notation.
-# 3. Finally, we can easily convert OpenFermion operators to PennyLane operators using the 
+# 3. We can easily convert OpenFermion operators to PennyLane operators using the
 #    :func:`~.pennylane.import_operator` function.
+# 4. Finally, we can convert PySCF wave functions to PennyLane state vectors using the
+#    :func:`~.pennylane.qchem.import_state` function.
 #
 # About the author
 # ----------------


### PR DESCRIPTION
**Title:**

**Summary:**
Adds a section to the  PySCF demo explaining how to import initial states.

**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**
