### PR TITLE
Update tutorial_lcu_blockencoding.py

### DIFF
--- a/demonstrations/tutorial_lcu_blockencoding.metadata.json
+++ b/demonstrations/tutorial_lcu_blockencoding.metadata.json
@@ -12,7 +12,7 @@
         }
     ],
     "dateOfPublication": "2023-10-25T00:00:00+00:00",
-    "dateOfLastModification": "2024-05-13T00:00:00+00:00",
+    "dateOfLastModification": "2024-05-31T00:00:00+00:00",
     "categories": [
         "Algorithms",
         "Quantum Computing"

--- a/demonstrations/tutorial_lcu_blockencoding.py
+++ b/demonstrations/tutorial_lcu_blockencoding.py
@@ -259,7 +259,7 @@ def lcu_circuit():  # block_encode
     return qml.state()
 
 
-output_matrix = qml.matrix(lcu_circuit, wire_order=[0, "ancilla"])()
+output_matrix = qml.matrix(lcu_circuit, wire_order=["ancilla", 0])()
 print("Block-encoded projector:\n")
 print(np.real(np.round(output_matrix,2)))
 


### PR DESCRIPTION
In the block encoding example from [this demo](https://pennylane.ai/qml/demos/tutorial_lcu_blockencoding/), the resulting matrix does not appear correctly. 
This PR solves the problem.