### PR TITLE
Update qchem functions to use Molecule 

### DIFF
--- a/demonstrations/tutorial_adaptive_circuits.py
+++ b/demonstrations/tutorial_adaptive_circuits.py
@@ -66,7 +66,8 @@ from pennylane import numpy as np
 import time
 
 symbols = ["Li", "H"]
-geometry = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 2.969280527])
+geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.969280527]])
+molecule = qchem.Molecule(symbols, geometry)
 
 ##############################################################################
 # We now compute the molecular Hamiltonian in the
@@ -78,8 +79,7 @@ geometry = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 2.969280527])
 # state and all of the excited states.
 
 H, qubits = qchem.molecular_hamiltonian(
-    symbols,
-    geometry,
+    molecule,
     active_electrons=2,
     active_orbitals=5
 )

--- a/demonstrations/tutorial_chemical_reactions.py
+++ b/demonstrations/tutorial_chemical_reactions.py
@@ -126,10 +126,13 @@ pes_point = 0
 
 for r in r_range:
     # Change only the z coordinate of one atom
-    coordinates = np.array([0.0, 0.0, 0.0, 0.0, 0.0, r])
+    coordinates = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, r]])
+
+    # Construct the Molecule object
+    molecule = qchem.Molecule(symbols, coordinates)
 
     # Obtain the qubit Hamiltonian 
-    H, qubits = qchem.molecular_hamiltonian(symbols, coordinates, method='pyscf')
+    H, qubits = qchem.molecular_hamiltonian(molecule, method='pyscf')
 
     # define the device, optimizer and circuit
     dev = qml.device("default.qubit", wires=qubits)
@@ -280,10 +283,12 @@ hf = qml.qchem.hf_state(electrons, orbitals)
 r_range = np.arange(1.0, 3.0, 0.1)
 for r in r_range:
 
-    coordinates = np.array([0.0, 0.0, 0.0, 0.0, 0.0, r, 0.0, 0.0, 4.0])
+    coordinates = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, r], [0.0, 0.0, 4.0]])
 
     # We now specify the multiplicity
-    H, qubits = qchem.molecular_hamiltonian(symbols, coordinates, mult=multiplicity, method='pyscf')
+    molecule = qchem.Molecule(symbols, coordinates, mult=multiplicity)
+
+    H, qubits = qchem.molecular_hamiltonian(molecule, method='pyscf')
 
     dev = qml.device("default.qubit", wires=qubits)
     opt = qml.GradientDescentOptimizer(stepsize=1.5)

--- a/demonstrations/tutorial_chemical_reactions.py
+++ b/demonstrations/tutorial_chemical_reactions.py
@@ -132,7 +132,7 @@ for r in r_range:
     molecule = qchem.Molecule(symbols, coordinates)
 
     # Obtain the qubit Hamiltonian 
-    H, qubits = qchem.molecular_hamiltonian(molecule, method='pyscf')
+    H, qubits = qchem.molecular_hamiltonian(molecule, method='openfermion')
 
     # define the device, optimizer and circuit
     dev = qml.device("default.qubit", wires=qubits)
@@ -288,7 +288,7 @@ for r in r_range:
     # We now specify the multiplicity
     molecule = qchem.Molecule(symbols, coordinates, mult=multiplicity)
 
-    H, qubits = qchem.molecular_hamiltonian(molecule, method='pyscf')
+    H, qubits = qchem.molecular_hamiltonian(molecule, method='openfermion')
 
     dev = qml.device("default.qubit", wires=qubits)
     opt = qml.GradientDescentOptimizer(stepsize=1.5)

--- a/demonstrations/tutorial_classically_boosted_vqe.py
+++ b/demonstrations/tutorial_classically_boosted_vqe.py
@@ -107,15 +107,13 @@ from pennylane import qchem
 from pennylane import numpy as np
 
 symbols = ["H", "H"]
-coordinates = np.array([0.0, 0.0, -0.6614, 0.0, 0.0, 0.6614])
+coordinates = np.array([[0.0, 0.0, -0.6614], [0.0, 0.0, 0.6614]])
 basis_set = "sto-3g"
 electrons = 2
 
