### PR TITLE
Fixes to the notebook converter

### DIFF
--- a/notebook_converter/notebook_to_demo.py
+++ b/notebook_converter/notebook_to_demo.py
@@ -184,7 +184,7 @@ def generate_code_output_block(output_source: List[str] = None, only_header: boo
             for line in [
                 ".. rst-class :: sphx-glr-script-out",
                 "",
-                ".. code-block: none",
+                "  .. code-block: none",
                 "",
             ]
         ]


### PR DESCRIPTION
**Title:** Fixes to the notebook converter

**Summary:** Several errors with the notebook converter have been reported in private discussions (with rendering codeblock outputs, or generally failing in some cases)