### PR TITLE
Interactive demo assets base path fix

### DIFF
--- a/_static/demos/circuits_as_fourier_series/sketch.js
+++ b/_static/demos/circuits_as_fourier_series/sketch.js
@@ -1,11 +1,4 @@
-var url_prefix = '../../_static/demos/circuits_as_fourier_series/src/';
-
- fetch(url_prefix + 'fourier0-1.png', {method: 'HEAD'}).then(res => {
-     if (!res.ok) {
-         url_prefix = '../_static/demos/circuits_as_fourier_series/src/';
-     }
- });
-
+const url_prefix = '/_static/demos/circuits_as_fourier_series/src/';
 
 ///// Sketch 0
 


### PR DESCRIPTION
## Changes
* Make asset past constant with respect to root of PennyLane Website
* This fixes assets not loading for [interactive demo](https://pennylane.ai/qml/demos/circuits_as_fourier_series/)


## Note 
- this might not work correctly with current QML preview, but will work on react site.
- this will work with https://github.com/PennyLaneAI/qml/pull/967