-H, qubits = qchem.molecular_hamiltonian(
-    symbols,
-    coordinates,
-    basis=basis_set,
-)
+molecule = qchem.Molecule(symbols, coordinates, basis_name=basis_set)
+
+H, qubits = qchem.molecular_hamiltonian(molecule)
 
 
 ######################################################################
@@ -266,14 +264,12 @@ print("Optimal parameters:", theta_opt)
 #
 
 symbols = ["H", "H"]
-coordinates = np.array([0.0, 0.0, -0.6614, 0.0, 0.0, 0.6614])
+coordinates = np.array([[0.0, 0.0, -0.6614], [0.0, 0.0, 0.6614]])
 basis_set = "sto-3g"
 
-H, qubits = qchem.molecular_hamiltonian(
-    symbols,
-    coordinates,
-    basis=basis_set,
-)
+molecule = qchem.Molecule(symbols, coordinates, basis_name=basis_set)
+
+H, qubits = qchem.molecular_hamiltonian(molecule)
 
 
 ######################################################################

--- a/demonstrations/tutorial_diffable_shadows.py
+++ b/demonstrations/tutorial_diffable_shadows.py
@@ -361,15 +361,12 @@ plt.show()
 # We start by building the Hamiltonian and enforcing qwc groups by setting ``grouping_type='qwc'``.
 
 symbols = ["H", "O", "H"]
-coordinates = np.array([-0.0399, -0.0038, 0.0, 1.5780, 0.8540, 0.0, 2.7909, -0.5159, 0.0])
-
+coordinates = np.array([[-0.0399, -0.0038, 0.0], [1.5780, 0.8540, 0.0], [2.7909, -0.5159, 0.0]])
 basis_set = "sto-3g"
+
+molecule = qml.qchem.Molecule(symbols, coordinates, basis_name=basis_set)
+
 H, n_wires = qml.qchem.molecular_hamiltonian(
-    symbols,
-    coordinates,
-    charge=0,
-    mult=1,
-    basis=basis_set,
     active_electrons=4,
     active_orbitals=4,
     mapping="bravyi_kitaev",

--- a/demonstrations/tutorial_diffable_shadows.py
+++ b/demonstrations/tutorial_diffable_shadows.py
@@ -367,6 +367,7 @@ basis_set = "sto-3g"
 molecule = qml.qchem.Molecule(symbols, coordinates, basis_name=basis_set)
 
 H, n_wires = qml.qchem.molecular_hamiltonian(
+    molecule,
     active_electrons=4,
     active_orbitals=4,
     mapping="bravyi_kitaev",

--- a/demonstrations/tutorial_diffable_shadows.py
+++ b/demonstrations/tutorial_diffable_shadows.py
@@ -371,7 +371,7 @@ H, n_wires = qml.qchem.molecular_hamiltonian(
     active_electrons=4,
     active_orbitals=4,
     mapping="bravyi_kitaev",
-    method="pyscf",
+    method="openfermion",
 )
 
 coeffs, obs = H.terms()

--- a/demonstrations/tutorial_differentiable_HF.py
+++ b/demonstrations/tutorial_differentiable_HF.py
@@ -269,8 +269,7 @@ def energy(mol):
     def circuit(*args):
         qml.BasisState(np.array([1, 1, 0, 0]), wires=range(4))
         qml.DoubleExcitation(*args[0][0], wires=[0, 1, 2, 3])
-        H = qml.qchem.molecular_hamiltonian(mol, alpha=mol.alpha,
-                                            coeff=mol.coeff, args=args[1:])[0]
+        H = qml.qchem.molecular_hamiltonian(mol, args=args[1:])[0]
         return qml.expval(H)
     return circuit
 

--- a/demonstrations/tutorial_differentiable_HF.py
+++ b/demonstrations/tutorial_differentiable_HF.py
@@ -251,9 +251,7 @@ plt.show()
 # over molecular orbitals that can be used to construct the molecular Hamiltonian with the
 # :func:`~.pennylane.qchem.molecular_hamiltonian` function.
 
-hamiltonian, qubits = qml.qchem.molecular_hamiltonian(mol.symbols,
-                                                      mol.coordinates,
-                                                      args=[mol.coordinates])
+hamiltonian, qubits = qml.qchem.molecular_hamiltonian(mol, args=[mol.coordinates])
 print(hamiltonian)
 
 ##############################################################################
@@ -271,7 +269,7 @@ def energy(mol):
     def circuit(*args):
         qml.BasisState(np.array([1, 1, 0, 0]), wires=range(4))
         qml.DoubleExcitation(*args[0][0], wires=[0, 1, 2, 3])
-        H = qml.qchem.molecular_hamiltonian(mol.symbols, mol.coordinates, alpha=mol.alpha,
+        H = qml.qchem.molecular_hamiltonian(mol, alpha=mol.alpha,
                                             coeff=mol.coeff, args=args[1:])[0]
         return qml.expval(H)
     return circuit

--- a/demonstrations/tutorial_error_mitigation.py
+++ b/demonstrations/tutorial_error_mitigation.py
@@ -462,7 +462,7 @@ noisy_energies = []
 
 for r, phi in zip(distances, params):
     # Assume atoms lie on the Z axis
-    coordinates = np.array([0.0, 0.0, 0.0, 0.0, 0.0, r])
+    coordinates = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, r]])
 
     # Construct Molecule object
     molecule = qchem.Molecule(symbols, coordinates)
