### PR TITLE
fix qml-dev: enable x64 

### DIFF
--- a/demonstrations/adjoint_diff_benchmarking.py
+++ b/demonstrations/adjoint_diff_benchmarking.py
@@ -25,6 +25,7 @@ import pennylane as qml
 import jax
 
 jax.config.update("jax_platform_name", "cpu")
+jax.config.update('jax_enable_x64', True)
 
 plt.style.use("bmh")
 

--- a/demonstrations/tutorial_backprop.py
+++ b/demonstrations/tutorial_backprop.py
@@ -60,6 +60,7 @@ from matplotlib import pyplot as plt
 import jax
 
 jax.config.update("jax_platform_name", "cpu")
+jax.config.update('jax_enable_x64', True)
 
 # set the random seed
 key = jax.random.PRNGKey(42)


### PR DESCRIPTION
The following error appears:

`ValueError: Cannot return 64-bit values when jax_enable_x64 is disabled`

To fix it, it has been activated in the specific demo.