### PR TITLE
Fix canonical URL of force fields demo

### DIFF
--- a/demonstrations/tutorial_eqnn_force_field.metadata.json
+++ b/demonstrations/tutorial_eqnn_force_field.metadata.json
@@ -26,7 +26,7 @@
     ],
     "seoDescription": "What is equivariant quantum machine learning for chemistry?",
     "doi": "",
-    "canonicalURL": "/qml/demos/tutorial_eqnn-force-field",
+    "canonicalURL": "/qml/demos/tutorial_eqnn_force_field",
     "references": [
         {
             "id": "Le",

--- a/demonstrations/tutorial_eqnn_force_field.metadata.json
+++ b/demonstrations/tutorial_eqnn_force_field.metadata.json
@@ -9,7 +9,7 @@
         }
     ],
     "dateOfPublication": "2024-03-12T00:00:00+00:00",
-    "dateOfLastModification": "2024-03-12T00:00:00+00:00",
+    "dateOfLastModification": "2024-03-13T00:00:00+00:00",
     "categories": [
         "Quantum Machine Learning", "Quantum Chemistry"
     ],


### PR DESCRIPTION
**Title:**

Fix canonical URL of **Symmetry-invariant quantum machine learning force fields** demo.

**Summary:**

The canonical URL of a demo must agree with its file name. In this case, `-` must be replaced with `_`.

**Relevant references:**

_N/A_

**Possible Drawbacks:**

_N/A_

**Related GitHub Issues:**

_N/A_