@@ -491,7 +491,7 @@ mitig_energies = []
 
 for r, phi in zip(distances, params):
     # Assume atoms lie on the Z axis
-    coordinates = np.array([0.0, 0.0, 0.0, 0.0, 0.0, r])
+    coordinates = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, r]])
 
     # Construct Molecule object
     molecule = qchem.Molecule(symbols, coordinates)

--- a/demonstrations/tutorial_error_mitigation.py
+++ b/demonstrations/tutorial_error_mitigation.py
@@ -464,8 +464,11 @@ for r, phi in zip(distances, params):
     # Assume atoms lie on the Z axis
     coordinates = np.array([0.0, 0.0, 0.0, 0.0, 0.0, r])
 
-    # Load qubit Hamiltonian
-    H, _ = qchem.molecular_hamiltonian(symbols, coordinates)
+    # Construct Molecule object
+    molecule = qchem.Molecule(symbols, coordinates)
+
+    # Build qubit Hamiltonian
+    H, _ = qchem.molecular_hamiltonian(molecule)
 
     # Define ansatz circuit
     def qchem_circuit(phi):
@@ -490,8 +493,11 @@ for r, phi in zip(distances, params):
     # Assume atoms lie on the Z axis
     coordinates = np.array([0.0, 0.0, 0.0, 0.0, 0.0, r])
 
-    # Load qubit Hamiltonian
-    H, _ = qchem.molecular_hamiltonian(symbols, coordinates)
+    # Construct Molecule object
+    molecule = qchem.Molecule(symbols, coordinates)
+
+    # Build qubit Hamiltonian
+    H, _ = qchem.molecular_hamiltonian(molecule)
 
     # Define ansatz circuit
     ops = [qml.PauliX(0), qml.PauliX(1), qml.DoubleExcitation(phi, wires=range(n_wires))]

--- a/demonstrations/tutorial_initial_state_preparation.py
+++ b/demonstrations/tutorial_initial_state_preparation.py
@@ -228,8 +228,9 @@ from pennylane import qchem
 # generate the molecular Hamiltonian for H3+
 symbols = ["H", "H", "H"]
 geometry = np.array([[0, 0, 0], [0, 0, R/0.529], [0, 0, 2*R/0.529]])
+molecule = qchem.Molecule(symbols, geometry, charge=1)
 
-H2mol, qubits = qchem.molecular_hamiltonian(symbols, geometry, charge=1)
+H2mol, qubits = qchem.molecular_hamiltonian(molecule)
 wires = list(range(qubits))
 dev = qml.device("default.qubit", wires=qubits)
 

--- a/demonstrations/tutorial_mol_geo_opt.py
+++ b/demonstrations/tutorial_mol_geo_opt.py
@@ -126,7 +126,8 @@ import pennylane as qml
 
 
 def H(x):
