### PR TITLE
Add a warning about versioning

### DIFF
--- a/demonstrations/ensemble_multi_qpu.metadata.json
+++ b/demonstrations/ensemble_multi_qpu.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2020-02-14T00:00:00+00:00",
-    "dateOfLastModification": "2024-03-04T00:00:00+00:00",
+    "dateOfLastModification": "2024-07-05T00:00:00+00:00",
     "categories": [
         "Quantum Machine Learning"
     ],

--- a/demonstrations/ensemble_multi_qpu.py
+++ b/demonstrations/ensemble_multi_qpu.py
@@ -17,6 +17,12 @@ Ensemble classification with Rigetti and Qiskit devices
 This tutorial outlines how two QPUs can be combined in parallel to help solve a machine learning
 classification problem.
 
+.. warning::
+    This demo does not work with the latest version of Qiskit or the Pennylane-Qiskit plugin.
+    It is compatible with ``qiskit==0.46`` and ``pennylane-qiskit==0.35.1``. Older versions of
+    Qiskit and the Pennylane-Qiskit plugin should not be installed in environments with an
+    existing installation of Qiskit 1.0 or above.
+
 We use the ``rigetti.qvm`` device to simulate one QPU and the ``qiskit.aer`` device to
 simulate another. Each QPU makes an independent prediction, and an ensemble model is
 formed by choosing the prediction of the most confident QPU. The iris dataset is used in this


### PR DESCRIPTION
The `ensemble_multi_qpu` demo is not compatible with the most recent versions of Qiskit (and the PennyLane Qiskit plugin). We add a warning with compatible versions.