### PR TITLE
Added warning to hybrid jobs demo (v0.32 compatibility). 

### DIFF
--- a/demonstrations/getting_started_with_hybrid_jobs.py
+++ b/demonstrations/getting_started_with_hybrid_jobs.py
@@ -52,7 +52,7 @@ Let’s setup an algorithm that makes use of both classical and quantum resource
 
 .. warning::
 
-    The following demo is only compatible with Python version 3.10.
+    The following demo is only compatible with Python version 3.10 and PennyLane v0.32.
 
 """
 

--- a/demonstrations/getting_started_with_hybrid_jobs.py
+++ b/demonstrations/getting_started_with_hybrid_jobs.py
@@ -323,7 +323,7 @@ def qpu_qubit_rotation_hybrid_job(num_steps=10, stepsize=0.5):
 ######################################################################
 # To get a sense of how long we will wait before the hybrid job runs, we can check the hybrid job
 # queue depth with ``AwsDevice(device_arn).queue_depth().jobs``. We can also check if the device is
-# currently available with ``AwsDevice(device_arn).is_available()``.
+# currently available with ``AwsDevice(device_arn).is_available``.
 #
 # When there are no other hybrid jobs in the queue ahead of you, and the device is available, the
 # hybrid job will start running.


### PR DESCRIPTION
Braket has v0.32, and there's picking / unpickling going on behind the scenes in the demo which causes issues when running this demo with another PennyLane version, say v0.33:

```
...
"/opt/braket/code/customer_code/extracted/decorator_job_w_t6ad3e/entry_point.py", line 63, in <module>
    recovered = cloudpickle.loads(b'…')
AttributeError: Can't get attribute '_expand_transform_finite_diff' on <module 'pennylane.gradients.finite_difference' from '/usr/local/lib/python3.10/site-packages/pennylane/gradients/finite_difference.py'>
Process exited with code: 1
```