### PR TITLE
fixing demo links

### DIFF
--- a/demonstrations/tutorial_mitigation_advantage.metadata.json
+++ b/demonstrations/tutorial_mitigation_advantage.metadata.json
@@ -66,7 +66,7 @@
         },
         {
             "type": "demonstration",
-            "id": "tutorial_diffable_mitigation",
+            "id": "tutorial_diffable-mitigation",
             "weight": 1.0
         }
     ]

--- a/demonstrations/tutorial_neutral_atoms.metadata.json
+++ b/demonstrations/tutorial_neutral_atoms.metadata.json
@@ -109,12 +109,12 @@
         },
         {
             "type": "demonstration",
-            "id": "tutorial_ahs_aquila",
+            "id": "ahs_aquila",
             "weight": 1.0
         },
         {
             "type": "demonstration",
-            "id": "pulse_programming101",
+            "id": "tutorial_pulse_programming101",
             "weight": 1.0
         },
         {

--- a/demonstrations/tutorial_stochastic_parameter_shift.metadata.json
+++ b/demonstrations/tutorial_stochastic_parameter_shift.metadata.json
@@ -62,11 +62,6 @@
     "referencedByPapers": [],
     "relatedContent": [
         {
-            "type": "glossary_entry",
-            "id": "parameter_shift",
-            "weight": 1.0
-        },
-        {
             "type": "demonstration",
             "id": "tutorial_backprop",
             "weight": 1.0


### PR DESCRIPTION
The links to the demos did not work due to errors in the metadata. It has been updated. I have removed the reference to a term from the glossary.