### PR TITLE
Fixed Qrack demo. State cannot work with finite shots

### DIFF
--- a/demonstrations/qrack.metadata.json
+++ b/demonstrations/qrack.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2024-07-10T00:00:00+00:00",
-    "dateOfLastModification": "2024-08-05T00:00:00+00:00",
+    "dateOfLastModification": "2024-08-20T00:00:00+00:00",
     "categories": [
         "Devices and Performance"
     ],

--- a/demonstrations/qrack.py
+++ b/demonstrations/qrack.py
@@ -403,7 +403,7 @@ plt.show()
 def validate(n):
     results = []
     for device in ["qrack.simulator", "lightning.qubit"]:
-        dev = qml.device(device, n, shots=1)
+        dev = qml.device(device, n, shots=None)
 
         @qjit
         @qml.qnode(dev)


### PR DESCRIPTION
**Title:**
Modified qrack simulator demo.

**Summary:**
State measurements can not work with finite shots. However, there is such a case in qrack simulator demo which can cause failure with the latest catalyst which verifies this.

**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-70792]
