### PR TITLE
Update qchem demos to be JAX or JAX/JIT compatible

### DIFF
--- a/demonstrations/tutorial_adaptive_circuits.metadata.json
+++ b/demonstrations/tutorial_adaptive_circuits.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2021-09-13T00:00:00+00:00",
-    "dateOfLastModification": "2024-07-10T00:00:00+00:00",
+    "dateOfLastModification": "2024-08-08T00:00:00+00:00",
     "categories": [
         "Quantum Chemistry"
     ],
@@ -18,7 +18,7 @@
         },
         {
             "type": "large_thumbnail",
-            "uri": "/_static/large_demo_thumbnails/thumbnail_large_adaptive_circuits_new.png"
+            "uri": "/_static/demo_thumbnails/large_demo_thumbnails/thumbnail_large_adaptive_circuits_new.png"
         }
     ],
     "seoDescription": "Learn how to build quantum chemistry circuits adaptively.",

--- a/demonstrations/tutorial_chemical_reactions.metadata.json
+++ b/demonstrations/tutorial_chemical_reactions.metadata.json
@@ -9,7 +9,7 @@
         }
     ],
     "dateOfPublication": "2021-07-23T00:00:00+00:00",
-    "dateOfLastModification": "2024-07-10T00:00:00+00:00",
+    "dateOfLastModification": "2024-08-08T00:00:00+00:00",
     "categories": [
         "Quantum Chemistry"
     ],
@@ -17,7 +17,7 @@
     "previewImages": [
         {
             "type": "thumbnail",
-            "uri": "/_static/demonstration_assets/regular_demo_thumbnails/thumbnail_modelling_chemical_reactions_QC.png"
+            "uri": "/_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_modelling_chemical_reactions_QC.png"
         }
     ],
     "seoDescription": "Construct potential energy surfaces for chemical reactions",

--- a/demonstrations/tutorial_chemical_reactions.py
+++ b/demonstrations/tutorial_chemical_reactions.py
@@ -4,13 +4,13 @@ Modelling chemical reactions on a quantum computer
 
 .. meta::
     :property="og:description": Construct potential energy surfaces for chemical reactions
-    :property="og:image": https://pennylane.ai/qml/_static/demonstration_assets//reaction.png
+    :property="og:image": https://pennylane.ai/qml/_static/demonstration_assets/reaction.png
 
 .. related::
    tutorial_quantum_chemistry Building molecular Hamiltonians
    tutorial_vqe A brief overview of VQE
 
-*Authors: Varun Rishi and Juan Miguel Arrazola — Posted: 23 July 2021. Last updated: 21 February 2023.*
+*Authors: Varun Rishi and Juan Miguel Arrazola — Posted: 23 July 2021. Last updated: 8 August 2024.*
 
 The term "chemical reaction" is another name for the transformation of molecules – the breaking and 
 forming of bonds. They are characterized by an energy barrier that determines
@@ -106,7 +106,7 @@ hf = qml.qchem.hf_state(electrons=2, orbitals=4)
 # the equilibrium bond length, and the point where the bond is broken, which occurs when the atoms
 # are far away from each other.
 
-from pennylane import numpy as np
+from jax import numpy as jnp
 
 # atomic symbols defining the molecule
 symbols = ['H', 'H']
@@ -115,7 +115,7 @@ symbols = ['H', 'H']
 energies = []
 
 # set up a loop to change bond length
-r_range = np.arange(0.5, 5.0, 0.25)
+r_range = jnp.arange(0.5, 5.0, 0.25)
 
 # keeps track of points in the potential energy surface
 pes_point = 0
@@ -124,9 +124,12 @@ pes_point = 0
 # We build the Hamiltonian using the :func:`~.pennylane.qchem.molecular_hamiltonian`
 # function, and use standard Pennylane techniques to optimize the circuit.
 
+import catalyst
+import optax
+
 for r in r_range:
     # Change only the z coordinate of one atom
-    coordinates = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, r]])
+    coordinates = jnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, r]])
 
     # Construct the Molecule object
     molecule = qchem.Molecule(symbols, coordinates)
@@ -135,10 +138,10 @@ for r in r_range:
     H, qubits = qchem.molecular_hamiltonian(molecule, method='openfermion')
 
     # define the device, optimizer and circuit
-    dev = qml.device("default.qubit", wires=qubits)
-    opt = qml.GradientDescentOptimizer(stepsize=0.4)
+    dev = qml.device("lightning.qubit", wires=qubits)
+    opt = optax.sgd(learning_rate=0.4)
 
-    @qml.qnode(dev, interface='autograd')
+    @qml.qnode(dev, interface='jax')
     def circuit(parameters):
         # Prepare the HF state: |1100>
         qml.BasisState(hf, wires=range(qubits))
@@ -149,19 +152,33 @@ for r in r_range:
         return qml.expval(H)  # we are interested in minimizing this expectation value
 
     # initialize the gate parameters
-    params = np.zeros(3, requires_grad=True)
+    init_params = jnp.zeros(3)
 
     # initialize with converged parameters from previous point
     if pes_point > 0:
-        params = params_old
+        init_params = params_old
 
     prev_energy = 0.0
-    for n in range(50):
-        # perform optimization step
-        params, energy = opt.step_and_cost(circuit, params)
+    @qml.qjit
+    def update_step(i, params, opt_state):
+        """Perform a single gradient update step"""
+        grads = qml.grad(circuit)(params)
+        updates, opt_state = opt.update(grads, opt_state)
+        params = optax.apply_updates(params, updates)
+        return (params, opt_state)
 
