### PR TITLE
Fix path in figure inclusion syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ quantum computing paper/result.
 
   ```python
   ##############################################################################
-  #.. figure:: ../_static/demonstrations_assets/<demo name>/image.png
+  #.. figure:: ../_static/demonstration_assets/<demo name>/image.png
   #    :align: center
   #    :width: 90%
   ```


### PR DESCRIPTION
The folder name in the readme figure inclusion syntax was incorrect.