### PR TITLE
Update metadata reminder message

### DIFF
--- a/.github/workflows/update-metadata-reminder.yml
+++ b/.github/workflows/update-metadata-reminder.yml
@@ -18,7 +18,7 @@ jobs:
             repo: context.repo.repo,
             body: `👋 Hey, looks like you've updated some demos!
 
-            🐘 Don't forget to update the \`dateOfLastModification\` in the associated metadata files so your changes show up on [pennylane.ai](https://pennylane.ai).
+            🐘 Don't forget to update the \`dateOfLastModification\` in the associated metadata files so your changes are reflected in Glass Onion (search and filter).
 
             Please hide this comment once the field(s) are updated. Thanks!`
           })

--- a/.github/workflows/update-metadata-reminder.yml
+++ b/.github/workflows/update-metadata-reminder.yml
@@ -18,7 +18,7 @@ jobs:
             repo: context.repo.repo,
             body: `👋 Hey, looks like you've updated some demos!
 
-            🐘 Don't forget to update the \`dateOfLastModification\` in the associated metadata files so your changes are reflected in Glass Onion (search and filter).
+            🐘 Don't forget to update the \`dateOfLastModification\` in the associated metadata files so your changes are reflected in Glass Onion (search and recommendations).
 
             Please hide this comment once the field(s) are updated. Thanks!`
           })


### PR DESCRIPTION
Failing to update the metadata won't affect whether or not the demo shows up on pennylane.ai, but does affect whether or not the changes are reflected in Glass Onion (search and recommendations). Updated the metadata reminder message to reflect this. 