-        if np.abs(energy - prev_energy) < 1e-6:
+    loss_history = []
+
+    opt_state = opt.init(init_params)
+    params = init_params
+
+    for i in range(50):
+        params, opt_state = update_step(i, params, opt_state)
+        energy = circuit(params)
+
+        if jnp.abs(energy - prev_energy) < 1e-6:
             break
+
         prev_energy = energy
 
     # store the converged parameters
@@ -280,35 +297,52 @@ hf = qml.qchem.hf_state(electrons, orbitals)
 
 
 # loop to change reaction coordinate
-r_range = np.arange(1.0, 3.0, 0.1)
+r_range = jnp.arange(1.0, 3.0, 0.1)
 for r in r_range:
 
-    coordinates = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, r], [0.0, 0.0, 4.0]])
+    coordinates = jnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, r], [0.0, 0.0, 4.0]])
 
     # We now specify the multiplicity
     molecule = qchem.Molecule(symbols, coordinates, mult=multiplicity)
 
     H, qubits = qchem.molecular_hamiltonian(molecule, method='openfermion')
 
-    dev = qml.device("default.qubit", wires=qubits)
-    opt = qml.GradientDescentOptimizer(stepsize=1.5)
+    dev = qml.device("lightning.qubit", wires=qubits)
+    opt = optax.sgd(learning_rate=1.5)
 
-    @qml.qnode(dev, interface='autograd')
+    @qml.qjit
+    @qml.qnode(dev, interface='jax')
     def circuit(parameters):
         AllSinglesDoubles(parameters, range(qubits), hf, singles, doubles)
         return qml.expval(H)  # we are interested in minimizing this expectation value
 
-    params = np.zeros(len(singles) + len(doubles), requires_grad=True)
+    init_params = jnp.zeros(len(singles) + len(doubles))
 
+    # initialize with converged parameters from previous point
     if pes_point > 0:
-        params = params_old
+        init_params = params_old
 
     prev_energy = 0.0
+    @qml.qjit
+    def update_step(i, params, opt_state):
+        """Perform a single gradient update step"""
+        grads = qml.grad(circuit)(params)
+        updates, opt_state = opt.update(grads, opt_state)
+        params = optax.apply_updates(params, updates)
+        return (params, opt_state)
 
-    for n in range(60):
-        params, energy = opt.step_and_cost(circuit, params)
-        if np.abs(energy - prev_energy) < 1e-6:
+    loss_history = []
+
+    opt_state = opt.init(init_params)
+    params = init_params
+
+    for i in range(60):
+        params, opt_state = update_step(i, params, opt_state)
+        energy = circuit(params)
+
+        if jnp.abs(energy - prev_energy) < 1e-6:
             break
+
         prev_energy = energy
 
     # store the converged parameters
@@ -393,7 +427,7 @@ k_B = 1.38e-23
 # Temperature
 T = 300
 
-ratio = np.exp(activation_energy / (2 * k_B * T))
+ratio = jnp.exp(activation_energy / (2 * k_B * T))
 
 print(f"Ratio of reaction rates is {ratio:.0f}")
 

--- a/demonstrations/tutorial_classically_boosted_vqe.metadata.json
+++ b/demonstrations/tutorial_classically_boosted_vqe.metadata.json
@@ -9,7 +9,7 @@
         }
     ],
     "dateOfPublication": "2022-10-31T00:00:00+00:00",
-    "dateOfLastModification": "2024-07-10T00:00:00+00:00",
+    "dateOfLastModification": "2024-08-08T00:00:00+00:00",
     "categories": [
         "Quantum Chemistry"
     ],
@@ -17,7 +17,7 @@
     "previewImages": [
         {
             "type": "thumbnail",
-            "uri": "/_static/demonstration_assets/regular_demo_thumbnails/thumbnail_classically-boosted_VQE.png"
+            "uri": "/_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_classically-boosted_VQE.png"
         }
     ],
     "seoDescription": "Learn how to implement classically-boosted VQE in PennyLane.",

--- a/demonstrations/tutorial_eqnn_force_field.metadata.json
+++ b/demonstrations/tutorial_eqnn_force_field.metadata.json
@@ -3,16 +3,15 @@
     "authors": [
         {
             "id": "oriel_kiss"
-        },
-        {
+          },
+          {
             "id": "isabel_nha_minh_le"
         }
     ],
     "dateOfPublication": "2024-03-12T00:00:00+00:00",
-    "dateOfLastModification": "2024-07-31T00:00:00+00:00",
+    "dateOfLastModification": "2024-08-05T00:00:00+00:00",
     "categories": [
-        "Quantum Machine Learning",
-        "Quantum Chemistry"
+        "Quantum Machine Learning", "Quantum Chemistry"
     ],
     "tags": [],
     "previewImages": [
@@ -22,7 +21,7 @@
         },
         {
             "type": "large_thumbnail",
-            "uri": "/_static/large_demo_thumbnails/thumbnail_large_EQNNforceField_2024-03-07.png"
+            "uri": "/_static/demo_thumbnails/large_demo_thumbnails/thumbnail_large_EQNNforceField_2024-03-07.png"
         }
     ],
     "seoDescription": "What is equivariant quantum machine learning for chemistry?",
@@ -58,7 +57,7 @@
             "publisher": "APS",
             "journal": "Phys. Rev. A",
             "url": "https://journals.aps.org/pra/abstract/10.1103/PhysRevA.103.032430"