-    return qml.qchem.molecular_hamiltonian(symbols, x, charge=1)[0]
+    molecule = qml.qchem.Molecule(symbols, x, charge=1)
+    return qml.qchem.molecular_hamiltonian(molecule)[0]
 
 
 ##############################################################################

--- a/demonstrations/tutorial_qchem_external.py
+++ b/demonstrations/tutorial_qchem_external.py
@@ -54,8 +54,9 @@ symbols = ["H", "O", "H"]
 geometry = np.array([[-0.0399, -0.0038, 0.0000],
                      [ 1.5780,  0.8540, 0.0000],
                      [ 2.7909, -0.5159, 0.0000]], requires_grad = False)
+molecule = qml.qchem.Molecule(symbols, geometry)
 
-H, qubits = qml.qchem.molecular_hamiltonian(symbols, geometry, method="pyscf")
+H, qubits = qml.qchem.molecular_hamiltonian(molecule, method="pyscf")
 print(H)
 
 ##############################################################################

--- a/demonstrations/tutorial_quantum_chemistry.py
+++ b/demonstrations/tutorial_quantum_chemistry.py
@@ -239,7 +239,7 @@ molecule = qchem.Molecule(
     coordinates,
     charge=charge,
     mult=multiplicity,
-    basis=basis_set
+    basis_name=basis_set
 )
 
 H, qubits = qchem.molecular_hamiltonian(

--- a/demonstrations/tutorial_quantum_chemistry.py
+++ b/demonstrations/tutorial_quantum_chemistry.py
@@ -69,7 +69,7 @@ array with the nuclear coordinates in
 import numpy as np
 
 symbols = ["H", "O", "H"]
-coordinates = np.array([-0.0399, -0.0038, 0.0, 1.5780, 0.8540, 0.0, 2.7909, -0.5159, 0.0])
+coordinates = np.array([[-0.0399, -0.0038, 0.0], [1.5780, 0.8540, 0.0], [2.7909, -0.5159, 0.0]])
 
 ##############################################################################
 # The :func:`~.pennylane.qchem.read_structure` function can also be used to read the
@@ -143,10 +143,11 @@ symbols, coordinates = qchem.read_structure("h2o.xyz")
 #
 # In PennyLane we have the :func:`~.pennylane.qchem.molecular_hamiltonian`
 # function which encapsulates all the steps explained above. It simplifies the process of building
-# the electronic Hamiltonian to a single line of code. We just need to input the
-# symbols and the nuclear coordinates of the molecule, as shown below:
+# the electronic Hamiltonian to a single line of code. We just need to input
+# the molecule, as shown below:
 
-H, qubits = qchem.molecular_hamiltonian(symbols, coordinates)
+molecule = qchem.Molecule(symbols, coordinates)
+H, qubits = qchem.molecular_hamiltonian(molecule)
 print("Number of qubits: {:}".format(qubits))
 print("Qubit Hamiltonian")
 print(H)
@@ -154,7 +155,7 @@ print(H)
 ##############################################################################
 # Advanced features
 # -----------------
-# The :func:`~.pennylane.qchem.molecular_hamiltonian` function allows us to define additional
+# The :class:`~.pennylane.qchem.Molecule` object allows us to define additional
 # keyword arguments to solve the Hartree-Fock equations of more complicated systems.
 # The net charge of the molecule may be specified to simulate positively or negatively
 # charged molecules. For a neutral system we choose
@@ -214,7 +215,7 @@ basis_set = "sto-3g"
 #     to perform the quantum simulations.
 #
 # For the water molecule in a minimal basis set we have a total of ten electrons
-# and seven molecular orbitals. In this example we define an symmetric active space with
+# and seven molecular orbitals. In this example we define a symmetric active space with
 # four electrons and four active orbitals using
 # the :func:`~.pennylane.qchem.active_space` function:
 
@@ -233,12 +234,16 @@ print("Number of qubits: {:}".format(2 * len(active)))
 # Finally, we use the :func:`~.pennylane.qchem.molecular_hamiltonian` function to
 # build the resulting Hamiltonian of the water molecule:
 
-H, qubits = qchem.molecular_hamiltonian(
+molecule = qchem.Molecule(
     symbols,
     coordinates,
     charge=charge,
     mult=multiplicity,
-    basis=basis_set,
+    basis=basis_set
+)
+
+H, qubits = qchem.molecular_hamiltonian(
+    molecule,
     active_electrons=4,
     active_orbitals=4,
 )
@@ -261,7 +266,8 @@ print(H)
 # backend can be selected by setting ``method='pyscf'`` in
 # :func:`~.pennylane.qchem.molecular_hamiltonian`:
 
-H, qubits = qchem.molecular_hamiltonian(symbols, coordinates, method="pyscf")
+molecule = qchem.Molecule(symbols, coordinates)
+H, qubits = qchem.molecular_hamiltonian(molecule, method="pyscf")
 print(H)
 
 ##############################################################################

--- a/demonstrations/tutorial_qubit_tapering.py
+++ b/demonstrations/tutorial_qubit_tapering.py
@@ -128,7 +128,8 @@ symbols = ["He", "H"]
 geometry = np.array([[0.00000000, 0.00000000, -0.87818361],
                      [0.00000000, 0.00000000,  0.87818362]])
 
-H, qubits = qml.qchem.molecular_hamiltonian(symbols, geometry, charge=1)
+molecule = qml.qchem.Molecule(symbols, geometry, charge=1)
+H, qubits = qml.qchem.molecular_hamiltonian(molecule)
 H
 
 ##############################################################################

--- a/demonstrations/tutorial_resource_estimation.py
+++ b/demonstrations/tutorial_resource_estimation.py
@@ -218,7 +218,8 @@ print(f'1-norm of the Hamiltonian: {algo.lamb}')
 #
 # First, we construct the molecular Hamiltonian.
 
-H = qml.qchem.molecular_hamiltonian(symbols, geometry)[0]
+molecule = qml.qchem.Molecule(symbols, geometry)
+H = qml.qchem.molecular_hamiltonian(molecule)[0]
 H_coeffs, H_ops = H.terms()
 
 ##############################################################################

--- a/demonstrations/tutorial_spsa.py
+++ b/demonstrations/tutorial_spsa.py
@@ -335,8 +335,9 @@ print(f"Circuit execution ratio: {np.round(grad_execs_to_prec/spsa_execs_to_prec
 from pennylane import qchem
 
 symbols = ["H", "H"]
-coordinates = np.array([0.0, 0.0, -0.6614, 0.0, 0.0, 0.6614])
-h2_ham, num_qubits = qchem.molecular_hamiltonian(symbols, coordinates)
+coordinates = np.array([[0.0, 0.0, -0.6614], [0.0, 0.0, 0.6614]])
+molecule = qchem.Molecule(symbols, coordinates)
+h2_ham, num_qubits = qchem.molecular_hamiltonian(molecule)
 h2_ham_coeffs, h2_ham_ops = h2_ham.terms()
 h2_ham = qml.Hamiltonian(qml.math.real(h2_ham_coeffs), h2_ham_ops)
 

--- a/demonstrations/tutorial_vqe.py
+++ b/demonstrations/tutorial_vqe.py
@@ -53,7 +53,7 @@ jax.config.update("jax_platform_name", "cpu")
 jax.config.update('jax_enable_x64', True)
 
 symbols = ["H", "H"]
-coordinates = np.array([0.0, 0.0, -0.6614, 0.0, 0.0, 0.6614])
+coordinates = np.array([[0.0, 0.0, -0.6614], [0.0, 0.0, 0.6614]])
 
 ##############################################################################
 # The molecular structure can also be imported from an external file using
@@ -64,7 +64,8 @@ coordinates = np.array([0.0, 0.0, -0.6614, 0.0, 0.0, 0.6614])
 
 import pennylane as qml
 
-H, qubits = qml.qchem.molecular_hamiltonian(symbols, coordinates)
+molecule = qml.qchem.Molecule(symbols, coordinates)
+H, qubits = qml.qchem.molecular_hamiltonian(molecule)
 print("Number of qubits = ", qubits)
 print("The Hamiltonian is ", H)
 


### PR DESCRIPTION
The `molecular_hamiltonian` function is updated to accept a molecule object to match recent upgrades in qchem. All molecular coordinates are updated to have a `(N * 3)` where `N` is the number of atoms.