### PR TITLE
Fix a bug in dense_to_mps

### DIFF
--- a/demonstrations/tutorial_mps.metadata.json
+++ b/demonstrations/tutorial_mps.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2024-09-29T00:00:00+00:00",
-    "dateOfLastModification": "2024-10-07T00:00:00+00:00",
+    "dateOfLastModification": "2024-10-11T00:00:00+00:00",
     "categories": [
         "Quantum Computing",
         "Algorithms",

--- a/demonstrations/tutorial_mps.py
+++ b/demonstrations/tutorial_mps.py
@@ -330,7 +330,7 @@ def dense_to_mps(psi, bond_dim):
     Ms.append(U)
     Ss.append(Ss)
     bondL = Vd.shape[0]
-    psi = Vd
+    psi = np.tensordot(np.diag(S), Vd, 1)
 
     for _ in range(n-2):
         psi = np.reshape(psi, (2*bondL, -1)) # reshape psi[2 * bondL, (2x2x2...)]


### PR DESCRIPTION
Bug reported by @hsim13372 , thanks a lot!

Quick fix. This was missed because the function is just used to show the dimensionality.