### PR TITLE
In-equation syntax in parshift Demo fix

### DIFF
--- a/demonstrations/tutorial_general_parshift.metadata.json
+++ b/demonstrations/tutorial_general_parshift.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2021-08-23T00:00:00+00:00",
-    "dateOfLastModification": "2024-01-01T00:00:00+00:00",
+    "dateOfLastModification": "2024-07-05T00:00:00+00:00",
     "categories": [
         "Optimization"
     ],

--- a/demonstrations/tutorial_general_parshift.py
+++ b/demonstrations/tutorial_general_parshift.py
@@ -601,8 +601,8 @@ odd_reconstructions = list(map(odd_reconstruction_equ, cost_functions, Ns))
 #   E_\text{even}(x) &= \sum_{\mu=0}^R E_\text{even}(x_\mu) \hat{D}_\mu(x)\\
 #   \hat{D}_\mu(x) &=
 #   \begin{cases}
-#      \frac{\sin(Rx)}{2R \tan(x/2)} &\text{if } \mu = 0 \\[12pt]
-#      \frac{\sin(R (x-x_\mu))}{2R \tan\left(\frac{1}{2} (x-x_\mu)\right)} + \frac{\sin(R (x+x_\mu))}{2R \tan\left(\frac{1}{2} (x+x_\mu)\right)} & \text{if } \mu \in [R-1] \\[12pt]
+#      \frac{\sin(Rx)}{2R \tan(x/2)} &\text{if } \mu = 0 \\
+#      \frac{\sin(R (x-x_\mu))}{2R \tan\left(\frac{1}{2} (x-x_\mu)\right)} + \frac{\sin(R (x+x_\mu))}{2R \tan\left(\frac{1}{2} (x+x_\mu)\right)} & \text{if } \mu \in [R-1] \\
 #      \frac{\sin(R (x-\pi))}{2R \tan\left(\frac{1}{2} (x-\pi)\right)} & \text{if } \mu = R.
 #   \end{cases}
 #


### PR DESCRIPTION
To address this
![image](https://github.com/PennyLaneAI/qml/assets/4939555/0f1cb229-2239-499d-812d-f198c4e90b48)
as described [here](https://xanaduhq.slack.com/archives/C03FRM3RCCV/p1720170995178649).