### PR TITLE
Update update-dev to fetch entire git-history

### DIFF
--- a/.github/workflows/update-dev.yml
+++ b/.github/workflows/update-dev.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.NIGHTLY_TOKEN }}
+          fetch-depth: 0  # We want entire git-history to avoid any merge conflicts
 
       - name: Nightly Merge
         env:
@@ -45,10 +46,10 @@ jobs:
           git config --global user.email "$CONFIG_EMAIL"
 
           git fetch origin $MERGE_HEAD
-          (git checkout $MERGE_HEAD && git pull)
+          (git checkout $MERGE_HEAD && git pull origin $MERGE_HEAD)
 
           git fetch origin $MERGE_BASE
-          (git checkout $MERGE_BASE && git pull)
+          (git checkout $MERGE_BASE && git pull origin $MERGE_BASE)
 
           git merge $MERGE_ARGS $MERGE_HEAD
           git push origin $MERGE_BASE


### PR DESCRIPTION
**Title:** Update update-dev to fetch entire git-history

**Summary:**
`actions/checkout` fetches only the most recent commit. But this caused merge conflicts as git was not aware of entire history between the bases.

**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**

----
If you are writing a demonstration, please answer these questions to facilitate the marketing process.

* GOALS — Why are we working on this now?

  *Eg. Promote a new PL feature or show a PL implementation of a recent paper.*


* AUDIENCE — Who is this for?

  *Eg. Chemistry researchers, PL educators, beginners in quantum computing.*


* KEYWORDS — What words should be included in the marketing post?


* Which of the following types of documentation is most similar to your file? 
(more details [here](https://www.notion.so/xanaduai/Different-kinds-of-documentation-69200645fe59442991c71f9e7d8a77f8))
    
- [ ] Tutorial
- [ ] Demo
- [ ] How-to