-        },
+        } ,
         {
             "id": "wierichs",
             "type": "article",
@@ -68,7 +67,7 @@
             "publisher": "",
             "journal": "",
             "url": "https://arxiv.org/abs/2312.06752"
-        },
+        } ,
         {
             "id": "meyer",
             "type": "article",
@@ -80,11 +79,10 @@
             "url": "https://journals.aps.org/prxquantum/abstract/10.1103/PRXQuantum.4.010328"
         }
     ],
-    "basedOnPapers": [
-        "https://arxiv.org/abs/2311.11362"
-    ],
+    "basedOnPapers": ["https://arxiv.org/abs/2311.11362"],
     "referencedByPapers": [],
     "relatedContent": [
+
         {
             "type": "demonstration",
             "id": "tutorial_geometric_qml",

--- a/demonstrations/tutorial_eqnn_force_field.py
+++ b/demonstrations/tutorial_eqnn_force_field.py
@@ -133,14 +133,12 @@ import pennylane as qml
 import numpy as np
 
 import jax
-
-jax.config.update("jax_platform_name", "cpu")
+jax.config.update('jax_platform_name', 'cpu')
 from jax import numpy as jnp
 
 import scipy
 import matplotlib.pyplot as plt
 import sklearn
-
 ######################################################################
 # Let us construct Pauli matrices, which are used to build the Hamiltonian.
 X = np.array([[0, 1], [1, 0]])
@@ -150,11 +148,7 @@ Z = np.array([[1, 0], [0, -1]])
 sigmas = jnp.array(np.array([X, Y, Z]))  # Vector of Pauli matrices
 sigmas_sigmas = jnp.array(
     np.array(
-        [
-            np.kron(X, X),
-            np.kron(Y, Y),
-            np.kron(Z, Z),
-        ]  # Vector of tensor products of Pauli matrices
+        [np.kron(X, X), np.kron(Y, Y), np.kron(Z, Z)]  # Vector of tensor products of Pauli matrices
     )
 )
 
@@ -173,6 +167,7 @@ def singlet(wires):
     qml.PauliZ(wires=wires[0])
     qml.PauliX(wires=wires[1])
     qml.CNOT(wires=wires)
+
 
 
 ######################################################################
@@ -204,6 +199,7 @@ def equivariant_encoding(alpha, data, wires):
     hamiltonian = jnp.einsum("i,ijk", data, sigmas)  # Heisenberg Hamiltonian
     U = jax.scipy.linalg.expm(-1.0j * alpha * hamiltonian / 2)
     qml.QubitUnitary(U, wires=wires, id="E")
+
 
 
 ######################################################################
@@ -294,12 +290,12 @@ B = 1  # Number of repetitions inside a trainable layer
 rep = 2  # Number of repeated vertical encoding
 
 active_atoms = 2  # Number of active atoms
-# Here we only have two active atoms since we fixed the oxygen (which becomes non-active) at the origin
+                  # Here we only have two active atoms since we fixed the oxygen (which becomes non-active) at the origin
 num_qubits = active_atoms * rep
 #################################
 
 
-dev = qml.device("default.qubit", wires=num_qubits)
+dev = qml.device("default.qubit.jax", wires=num_qubits)
 
 
 @qml.qnode(dev, interface="jax")
@@ -315,7 +311,9 @@ def vqlm(data, params):
 
     # Initial encoding
     for i in range(num_qubits):
-        equivariant_encoding(alphas[i, 0], jnp.asarray(data)[i % active_atoms, ...], wires=[i])
+        equivariant_encoding(
+            alphas[i, 0], jnp.asarray(data)[i % active_atoms, ...], wires=[i]
+        )
 
     # Reuploading model
     for d in range(D):
@@ -439,7 +437,6 @@ def inference(loss_data, opt_state):
 
     return E_pred, l
 
-
 #################################
 # **Parameter initialization:**
 #
@@ -469,8 +466,8 @@ running_loss = []
 # We train our VQLM using stochastic gradient descent.
 
 
-num_batches = 5000  # number of optimization steps
-batch_size = 256  # number of training data per batch
+num_batches = 5000 # number of optimization steps
+batch_size = 256   # number of training data per batch
 
 
 for ibatch in range(num_batches):
@@ -495,7 +492,7 @@ for ibatch in range(num_batches):
 history_loss = np.array(running_loss)
 
 fontsize = 12
-plt.figure(figsize=(4, 4))
+plt.figure(figsize=(4,4))
 plt.plot(history_loss[:, 0], "r-", label="training error")
 plt.plot(history_loss[:, 1], "b-", label="testing error")
 
@@ -515,7 +512,7 @@ plt.show()
 # could be improved, e.g. by using a deeper model as in the original paper.
 #
 
-plt.figure(figsize=(4, 4))
+plt.figure(figsize=(4,4))
 plt.title("Energy predictions", fontsize=fontsize)
 plt.plot(energy[indices_test], E_pred, "ro", label="Test predictions")
 plt.plot(energy[indices_test], energy[indices_test], "k.-", lw=1, label="Exact")

--- a/demonstrations/tutorial_givens_rotations.metadata.json
+++ b/demonstrations/tutorial_givens_rotations.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2021-06-30T00:00:00+00:00",
-    "dateOfLastModification": "2024-01-01T00:00:00+00:00",
+    "dateOfLastModification": "2024-08-08T00:00:00+00:00",
     "categories": [
         "Quantum Chemistry"
     ],
@@ -14,7 +14,7 @@
     "previewImages": [
         {
             "type": "thumbnail",
-            "uri": "/_static/demonstration_assets/regular_demo_thumbnails/thumbnail_Givens_rotations_for_QChem.png"
+            "uri": "/_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_Givens_rotations_for_QChem.png"
         }
     ],
     "seoDescription": "Discover the building blocks of quantum circuits for quantum chemistry",

--- a/demonstrations/tutorial_how_to_quantum_just_in_time_compile_vqe_catalyst.metadata.json
+++ b/demonstrations/tutorial_how_to_quantum_just_in_time_compile_vqe_catalyst.metadata.json
@@ -9,21 +9,22 @@
         }
     ],
     "dateOfPublication": "2024-04-26T00:00:00+00:00",
