### PR TITLE
Update tutorial_How_to_optimize_QML_model_using_JAX_and_Optax.py

### DIFF
--- a/demonstrations/tutorial_How_to_optimize_QML_model_using_JAX_and_Optax.metadata.json
+++ b/demonstrations/tutorial_How_to_optimize_QML_model_using_JAX_and_Optax.metadata.json
@@ -9,7 +9,7 @@
         }
     ],
     "dateOfPublication": "2024-01-18T00:00:00+00:00",
-    "dateOfLastModification": "2024-01-18T00:00:00+00:00",
+    "dateOfLastModification": "2024-03-08T00:00:00+00:00",
     "categories": [
         "Quantum Machine Learning",
         "Optimization"


### PR DESCRIPTION
Solving issue #1045 

As indicated in the issue, the optimizer being used within the `update_step_jit` function is not the one defined in the `optimization_jit` function. I tried to pass `opt` but it gave problems so I simply defined the optimizer outside.

In the case where jit is not being applied, I was able to pass the optimizer, so I updated those functions.
Tagging @josh146 in case there is a better solution in this case