### PR TITLE
Update Rigetti demos

### DIFF
--- a/demonstrations/ensemble_multi_qpu.py
+++ b/demonstrations/ensemble_multi_qpu.py
@@ -136,10 +136,24 @@ def plot_points(x_train, y_train, x_test, y_test):
         Patch(facecolor=colours[0], edgecolor=c_transparent, label="Class 0"),
         Patch(facecolor=colours[1], edgecolor=c_transparent, label="Class 1"),
         Patch(facecolor=colours[2], edgecolor=c_transparent, label="Class 2"),
-        Line2D([0], [0], marker="o", color=c_transparent, label="Train",
-               markerfacecolor="black", markersize=10),
-        Line2D([0], [0], marker="x", color=c_transparent, label="Test",
-               markerfacecolor="black", markersize=10),
+        Line2D(
+            [0],
+            [0],
+            marker="o",
+            color=c_transparent,
+            label="Train",
+            markerfacecolor="black",
+            markersize=10,
+        ),
+        Line2D(
+            [0],
+            [0],
+            marker="x",
+            color=c_transparent,
+            label="Test",
+            markerfacecolor="black",
+            markersize=10,
+        ),
     ]
 
     ax.legend(handles=custom_lines, bbox_to_anchor=(1.0, 0.75))
@@ -254,15 +268,15 @@ qnodes = [
 # predictions faster because we do not need to wait for one QPU to output before running on the
 # other.
 
+
 def decision(softmax):
     return int(torch.argmax(softmax))
 
 
 def predict_point(params, x_point=None, parallel=True):
     if parallel:
-        results = tuple(dask.delayed(q)(params, x=x_point) for q in qnodes)
-        results = dask.compute(*results, scheduler="threads")
-        results = torch.tensor(torch.vstack(results))
+        results = tuple(dask.delayed(q)(params, x=torch.from_numpy(x_point)) for q in qnodes)
+        results = torch.tensor(dask.compute(*results, scheduler="threads"))
     else:
         results = tuple(q(params, x=x_point) for q in qnodes)
         results = torch.tensor(results)
@@ -356,6 +370,7 @@ def accuracy(predictions, actuals):
     accuracy = count / (len(predictions))
     return accuracy
 
+
 ##############################################################################
 
 print("Training accuracy (ensemble): {}".format(accuracy(p_train, y_train)))
@@ -446,8 +461,10 @@ predictions_0 = choices_vs_prediction_0[:, 1]
 predictions_1 = choices_vs_prediction_1[:, 1]
 
 
-expl = "When QPU{} was chosen by the ensemble, it made the following distribution of " \
-       "predictions:\n{}"
+expl = (
+    "When QPU{} was chosen by the ensemble, it made the following distribution of "
+    "predictions:\n{}"
+)
 print(expl.format("0", Counter(predictions_0)))
 print("\n" + expl.format("1", Counter(predictions_1)))
 print("\nDistribution of classes in iris dataset: {}".format(Counter(y)))
@@ -506,20 +523,37 @@ def plot_points_prediction(x, y, p, title):
     c_transparent = "#00000000"
 
     custom_lines = [
+        Patch(facecolor=colours_prediction["correct"], edgecolor=c_transparent, label="Correct"),
         Patch(
-            facecolor=colours_prediction["correct"],
-            edgecolor=c_transparent, label="Correct"
+            facecolor=colours_prediction["incorrect"], edgecolor=c_transparent, label="Incorrect"
         ),
-        Patch(
-            facecolor=colours_prediction["incorrect"],
-            edgecolor=c_transparent, label="Incorrect"
+        Line2D(
+            [0],
+            [0],
+            marker=markers[0],
+            color=c_transparent,
+            label="Class 0",
+            markerfacecolor="black",
+            markersize=10,
         ),
-        Line2D([0], [0], marker=markers[0], color=c_transparent, label="Class 0",
-               markerfacecolor="black", markersize=10),
-        Line2D([0], [0], marker=markers[1], color=c_transparent, label="Class 1",
-               markerfacecolor="black", markersize=10),
-        Line2D([0], [0], marker=markers[2], color=c_transparent, label="Class 2",
-               markerfacecolor="black", markersize=10),
+        Line2D(
+            [0],
+            [0],
+            marker=markers[1],
+            color=c_transparent,
+            label="Class 1",
+            markerfacecolor="black",
+            markersize=10,
+        ),
+        Line2D(
+            [0],
+            [0],
+            marker=markers[2],
+            color=c_transparent,
+            label="Class 2",
+            markerfacecolor="black",
+            markersize=10,
+        ),
     ]
 
     ax.legend(handles=custom_lines, bbox_to_anchor=(1.0, 0.75))

--- a/demonstrations/ensemble_multi_qpu.py
+++ b/demonstrations/ensemble_multi_qpu.py
@@ -46,6 +46,16 @@ from matplotlib.patches import Patch
 # /interfaces.html>`_, which can be installed from `here
 # <https://pytorch.org/get-started/locally/>`__.
 #
+# .. warning::
+#    Rigetti's QVM and Quil Compiler services must be running for this tutorial to execute. They
+#    can be installed by consulting the `Rigetti documentation
+#    <http://docs.rigetti.com/qcs/>`__ or, for users with Docker, by running:
+#
+#    .. code-block:: bash
+#
+#        docker run -d -p 5555:5555 rigetti/quilc -R -p 5555
+#        docker run -d -p 5000:5000 rigetti/qvm -S -p 5000
+#
 # Load data
 # ---------
 #
@@ -186,15 +196,6 @@ devs = [dev0, dev1]
 #    swap ``qiskit.aer`` for ``qiskit.ibmq`` and specify their chosen backend (see `here
 #    <https://docs.pennylane.ai/projects/qiskit/en/latest/devices/ibmq.html>`__).
 #
-# .. warning::
-#    Rigetti's QVM and Quil Compiler services must be running for this tutorial to execute. They
-#    can be installed by consulting the `Rigetti documentation
-#    <http://docs.rigetti.com/qcs/>`__ or, for users with Docker, by running:
-#
-#    .. code-block:: bash
-#
-#        docker run -d -p 5555:5555 rigetti/quilc -R -p 5555
-#        docker run -d -p 5000:5000 rigetti/qvm -S -p 5000
 #
 # The circuits for both QPUs are shown in the figure below:
 #

--- a/demonstrations/ensemble_multi_qpu.py
+++ b/demonstrations/ensemble_multi_qpu.py
@@ -136,24 +136,10 @@ def plot_points(x_train, y_train, x_test, y_test):
         Patch(facecolor=colours[0], edgecolor=c_transparent, label="Class 0"),
         Patch(facecolor=colours[1], edgecolor=c_transparent, label="Class 1"),
         Patch(facecolor=colours[2], edgecolor=c_transparent, label="Class 2"),
-        Line2D(
-            [0],
-            [0],
-            marker="o",
-            color=c_transparent,
-            label="Train",
-            markerfacecolor="black",
-            markersize=10,
-        ),
-        Line2D(
-            [0],
-            [0],
-            marker="x",
-            color=c_transparent,
-            label="Test",
-            markerfacecolor="black",
-            markersize=10,
-        ),
+        Line2D([0], [0], marker="o", color=c_transparent, label="Train",
+               markerfacecolor="black", markersize=10),
+        Line2D([0], [0], marker="x", color=c_transparent, label="Test",
+               markerfacecolor="black", markersize=10),
     ]
 
     ax.legend(handles=custom_lines, bbox_to_anchor=(1.0, 0.75))
@@ -268,7 +254,6 @@ qnodes = [
 # predictions faster because we do not need to wait for one QPU to output before running on the
 # other.
 
-
 def decision(softmax):
     return int(torch.argmax(softmax))
 
@@ -370,7 +355,6 @@ def accuracy(predictions, actuals):
     accuracy = count / (len(predictions))
     return accuracy
 
-
 ##############################################################################
 
 print("Training accuracy (ensemble): {}".format(accuracy(p_train, y_train)))
@@ -461,10 +445,8 @@ predictions_0 = choices_vs_prediction_0[:, 1]
 predictions_1 = choices_vs_prediction_1[:, 1]
 
 
-expl = (
-    "When QPU{} was chosen by the ensemble, it made the following distribution of "
-    "predictions:\n{}"
-)
+expl = "When QPU{} was chosen by the ensemble, it made the following distribution of " \
+       "predictions:\n{}"
 print(expl.format("0", Counter(predictions_0)))
 print("\n" + expl.format("1", Counter(predictions_1)))
 print("\nDistribution of classes in iris dataset: {}".format(Counter(y)))
@@ -523,37 +505,20 @@ def plot_points_prediction(x, y, p, title):
     c_transparent = "#00000000"
 
     custom_lines = [
-        Patch(facecolor=colours_prediction["correct"], edgecolor=c_transparent, label="Correct"),
         Patch(
-            facecolor=colours_prediction["incorrect"], edgecolor=c_transparent, label="Incorrect"
+            facecolor=colours_prediction["correct"],
+            edgecolor=c_transparent, label="Correct"
         ),
-        Line2D(
-            [0],
-            [0],
-            marker=markers[0],
-            color=c_transparent,
-            label="Class 0",
-            markerfacecolor="black",
-            markersize=10,
+        Patch(
+            facecolor=colours_prediction["incorrect"],
+            edgecolor=c_transparent, label="Incorrect"
         ),
-        Line2D(
-            [0],
-            [0],
-            marker=markers[1],
-            color=c_transparent,
-            label="Class 1",
-            markerfacecolor="black",
-            markersize=10,
-        ),
-        Line2D(
-            [0],
-            [0],
-            marker=markers[2],
-            color=c_transparent,
-            label="Class 2",
-            markerfacecolor="black",
-            markersize=10,
-        ),
+        Line2D([0], [0], marker=markers[0], color=c_transparent, label="Class 0",
+               markerfacecolor="black", markersize=10),
+        Line2D([0], [0], marker=markers[1], color=c_transparent, label="Class 1",
+               markerfacecolor="black", markersize=10),
+        Line2D([0], [0], marker=markers[2], color=c_transparent, label="Class 2",
+               markerfacecolor="black", markersize=10),
     ]
 
     ax.legend(handles=custom_lines, bbox_to_anchor=(1.0, 0.75))

--- a/demonstrations/pytorch_noise.py
+++ b/demonstrations/pytorch_noise.py
@@ -25,9 +25,26 @@ Amazon Braket.
 To follow along with this tutorial on your own computer, you will require the
 following dependencies:
 
-* The `Rigetti SDK <https://qcs.rigetti.com/sdk-downloads>`_, which contains the quantum virtual
+# .. warning::
+#    Rigetti's QVM and Quil Compiler services must be running for this tutorial to execute. They
+#    can be installed by consulting the `Rigetti documentation
+#    <http://docs.rigetti.com/qcs/>`__ or,
+#
+#    .. code-block:: bash
+#
+#        docker run -d -p 5555:5555 rigetti/quilc -R -p 5555
+#        docker run -d -p 5000:5000 rigetti/qvm -S -p 5000
+
+* Rigetti's QVM and Quil Compiler services. One option for setting this up is the
+  `Rigetti SDK <https://qcs.rigetti.com/sdk-downloads>`_, which contains the quantum virtual
   machine (QVM) and quilc quantum compiler. Once installed, the QVM and quilc can be
   started by running the commands ``quilc -S`` and ``qvm -S`` in separate terminal windows.
+  Alternatively, for users with Docker, the QVM and Quil Compiler services can be run with commands:
+
+    .. code-block:: bash
+
+        docker run -d -p 5555:5555 rigetti/quilc -R -p 5555
+        docker run -d -p 5000:5000 rigetti/qvm -S -p 5000
 
 * `PennyLane-Rigetti plugin <https://docs.pennylane.ai/projects/rigetti/en/latest/>`_, in order
   to access the QVM as a PennyLane device. This can be installed via pip:
@@ -198,7 +215,7 @@ my_bucket = "amazon-braket-Your-Bucket-Name"  # the name of the bucket
 my_prefix = "Your-Folder-Name"  # the name of the folder in the bucket
 s3_folder = (my_bucket, my_prefix)
 
-device_arn = "arn:aws:braket:us-west-1::device/qpu/rigetti/Aspen-M-2"
+device_arn = "arn:aws:braket:us-west-1::device/qpu/rigetti/Aspen-M-3"
 
 qpu = qml.device(
     "braket.aws.qubit",
@@ -208,7 +225,7 @@ qpu = qml.device(
 )
 
 # Note: swap dev to qpu here to use the QPU
-# Warning: check the pricing of Aspen-M-2 on Braket to make
+# Warning: check the pricing of Aspen-M-3 on Braket to make
 # sure you are aware of the costs associated with running the
 # optimization below.
 @qml.qnode(dev, interface="torch")

--- a/demonstrations/pytorch_noise.py
+++ b/demonstrations/pytorch_noise.py
@@ -31,10 +31,10 @@ following dependencies:
   started by running the commands ``quilc -S`` and ``qvm -S`` in separate terminal windows.
   Alternatively, for users with Docker, the QVM and Quil Compiler services can be run with commands:
 
-    .. code-block:: bash
+  .. code-block:: bash
 
-        docker run -d -p 5555:5555 rigetti/quilc -R -p 5555
-        docker run -d -p 5000:5000 rigetti/qvm -S -p 5000
+      docker run -d -p 5555:5555 rigetti/quilc -R -p 5555
+      docker run -d -p 5000:5000 rigetti/qvm -S -p 5000
 
 * `PennyLane-Rigetti plugin <https://docs.pennylane.ai/projects/rigetti/en/latest/>`_, in order
   to access the QVM as a PennyLane device. This can be installed via pip:

--- a/demonstrations/pytorch_noise.py
+++ b/demonstrations/pytorch_noise.py
@@ -25,16 +25,6 @@ Amazon Braket.
 To follow along with this tutorial on your own computer, you will require the
 following dependencies:
 
-# .. warning::
-#    Rigetti's QVM and Quil Compiler services must be running for this tutorial to execute. They
-#    can be installed by consulting the `Rigetti documentation
-#    <http://docs.rigetti.com/qcs/>`__ or,
-#
-#    .. code-block:: bash
-#
-#        docker run -d -p 5555:5555 rigetti/quilc -R -p 5555
-#        docker run -d -p 5000:5000 rigetti/qvm -S -p 5000
-
 * Rigetti's QVM and Quil Compiler services. One option for setting this up is the
   `Rigetti SDK <https://qcs.rigetti.com/sdk-downloads>`_, which contains the quantum virtual
   machine (QVM) and quilc quantum compiler. Once installed, the QVM and quilc can be


### PR DESCRIPTION
A few updates to the Rigetti demos:

- Pytorch Noise
   - Update Aspen-M-2 to Aspen-M-3 for the hardware version (M-2 is decommissioned)
   - Add the info about connecting to Rigetti with Docker (included in the other Rigetti demos)
- Ensemble Multi QPU
   - Move the information about connecting to the Rigetti device to _before_ the section where we try to connect to the Rigetti device
   - Change how we cast to torch during prediction phase
