### PR TITLE
Fix Learning Dynamics Incoherently author display and Glass Onion support

### DIFF
--- a/demonstrations/tutorial_learning_dynamics_incoherently.metadata.json
+++ b/demonstrations/tutorial_learning_dynamics_incoherently.metadata.json
@@ -24,7 +24,7 @@
     ],
     "seoDescription": "Learn how to reproduce an unknown quantum process with classical shadow measurements",
     "doi": "",
-    "canonicalURL": "/qml/demos/learning_dynamics_incoherently",
+    "canonicalURL": "/qml/demos/tutorial_learning_dynamics_incoherently",
     "references": [
         {
             "id": "jerbi2023power",


### PR DESCRIPTION
The demo author field was not appearing and the demo was not surfaced in search/Glass Onion due to an incorrect canonicalURL. Updated the canonicalURL field to match the demo.