### PR TITLE
update dateOfLastModification for updated demos

### DIFF
--- a/demonstrations/braket-parallel-gradients.metadata.json
+++ b/demonstrations/braket-parallel-gradients.metadata.json
@@ -12,7 +12,7 @@
         }
     ],
     "dateOfPublication": "2020-12-08T00:00:00+00:00",
-    "dateOfLastModification": "2024-01-01T00:00:00+00:00",
+    "dateOfLastModification": "2024-03-04T00:00:00+00:00",
     "categories": [
         "Devices and Performance"
     ],

--- a/demonstrations/ensemble_multi_qpu.metadata.json
+++ b/demonstrations/ensemble_multi_qpu.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2020-02-14T00:00:00+00:00",
-    "dateOfLastModification": "2024-01-01T00:00:00+00:00",
+    "dateOfLastModification": "2024-03-04T00:00:00+00:00",
     "categories": [
         "Quantum Machine Learning"
     ],

--- a/demonstrations/function_fitting_qsp.metadata.json
+++ b/demonstrations/function_fitting_qsp.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2022-05-24T00:00:00+00:00",
-    "dateOfLastModification": "2024-01-01T00:00:00+00:00",
+    "dateOfLastModification": "2024-03-04T00:00:00+00:00",
     "categories": [
         "Quantum Machine Learning"
     ],

--- a/demonstrations/getting_started_with_hybrid_jobs.metadata.json
+++ b/demonstrations/getting_started_with_hybrid_jobs.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2023-10-16T00:00:00+00:00",
-    "dateOfLastModification": "2024-01-01T00:00:00+00:00",
+    "dateOfLastModification": "2024-03-04T00:00:00+00:00",
     "categories": [
         "Devices and Performance"
     ],

--- a/demonstrations/pytorch_noise.metadata.json
+++ b/demonstrations/pytorch_noise.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2019-10-11T00:00:00+00:00",
-    "dateOfLastModification": "2024-01-01T00:00:00+00:00",
+    "dateOfLastModification": "2024-03-04T00:00:00+00:00",
     "categories": [
         "Devices and Performance"
     ],

--- a/demonstrations/tutorial_apply_qsvt.metadata.json
+++ b/demonstrations/tutorial_apply_qsvt.metadata.json
@@ -9,7 +9,7 @@
         }
     ],
     "dateOfPublication": "2023-08-22T00:00:00+00:00",
-    "dateOfLastModification": "2024-01-01T00:00:00+00:00",
+    "dateOfLastModification": "2024-03-04T00:00:00+00:00",
     "categories": [
         "Quantum Computing",
         "Algorithms",

--- a/demonstrations/tutorial_classically_boosted_vqe.metadata.json
+++ b/demonstrations/tutorial_classically_boosted_vqe.metadata.json
@@ -9,7 +9,7 @@
         }
     ],
     "dateOfPublication": "2022-10-31T00:00:00+00:00",
-    "dateOfLastModification": "2024-01-01T00:00:00+00:00",
+    "dateOfLastModification": "2024-03-04T00:00:00+00:00",
     "categories": [
         "Quantum Chemistry"
     ],

--- a/demonstrations/tutorial_intro_qsvt.metadata.json
+++ b/demonstrations/tutorial_intro_qsvt.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2023-05-23T00:00:00+00:00",
-    "dateOfLastModification": "2024-01-01T00:00:00+00:00",
+    "dateOfLastModification": "2024-03-04T00:00:00+00:00",
     "categories": [
         "Algorithms",
         "Quantum Computing"

--- a/demonstrations/tutorial_lcu_blockencoding.metadata.json
+++ b/demonstrations/tutorial_lcu_blockencoding.metadata.json
@@ -12,7 +12,7 @@
         }
     ],
     "dateOfPublication": "2023-10-25T00:00:00+00:00",
-    "dateOfLastModification": "2024-01-01T00:00:00+00:00",
+    "dateOfLastModification": "2024-03-04T00:00:00+00:00",
     "categories": [
         "Algorithms",
         "Quantum Computing"

--- a/demonstrations/tutorial_neutral_atoms.metadata.json
+++ b/demonstrations/tutorial_neutral_atoms.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2023-05-30T00:00:00+00:00",
-    "dateOfLastModification": "2024-01-01T00:00:00+00:00",
+    "dateOfLastModification": "2024-03-04T00:00:00+00:00",
     "categories": [
         "Quantum Hardware",
         "Quantum Computing"

--- a/demonstrations/tutorial_qgrnn.metadata.json
+++ b/demonstrations/tutorial_qgrnn.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2020-07-27T00:00:00+00:00",
-    "dateOfLastModification": "2024-01-01T00:00:00+00:00",
+    "dateOfLastModification": "2024-03-04T00:00:00+00:00",
     "categories": [
         "Quantum Machine Learning"
     ],

--- a/demonstrations/tutorial_sc_qubits.metadata.json
+++ b/demonstrations/tutorial_sc_qubits.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2022-03-22T00:00:00+00:00",
-    "dateOfLastModification": "2024-01-01T00:00:00+00:00",
+    "dateOfLastModification": "2024-03-04T00:00:00+00:00",
     "categories": [
         "Quantum Hardware",
         "Quantum Computing"

--- a/demonstrations/tutorial_vqt.metadata.json
+++ b/demonstrations/tutorial_vqt.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2020-07-07T00:00:00+00:00",
-    "dateOfLastModification": "2024-01-01T00:00:00+00:00",
+    "dateOfLastModification": "2024-03-04T00:00:00+00:00",
     "categories": [
         "Optimization"
     ],


### PR DESCRIPTION
We didn't know we needed to update `dateOfLastModification` in all the metadata files to make the demos update on the website, so we didn't do it. This PR does it for all the demos updated this release. We will need to go back and see how much this covers of past updates, but in the interest of time, here are the ones for the 0.35 release.

Once this is merged into dev, I'll redo the step in the release process where we make a copy of `dev` and merge it into `master` and build the site.

Here are all the demos modified for the 0.35 release: #1044 