### PR TITLE
Update workflows to upload and sync objects.inv to dev, staging and prod environments

### DIFF
--- a/.github/workflows/deploy-demos-to-prod.yml
+++ b/.github/workflows/deploy-demos-to-prod.yml
@@ -19,6 +19,7 @@ jobs:
         run: |
           aws s3 cp --recursive s3://$AWS_S3_BUCKET_ID/master ./local-master
           aws s3 cp s3://$AWS_S3_HTML_BUCKET_ID/qml/searchindex.js searchindex.js
+          aws s3 cp s3://$AWS_S3_HTML_BUCKET_ID/qml/objects.inv objects.inv
 
       - name: Push production bucket
         env:
@@ -29,6 +30,7 @@ jobs:
         run: |
           aws s3 sync ./local-master s3://$AWS_S3_BUCKET_ID/master --delete
           aws s3 cp searchindex.js s3://$AWS_S3_HTML_BUCKET_ID/qml/searchindex.js
+          aws s3 cp objects.inv s3://$AWS_S3_HTML_BUCKET_ID/qml/objects.inv
 
       - name: Trigger production website build
         uses: peter-evans/repository-dispatch@v2

--- a/.github/workflows/upload-json.yml
+++ b/.github/workflows/upload-json.yml
@@ -105,6 +105,9 @@ jobs:
       - name: Sync searchindex to HTML Bucket
         run: aws s3 cp searchindex.js s3://$AWS_S3_HTML_BUCKET_ID/qml/searchindex.js
 
+      - name: Sync objects.inv to HTML Bucket
+        run: aws s3 cp ${{ steps.qml_json.outputs.download-path }}/objects.inv s3://$AWS_S3_HTML_BUCKET_ID/qml/objects.inv
+
   trigger-website-build:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
**Title:** Update workflows to upload and sync objects.inv to dev, staging and prod environments

**Summary:** 
Currently we do not sync the generated objects.inv file from QML sphinx build. This causes issues when building docs for pennylane docs as linking to things within QML fails.

A quick solution was being used currently where the objects.inv was being manually updated, but this PR changes the workflow so that it is done with merges to dev/master branches, 

**Relevant references:**
[sc-73313](https://app.shortcut.com/xanaduai/story/73313/update-qml-pipeline-to-save-objects-inv-from-each-master-dev-branch-build)


**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.

----
If you are writing a demonstration, please answer these questions to facilitate the marketing process.

* GOALS — Why are we working on this now?

  *Eg. Promote a new PL feature or show a PL implementation of a recent paper.*

N/A

* AUDIENCE — Who is this for?

  *Eg. Chemistry researchers, PL educators, beginners in quantum computing.*

N/A. Internal facing changes.

* KEYWORDS — What words should be included in the marketing post?


* Which of the following types of documentation is most similar to your file? 
(more details [here](https://www.notion.so/xanaduai/Different-kinds-of-documentation-69200645fe59442991c71f9e7d8a77f8))
    
- [ ] Tutorial
- [ ] Demo
- [ ] How-to