### PR TITLE
update-sphinx-gallery-version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -8097,4 +8097,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.0"
-content-hash = "e5ad6ab1f65bc56bdc5428651f29f7b6123bdc534e9dc4a195f49cc77c2fbc31"
+content-hash = "9d79a3c7864580ff575f8eed195b739cca63167e993e57f175bbe0127496a48f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -8097,4 +8097,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.0"
-content-hash = "004b42b826844885918613e3a61a3d617b94f34af140845b0969903e31bfd128"
+content-hash = "e5ad6ab1f65bc56bdc5428651f29f7b6123bdc534e9dc4a195f49cc77c2fbc31"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ quimb = "1.8.2"
 qiskit = ">=1.0.0"
 qiskit-aer = ">=0.14.0"
 sphinxcontrib-applehelp = "1.0.8"
-sphinx-gallery = "0.12.2"
+sphinx-gallery = "<=0.12.2"
 
 
 # Install a difference version of torch from PyPI as the one from PyTorch repo is not compatible with MacOS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ quimb = "1.8.2"
 qiskit = ">=1.0.0"
 qiskit-aer = ">=0.14.0"
 sphinxcontrib-applehelp = "1.0.8"
+sphinx-gallery = "0.12.2"
 
 
 # Install a difference version of torch from PyPI as the one from PyTorch repo is not compatible with MacOS


### PR DESCRIPTION
## Changes
- Fixed `sphinx-gallery` version up to `0.12.2` as the newer version was causing the build to fail.
- [Context](https://xanaduhq.slack.com/archives/C03FRM3RCCV/p1722247157554599)

## Verification
- All checks pass in the PR preview ✅ 
- PR preview https://qml-build-previews.pennylane.ai/pull_request_build_preview/1174/qml/demonstrations/