### PR TITLE
update auto-run demos before 0.34 release

### DIFF
--- a/demonstrations/learning2learn.py
+++ b/demonstrations/learning2learn.py
@@ -241,7 +241,7 @@ def qaoa_from_graph(graph, n_layers=1):
         dev = qml.device("default.qubit.tf", wires=len(graph.nodes))
 
         # This qnode evaluates the expectation value of the cost hamiltonian operator
-        cost = qml.QNode(circuit, dev, diff_method="backprop")
+        cost = qml.QNode(circuit, dev, diff_method="backprop", interface="tf")
 
         return cost(params)
 

--- a/demonstrations/tutorial_teleportation.py
+++ b/demonstrations/tutorial_teleportation.py
@@ -313,13 +313,13 @@ _ = qml.draw_mpl(teleport, style="pennylane")(state)
 # PennyLane, when you bind a circuit to a device that does not support them,
 # it will automatically apply the principle of deferred measurement and update
 # your circuit to use controlled operations instead. Note that you need to
-# specify ``expansion_strategy="device"`` when creating the QNode for the
-# drawer to know to do device expansion before drawing.
+# specify ``expansion_strategy="device"`` when calling ``draw_mpl`` so it
+# runs the device pre-processing before drawing the circuit.
 
 dev = qml.device("default.qubit", wires=["S", "A", "B"])
 
 
-@qml.qnode(dev, expansion_strategy="device")
+@qml.qnode(dev)
 def teleport(state):
     state_preparation(state)
     entangle_qubits()
@@ -328,7 +328,7 @@ def teleport(state):
     return qml.density_matrix(wires=["B"])
 
 
-_ = qml.draw_mpl(teleport, style="pennylane")(state)
+_ = qml.draw_mpl(teleport, style="pennylane", expansion_strategy="device")(state)
 
 ##############################################################################
 #

--- a/demonstrations/tutorial_teleportation.py
+++ b/demonstrations/tutorial_teleportation.py
@@ -297,7 +297,6 @@ def teleport(state):
     state_preparation(state)
     entangle_qubits()
     basis_rotation()
-    qml.Barrier(["S", "A"], only_visual=True)
     measure_and_update()
 
 
@@ -313,12 +312,14 @@ _ = qml.draw_mpl(teleport, style="pennylane")(state)
 # working in a system that does not support mid-circuit measurements. In
 # PennyLane, when you bind a circuit to a device that does not support them,
 # it will automatically apply the principle of deferred measurement and update
-# your circuit to use controlled operations instead.
+# your circuit to use controlled operations instead. Note that you need to
+# specify ``expansion_strategy="device"`` when creating the QNode for the
+# drawer to know to do device expansion before drawing.
 
 dev = qml.device("default.qubit", wires=["S", "A", "B"])
 
 
-@qml.qnode(dev)
+@qml.qnode(dev, expansion_strategy="device")
 def teleport(state):
     state_preparation(state)
     entangle_qubits()

--- a/demonstrations/tutorial_unitary_designs.py
+++ b/demonstrations/tutorial_unitary_designs.py
@@ -481,7 +481,7 @@ def apply_noise(tape, damp_factor, depo_factor, flip_prob):
         return results[0]
 
     # Apply the original measurements
-    return (type(tape)(noisy_ops, tape.measurements),), null_postprocessing_fn
+    return (type(tape)(noisy_ops, tape.measurements, shots=tape.shots),), null_postprocessing_fn
 
 ######################################################################
 # We can now apply this transform to create a noisy version of our ideal
@@ -510,7 +510,7 @@ def conjugate_with_unitary(tape, matrix):
     def null_postprocessing_fn(results):
         return results[0]
 
-    return (type(tape)(new_ops, tape.measurements),), null_postprocessing_fn
+    return (type(tape)(new_ops, tape.measurements, shots=tape.shots),), null_postprocessing_fn
 
 ######################################################################
 # Finally, in order to perform a comparison, we need a function to compute the
@@ -583,7 +583,7 @@ def conjugate_with_clifford(tape, clifford_string):
     def null_postprocessing_fn(results):
         return results[0]
 
-    return (type(tape)(new_ops, tape.measurements),), null_postprocessing_fn
+    return (type(tape)(new_ops, tape.measurements, shots=tape.shots),), null_postprocessing_fn
 
 ######################################################################
 # You may have noticed this transform has exactly the same form as


### PR DESCRIPTION
- learning2learn was failing because we call a QNode with a vanilla list of parameters at some point, and it wrongly auto-assumed that the interface was `autograd`. Not sure why this only came up now, but forcing it to `tf` fixes it
- the Barrier in the teleportation demo was just to make it look like the two measurements happen simultaneously, but that doesn't happen anymore regardless... so I removed it
- the second full circuit MPL drawing (with the QNode) is supposed to show that defer_measurements is applied, so I had to add `expansion_strategy="device"` to the QNode to make sure it is applied (it used to be applied at qnode-level, but now it's part of device pre-processing)
  - question: should I put the kwarg in the qnode construction, or in the invocation of `draw_mpl`? I think they both accept it
- unitary_designs was using the old `qfunc_transform` and a warning was being raised. Updated to the new `transform` API to avoid the warning