### PR TITLE
Use noise models in mitigation demos

### DIFF
--- a/demonstrations/tutorial_diffable-mitigation.metadata.json
+++ b/demonstrations/tutorial_diffable-mitigation.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2022-08-22T00:00:00+00:00",
-    "dateOfLastModification": "2024-08-06T00:00:00+00:00",
+    "dateOfLastModification": "2024-10-07T00:00:00+00:00",
     "categories": [
         "Optimization"
     ],

--- a/demonstrations/tutorial_diffable-mitigation.py
+++ b/demonstrations/tutorial_diffable-mitigation.py
@@ -42,7 +42,7 @@ PennyLane now provides one such differentiable quantum error mitigation techniqu
 Thus, we can improve the estimates of observables without breaking the differentiable workflow of our variational algorithm.
 We will briefly introduce these functionalities and afterwards go more in depth to explore what happens under the hood.
 
-We start by initializing a noisy device under the :class:`~.pennylane.DepolarizingChannel`:
+We start by initializing a noisy device using a noise model with :class:`~.pennylane.DepolarizingChannel` errors:
 """
 
 import pennylane as qml
@@ -54,13 +54,14 @@ from matplotlib import pyplot as plt
 n_wires = 4
 np.random.seed(1234)
 
-# Describe noise
-noise_gate = qml.DepolarizingChannel
-noise_strength = 0.05
+# Describe noise model
+fcond = qml.noise.wires_in(range(n_wires))
+noise = qml.noise.partial_wires(qml.DepolarizingChannel, 0.05)
+noise_model = qml.NoiseModel({fcond: noise})
 
 # Load devices
 dev_ideal = qml.device("default.mixed", wires=n_wires)
-dev_noisy = qml.transforms.insert(dev_ideal, noise_gate, noise_strength, position="all")
+dev_noisy = qml.add_noise(dev_ideal, noise_model=noise_model)
 
 ##############################################################################
 # We are going to use the transverse field Ising model Hamiltonian :math:`H = - \sum_i X_i X_{i+1} + 0.5 \sum_i Z_i` as our observable:

--- a/demonstrations/tutorial_error_mitigation.metadata.json
+++ b/demonstrations/tutorial_error_mitigation.metadata.json
@@ -9,7 +9,7 @@
         }
     ],
     "dateOfPublication": "2021-11-29T00:00:00+00:00",
-    "dateOfLastModification": "2024-08-21T00:00:00+00:00",
+    "dateOfLastModification": "2024-10-07T00:00:00+00:00",
     "categories": [
         "Algorithms",
         "Quantum Computing"

--- a/demonstrations/tutorial_error_mitigation.py
+++ b/demonstrations/tutorial_error_mitigation.py
@@ -49,31 +49,35 @@ accurately calculate the potential energy surface of molecular hydrogen.
 Mitigating noise in a simple circuit
 ------------------------------------
 
-We first need a noisy device to execute our circuit on. Let's keep things simple for now by loading
-the :mod:`default.mixed <pennylane.devices.default_mixed>` simulator and artificially adding
-:class:`PhaseDamping <pennylane.PhaseDamping>` noise.
+We first need a noisy device to execute our circuit on. Let's keep things simple
+for now by loading the :mod:`default.mixed <pennylane.devices.default_mixed>` simulator
+and artificially adding :class:`PhaseDamping <pennylane.PhaseDamping>` noise using a
+:class:`NoiseModel <pennylane.NoiseModel>`.
 """
 
 import pennylane as qml
 
 n_wires = 4
 
-# Describe noise
-noise_gate = qml.PhaseDamping
-noise_strength = 0.1
+# Describe noise model
+fcond = qml.noise.wires_in(range(n_wires))
+noise = qml.noise.partial_wires(qml.PhaseDamping, 0.1)
+noise_model = qml.NoiseModel({fcond: noise})
 
 # Load devices
 dev_ideal = qml.device("default.mixed", wires=n_wires)
-dev_noisy = qml.transforms.insert(dev_ideal, noise_gate, noise_strength)
+dev_noisy = qml.add_noise(dev_ideal, noise_model=noise_model)
 
 ###############################################################################
-# In the above, we load a noise-free device ``dev_ideal`` and a noisy device ``dev_noisy``, which
-# is constructed from the :func:`qml.transforms.insert <pennylane.transforms.insert>` transform.
-# This transform works by intercepting each circuit executed on the device and adding the
-# :class:`PhaseDamping <pennylane.PhaseDamping>` noise channel directly after every gate in the
-# circuit. To get a better understanding of noise channels like
-# :class:`PhaseDamping <pennylane.PhaseDamping>`, check out the :doc:`tutorial_noisy_circuits`
-# tutorial.
+# In the above, we load a noise-free device ``dev_ideal`` and a noisy device ``dev_noisy``,
+# which is constructed from the :func:`qml.add_noise <pennylane.transforms.add_noise>`
+# transform. This transform works by intercepting each circuit executed on the device and
+# adding the noise to it based on the ``noise_model``. For example, in this case, it will
+# add :class:`PhaseDamping <pennylane.PhaseDamping>` noise channel after every gate in the
+# circuit acting on wires :math:`[0, 1, 2, 3]`. To get a better understanding of noise
+# channels like :class:`PhaseDamping <pennylane.PhaseDamping>` and using noise models,
+# check out the :doc:`tutorial_noisy_circuits` and :doc:`tutorial_how_to_use_noise_models`
+# tutorials, respectively.
 #
 # The next step is to define our circuit. Inspired by the mirror circuits concept introduced by
 # Proctor *et al.* [#proctor2020measuring]_ let's fix a circuit that applies a unitary :math:`U`


### PR DESCRIPTION
Tweak the way noisy devices are defined in the mitigation demos using noise models, whenever possible. 