-    "dateOfLastModification": "2024-04-26T00:00:00+00:00",
+    "dateOfLastModification": "2024-08-08T00:00:00+00:00",
     "categories": [
         "Quantum Machine Learning",
         "Optimization",
-        "Quantum Chemistry"
+        "Quantum Chemistry",
+        "How-to"
     ],
     "tags": ["how to"],
     "previewImages": [
         {
             "type": "thumbnail",
-            "uri": "/_static/demonstration_assets/regular_demo_thumbnails/thumbnail_how-to-vqe-qjit.png"
+            "uri": "/_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_how-to-vqe-qjit.png"
         },
         {
             "type": "large_thumbnail",
-            "uri": "/_static/large_demo_thumbnails/thumbnail_large_how-to-vqe-qjit.png"
+            "uri": "/_static/demo_thumbnails/large_demo_thumbnails/thumbnail_large_how-to-vqe-qjit.png"
         }
     ],
     "seoDescription": "Learn how to find the ground state of a molecule with VQE using PennyLane, Catalyst, and just-in-time compilation.",

--- a/demonstrations/tutorial_how_to_quantum_just_in_time_compile_vqe_catalyst.py
+++ b/demonstrations/tutorial_how_to_quantum_just_in_time_compile_vqe_catalyst.py
@@ -12,7 +12,7 @@ atoms sharing two electrons) using `Catalyst <https://github.com/PennyLaneAI/Cat
 quantum just-in-time framework for PennyLane, that allows hybrid quantum-classical workflows to be
 compiled, optimized, and executed with a significant performance boost.
 
-.. figure:: ../_static/demonstration_assets/how_to_vqe_qjit/OGthumbnail_large_how-to-vqe-qjit_2024-04-23.png
+.. figure:: ../_static/demo_thumbnails/opengraph_demo_thumbnails/OGthumbnail_large_how-to-vqe-qjit_2024-04-23.png
     :align: center
     :width: 60%
     :target: javascript:void(0)
@@ -44,7 +44,7 @@ We will break the implementation into three steps:
 #
 
 import pennylane as qml
-from pennylane import numpy as np
+import numpy as np
 
 dataset = qml.data.load('qchem', molname="H3+")[0]
 H, qubits = dataset.hamiltonian, len(dataset.hamiltonian.wires)

--- a/demonstrations/tutorial_initial_state_preparation.metadata.json
+++ b/demonstrations/tutorial_initial_state_preparation.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2023-10-20T00:00:00+00:00",
-    "dateOfLastModification": "2024-07-10T00:00:00+00:00",
+    "dateOfLastModification": "2024-08-08T00:00:00+00:00",
     "categories": [
         "Quantum Chemistry"
     ],
@@ -18,7 +18,7 @@
         },
         {
             "type": "large_thumbnail",
-            "uri": "/_static/large_demo_thumbnails/thumbnail_large_initial_state_preparation.png"
+            "uri": "/_static/demo_thumbnails/large_demo_thumbnails/thumbnail_large_initial_state_preparation.png"
         }
     ],
     "seoDescription": "Prepare initial states for quantum algorithms from output of traditional quantum chemistry methods.",

--- a/demonstrations/tutorial_initial_state_preparation.py
+++ b/demonstrations/tutorial_initial_state_preparation.py
@@ -49,13 +49,11 @@ orbitals (:func:`~.pennylane.qchem.import_state` works for unrestricted orbitals
 
 from pyscf import gto, scf, ci
 from pennylane.qchem import import_state
-from pennylane import numpy as np
+import numpy as np
 
 R = 1.2
 # create the H3+ molecule
-mol = gto.M(atom=[["H", (0, 0, 0)],
-                  ["H", (0, 0, R)],
-                  ["H", (0, 0, 2 * R)]], charge=1)
+mol = gto.M(atom=[["H", (0, 0, 0)], ["H", (0, 0, R)], ["H", (0, 0, 2 * R)]], charge=1)
 # perfrom restricted Hartree-Fock and then CISD
 myhf = scf.RHF(mol).run()
 myci = ci.CISD(myhf).run()
@@ -159,7 +157,7 @@ print(f"CCSD-based state vector: \n{np.round(wf_ccsd.real, 4)}")
 # Let's take this opportunity to create the Hartree-Fock initial state, to compare the
 # other states against it later on.
 
-from pennylane import numpy as np
+import numpy as np
 
 hf_primer = ([[3, 0, 0]], np.array([1.0]))
 wf_hf = import_state(hf_primer)
@@ -227,7 +225,7 @@ from pennylane import qchem
 
 # generate the molecular Hamiltonian for H3+
 symbols = ["H", "H", "H"]
-geometry = np.array([[0, 0, 0], [0, 0, R/0.529], [0, 0, 2*R/0.529]])
+molecule = qchem.Molecule(symbols, geometry, charge=1, unit="angstrom")
 molecule = qchem.Molecule(symbols, geometry, charge=1)
 
 H2mol, qubits = qchem.molecular_hamiltonian(molecule)
@@ -252,19 +250,30 @@ def circuit_VQE(theta, initial_state):
             qml.SingleExcitation(theta[i], wires=excitation)
     return qml.expval(H2mol)
 
+def cost_fn(param):
+    return circuit_VQE(param, initial_state=wf_hf)
+
 ##############################################################################
 # Next, we create the VQE optimizer, initialize the variational parameters and run the VQE optimization.
+import optax
+import jax
+from jax import numpy as jnp
 
-opt = qml.GradientDescentOptimizer(stepsize=0.4)
-theta = np.array(np.zeros(len(excitations)), requires_grad=True)
+opt = optax.sgd(learning_rate=0.4)
+theta = jnp.array(jnp.zeros(len(excitations)))
 delta_E, iteration = 10, 0
 results_hf = []
+opt_state = opt.init(theta)
+prev_energy = cost_fn(theta)
 
 # run the VQE optimization loop until convergence threshold is reached
 while abs(delta_E) > 1e-5:
-    theta, prev_energy = opt.step_and_cost(circuit_VQE, theta, initial_state=wf_hf)
-    new_energy = circuit_VQE(theta, initial_state=wf_hf)
+    gradient = jax.grad(cost_fn)(theta)
+    updates, opt_state = opt.update(gradient, opt_state)
+    theta = optax.apply_updates(theta, updates)
+    new_energy = cost_fn(theta)
     delta_E = new_energy - prev_energy
+    prev_energy = new_energy
     results_hf.append(new_energy)
     if len(results_hf) % 5 == 0:
         print(f"Step = {len(results_hf)},  Energy = {new_energy:.6f} Ha")
@@ -273,16 +282,24 @@ print(f"Starting with HF state took {len(results_hf)} iterations until convergen
 ##############################################################################
 # And compare with how things go when you run it with the CISD initial state:
 
-theta = np.array(np.zeros(len(excitations)), requires_grad=True)
+def cost_fn(param):
+    return circuit_VQE(param, initial_state=wf_cisd)
+
+theta = jnp.array(jnp.zeros(len(excitations)))
 delta_E, iteration = 10, 0
 results_cisd = []
+opt_state = opt.init(theta)
+prev_energy = cost_fn(theta)
 
 while abs(delta_E) > 1e-5:
-    theta, prev_energy = opt.step_and_cost(circuit_VQE, theta, initial_state=wf_cisd)
-    new_energy = circuit_VQE(theta, initial_state=wf_cisd)
+    gradient = jax.grad(cost_fn)(theta)
+    updates, opt_state = opt.update(gradient, opt_state)
+    theta = optax.apply_updates(theta, updates)
+    new_energy = cost_fn(theta)
     delta_E = new_energy - prev_energy
+    prev_energy = new_energy
     results_cisd.append(new_energy)
-    if len(results_cisd) % 5 == 0:
+    if len(results_hf) % 5 == 0:
         print(f"Step = {len(results_cisd)},  Energy = {new_energy:.6f} Ha")
 print(f"Starting with CISD state took {len(results_cisd)} iterations until convergence.")
 

--- a/demonstrations/tutorial_measurement_optimize.metadata.json
+++ b/demonstrations/tutorial_measurement_optimize.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2021-01-18T00:00:00+00:00",
-    "dateOfLastModification": "2024-01-01T00:00:00+00:00",
+    "dateOfLastModification": "2024-08-08T00:00:00+00:00",
     "categories": [
         "Quantum Chemistry"
     ],
@@ -14,7 +14,7 @@
     "previewImages": [
         {
             "type": "thumbnail",
-            "uri": "/_static/demonstration_assets/regular_demo_thumbnails/thumbnail_measurement_optimization.png"
+            "uri": "/_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_measurement_optimization.png"
         }
     ],
     "seoDescription": "Optimize and reduce the number of measurements required to evaluate a variational algorithm cost function.",

--- a/demonstrations/tutorial_measurement_optimize.py
+++ b/demonstrations/tutorial_measurement_optimize.py
@@ -4,7 +4,7 @@ Measurement optimization
 
 .. meta::
     :property="og:description": Optimize and reduce the number of measurements required to evaluate a variational algorithm cost function.
-    :property="og:image": https://pennylane.ai/qml/_static/demonstration_assets//grouping.png
+    :property="og:image": https://pennylane.ai/qml/_static/demonstration_assets/grouping.png
 
 .. related::
 
@@ -12,7 +12,7 @@ Measurement optimization
    tutorial_quantum_chemistry Building molecular Hamiltonians
    tutorial_qaoa_intro Intro to QAOA
 
-*Author: Josh Izaac — Posted: 18 January 2021. Last updated: 29 August 2023.*
+*Author: Josh Izaac — Posted: 18 January 2021. Last updated: 8 August 2024.*
 
 The variational quantum eigensolver (VQE) is the OG variational quantum algorithm. Harnessing
 near-term quantum hardware to solve for the electronic structure of molecules, VQE is *the*
@@ -110,11 +110,13 @@ function to download the dataset of the molecule.
 
 import functools
 import warnings
-from pennylane import numpy as np
+import jax
+from jax import numpy as jnp
 import pennylane as qml
 
+jax.config.update("jax_enable_x64", True)
 
-dataset = qml.data.load('qchem', molname="H2", bondlength=0.7)[0]
+dataset = qml.data.load("qchem", molname="H2", bondlength=0.7)[0]
 H, num_qubits = dataset.hamiltonian, len(dataset.hamiltonian.wires)
 
 print("Required number of qubits:", num_qubits)
@@ -141,7 +143,7 @@ ansatz = functools.partial(
 )
 
 # generate the cost function
-@qml.qnode(dev, interface="autograd")
+@qml.qnode(dev, interface="jax")
 def cost_circuit(params):
     ansatz(params, wires=range(num_qubits))
     return qml.expval(H)
@@ -150,7 +152,9 @@ def cost_circuit(params):
 # If we evaluate this cost function, we can see that it corresponds to 15 different
 # executions under the hood—one per expectation value:
 
-params = np.random.normal(0, np.pi, len(singles) + len(doubles))
+from jax import random as random
+key = random.PRNGKey(0)
+params = random.normal(key, shape=(len(singles) + len(doubles),)) * jnp.pi
 with qml.Tracker(dev) as tracker:  # track the number of executions
     print("Cost function value:", cost_circuit(params))
 
@@ -387,20 +391,20 @@ obs = [
 
 dev = qml.device("default.qubit", wires=3)
 
-@qml.qnode(dev, interface="autograd")
+@qml.qnode(dev, interface="jax")
 def circuit1(weights):
     qml.StronglyEntanglingLayers(weights, wires=range(3))
     return qml.expval(obs[0])
 
 
-@qml.qnode(dev, interface="autograd")
+@qml.qnode(dev, interface="jax")
 def circuit2(weights):
     qml.StronglyEntanglingLayers(weights, wires=range(3))
     return qml.expval(obs[1])
 
 param_shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=3, n_wires=3)
-rng = np.random.default_rng(192933)
-weights = rng.normal(scale=0.1, size=param_shape)
+key = random.PRNGKey(192933)
+weights = random.normal(key, shape=param_shape) * 0.1
 
 print("Expectation value of XYI = ", circuit1(weights))
 print("Expectation value of XIZ = ", circuit2(weights))
@@ -409,15 +413,15 @@ print("Expectation value of XIZ = ", circuit2(weights))
 # Now, let's use our QWC approach to reduce this down to a *single* measurement
 # of the probabilities in the shared eigenbasis of both QWC observables:
 
-@qml.qnode(dev, interface="autograd")
+@qml.qnode(dev, interface="jax")
 def circuit_qwc(weights):
     qml.StronglyEntanglingLayers(weights, wires=range(3))
 
     # rotate wire 0 into the shared eigenbasis
-    qml.RY(-np.pi / 2, wires=0)
+    qml.RY(-jnp.pi / 2, wires=0)
 
     # rotate wire 1 into the shared eigenbasis
-    qml.RX(np.pi / 2, wires=1)
+    qml.RX(jnp.pi / 2, wires=1)
 
     # wire 2 does not require a rotation
 
@@ -427,7 +431,6 @@ def circuit_qwc(weights):
 
 rotated_probs = circuit_qwc(weights)
 print(rotated_probs)
-
 
 ##############################################################################
 # We're not quite there yet; we have only calculated the probabilities of the variational circuit
@@ -440,12 +443,12 @@ print(rotated_probs)
 # generate the eigenvalues of the full Pauli terms, making sure that the order
 # of the eigenvalues in the Kronecker product corresponds to the tensor product.
 
-eigenvalues_XYI = np.kron(np.kron([1, -1], [1, -1]), [1, 1])
-eigenvalues_XIZ = np.kron(np.kron([1, -1], [1, 1]), [1, -1])
+eigenvalues_XYI = jnp.kron(jnp.kron(jnp.array([1, -1]), jnp.array([1, -1])), jnp.array([1, 1]))
+eigenvalues_XIZ = jnp.kron(jnp.kron(jnp.array([1, -1]), jnp.array([1, 1])), jnp.array([1, -1]))
 
 # Taking the linear combination of the eigenvalues and the probabilities
-print("Expectation value of XYI = ", np.dot(eigenvalues_XYI, rotated_probs))
-print("Expectation value of XIZ = ", np.dot(eigenvalues_XIZ, rotated_probs))
+print("Expectation value of XYI = ", jnp.dot(eigenvalues_XYI, rotated_probs))
+print("Expectation value of XIZ = ", jnp.dot(eigenvalues_XIZ, rotated_probs))
 
 
 ##############################################################################
@@ -455,7 +458,7 @@ print("Expectation value of XIZ = ", np.dot(eigenvalues_XIZ, rotated_probs))
 # Luckily, PennyLane automatically performs this QWC grouping under the hood. We simply
 # return the two QWC Pauli terms from the QNode:
 
-@qml.qnode(dev, interface="autograd")
+@qml.qnode(dev, interface="jax")
 def circuit(weights):
     qml.StronglyEntanglingLayers(weights, wires=range(3))
     return [
@@ -711,15 +714,16 @@ rotations, measurements = qml.pauli.diagonalize_qwc_groupings(obs_groupings)
 # However, this isn't strictly necessary—recall previously that the QNode
 # has the capability to *automatically* measure qubit-wise commuting observables!
 
-dev = qml.device("default.qubit", wires=4)
+dev = qml.device("lightning.qubit", wires=4)
 
-@qml.qnode(dev, interface="autograd")
+@qml.qnode(dev, interface="jax")
 def circuit(weights, group=None, **kwargs):
     qml.StronglyEntanglingLayers(weights, wires=range(4))
     return [qml.expval(o) for o in group]
 
 param_shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=3, n_wires=4)
-weights = np.random.normal(scale=0.1, size=param_shape)
+key = random.PRNGKey(1)
+weights = random.normal(key, shape=param_shape) * 0.1
 result = [circuit(weights, group=g) for g in obs_groupings]
 
 print("Term expectation values:")
@@ -728,7 +732,7 @@ for group, expvals in enumerate(result):
 
 # Since all the coefficients of the Hamiltonian are unity,
 # we can simply sum the expectation values.
-print("<H> = ", np.sum(np.hstack(result)))
+print("<H> = ", jnp.sum(jnp.hstack(result)))
 
 
 ##############################################################################
@@ -737,9 +741,9 @@ print("<H> = ", np.sum(np.hstack(result)))
 # problems), we can use the option ``grouping_type="qwc"`` in :class:`~.pennylane.Hamiltonian` to
 # automatically optimize the measurements.
 
-H = qml.Hamiltonian(coeffs=np.ones(len(terms)), observables=terms, grouping_type="qwc")
+H = qml.Hamiltonian(coeffs=jnp.ones(len(terms)), observables=terms, grouping_type="qwc")
 _, H_ops = H.terms()
-@qml.qnode(dev, interface="autograd")
+@qml.qnode(dev, interface="jax")
 def cost_fn(weights):
     qml.StronglyEntanglingLayers(weights, wires=range(4))
     return qml.expval(H)

--- a/demonstrations/tutorial_qchem_external.metadata.json
+++ b/demonstrations/tutorial_qchem_external.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2023-01-03T00:00:00+00:00",
-    "dateOfLastModification": "2024-06-20T00:00:00+00:00",
+    "dateOfLastModification": "2024-08-08T00:00:00+00:00",
     "categories": [
         "Quantum Chemistry", "Devices and Performance"
     ],
@@ -18,7 +18,7 @@
         },
         {
             "type": "large_thumbnail",
-            "uri": "/_static/large_demo_thumbnails/thumbnail_large_external_libs.png"
+            "uri": "/_static/demo_thumbnails/large_demo_thumbnails/thumbnail_large_external_libs.png"
         }
     ],
     "seoDescription": "Learn how to integrate external quantum chemistry libraries with PennyLane.",

--- a/demonstrations/tutorial_qchem_external.py
+++ b/demonstrations/tutorial_qchem_external.py
@@ -5,7 +5,7 @@ Using PennyLane with PySCF and OpenFermion
 
 .. meta::
     :property="og:description": Learn how to integrate external quantum chemistry libraries with PennyLane.
-    :property="og:image": https://pennylane.ai/qml/_static/demonstration_assets//thumbnail_tutorial_external_libs.png
+    :property="og:image": https://pennylane.ai/qml/_static/demonstration_assets/thumbnail_tutorial_external_libs.png
 
 
 .. related::
@@ -14,7 +14,7 @@ Using PennyLane with PySCF and OpenFermion
     tutorial_givens_rotations Givens rotations for quantum chemistry
     tutorial_adaptive_circuits Adaptive circuits for quantum chemistry
 
-*Author: Soran Jahangiri — Posted: 3 January 2023.*
+*Author: Soran Jahangiri — Posted: 3 January 2023. Updated: 8 August 2024.*
 
 The quantum chemistry module in PennyLane, :mod:`qchem  <pennylane.qchem>`, provides built-in
 methods to compute molecular integrals, solve Hartree-Fock equations, and construct
@@ -48,12 +48,12 @@ backend as:
 """
 
 import pennylane as qml
-from pennylane import numpy as np
+import numpy as np
 
 symbols = ["H", "O", "H"]
 geometry = np.array([[-0.0399, -0.0038, 0.0000],
                      [ 1.5780,  0.8540, 0.0000],
-                     [ 2.7909, -0.5159, 0.0000]], requires_grad = False)
+                     [ 2.7909, -0.5159, 0.0000]])
 molecule = qml.qchem.Molecule(symbols, geometry)
 
 H, qubits = qml.qchem.molecular_hamiltonian(molecule, method="pyscf")

--- a/demonstrations/tutorial_quantum_chemistry.metadata.json
+++ b/demonstrations/tutorial_quantum_chemistry.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2020-08-02T00:00:00+00:00",
-    "dateOfLastModification": "2024-07-10T00:00:00+00:00",
+    "dateOfLastModification": "2024-08-05T00:00:00+00:00",
     "categories": [
         "Quantum Chemistry"
     ],
@@ -14,7 +14,7 @@
     "previewImages": [
         {
             "type": "thumbnail",
-            "uri": "/_static/demonstration_assets/regular_demo_thumbnails/thumbnail_building_molecular_Hamiltonians.png"
+            "uri": "/_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_building_molecular_Hamiltonians.png"
         }
     ],
     "seoDescription": "Learn how to build electronic Hamiltonians of molecules.",

--- a/demonstrations/tutorial_quantum_chemistry.py
+++ b/demonstrations/tutorial_quantum_chemistry.py
@@ -6,7 +6,7 @@ Building molecular Hamiltonians
 .. meta::
     :property="og:description": Learn how to build electronic Hamiltonians of molecules.
 
-    :property="og:image": https://pennylane.ai/qml/_static/demonstration_assets//water_structure.png
+    :property="og:image": https://pennylane.ai/qml/_static/demonstration_assets/water_structure.png
 
 .. related::
    tutorial_vqe A brief overview of VQE
@@ -255,7 +255,7 @@ print(H)
 ##############################################################################
 # In this case, since we have truncated the basis of molecular orbitals, the resulting
 # observable is an approximation of the Hamiltonian generated in the
-# section :ref:`hamiltonian`.
+# section `Building the Hamiltonian <https://pennylane.ai/qml/demos/tutorial_quantum_chemistry/#building-the-hamiltonian>`__.
 #
 # OpenFermion-PySCF backend
 # -------------------------

--- a/demonstrations/tutorial_qubit_tapering.metadata.json
+++ b/demonstrations/tutorial_qubit_tapering.metadata.json
@@ -9,7 +9,7 @@
         }
     ],
     "dateOfPublication": "2022-05-16T00:00:00+00:00",
-    "dateOfLastModification": "2024-07-10T00:00:00+00:00",
+    "dateOfLastModification": "2024-08-08T00:00:00+00:00",
     "categories": [
         "Quantum Chemistry"
     ],
@@ -17,7 +17,7 @@
     "previewImages": [
         {
             "type": "thumbnail",
-            "uri": "/_static/demonstration_assets/regular_demo_thumbnails/thumbnail_Qubit_tapering.png"
+            "uri": "/_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_Qubit_tapering.png"
         }
     ],
     "seoDescription": "Learn how to taper off qubits",

--- a/demonstrations/tutorial_vqe.metadata.json
+++ b/demonstrations/tutorial_vqe.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2020-02-08T00:00:00+00:00",
-    "dateOfLastModification": "2024-07-10T00:00:00+00:00",
+    "dateOfLastModification": "2024-08-05T00:00:00+00:00",
     "categories": [
         "Quantum Chemistry", "Getting Started"
     ],
@@ -14,7 +14,7 @@
     "previewImages": [
         {
             "type": "thumbnail",
-            "uri": "/_static/demonstration_assets/regular_demo_thumbnails/thumbnail_brief_overview_of_VQE.png"
+            "uri": "/_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_brief_overview_of_VQE.png"
         }
     ],
     "seoDescription": "Find the ground state of a Hamiltonian using the variational quantum eigensolver algorithm.",

--- a/demonstrations/tutorial_vqe.py
+++ b/demonstrations/tutorial_vqe.py
@@ -5,7 +5,7 @@ A brief overview of VQE
 .. meta::
     :property="og:description": Find the ground state of a Hamiltonian using the
         variational quantum eigensolver algorithm.
-    :property="og:image": https://pennylane.ai/qml/_static/demonstration_assets//pes_h2.png
+    :property="og:image": https://pennylane.ai/qml/_static/demonstration_assets/pes_h2.png
 
 .. related::
 

--- a/demonstrations/tutorial_vqe_spin_sectors.metadata.json
+++ b/demonstrations/tutorial_vqe_spin_sectors.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2020-10-13T00:00:00+00:00",
-    "dateOfLastModification": "2024-01-01T00:00:00+00:00",
+    "dateOfLastModification": "2024-08-08T00:00:00+00:00",
     "categories": [
         "Quantum Chemistry"
     ],
@@ -14,7 +14,7 @@
     "previewImages": [
         {
             "type": "thumbnail",
-            "uri": "/_static/demonstration_assets/regular_demo_thumbnails/thumbnail_VQE_different_spin_sectors.png"
+            "uri": "/_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_VQE_different_spin_sectors.png"
         }
     ],
     "seoDescription": "Find the lowest-energy states of a Hamiltonian in different spin sectors",

--- a/demonstrations/vqe_parallel.metadata.json
+++ b/demonstrations/vqe_parallel.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2020-02-14T00:00:00+00:00",
-    "dateOfLastModification": "2024-01-01T00:00:00+00:00",
+    "dateOfLastModification": "2024-08-05T00:00:00+00:00",
     "categories": [
         "Quantum Chemistry"
     ],
@@ -14,7 +14,7 @@
     "previewImages": [
         {
             "type": "thumbnail",
-            "uri": "/_static/demonstration_assets/regular_demo_thumbnails/thumbnail_VQE_parallel_QPUs_Rigetti.png"
+            "uri": "/_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_VQE_parallel_QPUs_Rigetti.png"
         }
     ],
     "seoDescription": "Using parallel QPUs to speed up the calculation of the potential energy surface of molecular Hamiltonian.",

--- a/demonstrations/vqe_parallel.py
+++ b/demonstrations/vqe_parallel.py
@@ -7,7 +7,7 @@ VQE with parallel QPUs with Rigetti
 .. meta::
     :property="og:description": Using parallel QPUs to
         speed up the calculation of the potential energy surface of molecular Hamiltonian.
-    :property="og:image": https://pennylane.ai/qml/_static/demonstration_assets//vqe_diagram.png
+    :property="og:image": https://pennylane.ai/qml/_static/demonstration_assets/vqe_diagram.png
 
 .. related::
 


### PR DESCRIPTION
**Title:**
Update qchem demos to be JAX or JAX/JIT compatible

**Summary:**
As we phase out autograd, we need to ensure that our current qchem demos can work with either vanilla numpy or jax. Demos that are JIT compatible were made to use JIT as well. For demos that don't have any differentiation, we opt to use vanilla numpy.

Notes: the qubit tapering demo is not JIT compatible due to 2 issues: 1) Wire ordering is not ascending (Not a bug, but might need attention) 2) qml.taper_operation() uses the `Exp` operator, which has a conditional statement ([Bug report](https://github.com/PennyLaneAI/pennylane/issues/5993))

**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-69776]