### PR TITLE
Update `gradient_fn` argument to use `diff_method`

### DIFF
--- a/demonstrations/tutorial_error_mitigation.py
+++ b/demonstrations/tutorial_error_mitigation.py
@@ -273,7 +273,7 @@ def executor(circuits, dev=dev_noisy):
         )
         circuits_with_meas.append(circuit_with_meas)
 
-    return qml.execute(circuits_with_meas, dev, gradient_fn=None)
+    return qml.execute(circuits_with_meas, dev, diff_method=None)
 
 
 ##############################################################################
@@ -540,7 +540,7 @@ for r, phi in zip(distances, params):
         circuits, postproc = qml.transforms.split_non_commuting(
             circuit_with_meas, grouping_strategy=None
         )
-        circuits_executed = qml.execute(circuits, dev_noisy, gradient_fn=None)
+        circuits_executed = qml.execute(circuits, dev_noisy, diff_method=None)
         return postproc(circuits_executed)
 
     mitig_energy = execute_with_zne(circuit, executor, scale_noise=fold_global)

--- a/demonstrations/tutorial_quantum_circuit_cutting.py
+++ b/demonstrations/tutorial_quantum_circuit_cutting.py
@@ -741,10 +741,10 @@ print(f"Channel 1: {channel_shots[1]} times.")
 tape0 = QuantumTape(ops=ops_0, measurements=tape.measurements, shots=channel_shots[0].item())
 tape1 = QuantumTape(ops=ops_1, measurements=tape.measurements, shots=channel_shots[1].item())
 
-(shots0,) = qml.execute([tape0], device=device, cache=False, gradient_fn=None)
+(shots0,) = qml.execute([tape0], device=device, cache=False, diff_method=None)
 samples[choices == 0] = shots0
 
-(shots1,) = qml.execute([tape1], device=device, cache=False, gradient_fn=None)
+(shots1,) = qml.execute([tape1], device=device, cache=False, diff_method=None)
 samples[choices == 1] = shots1
 
 ######################################################################


### PR DESCRIPTION
**Summary:**

Updating this repository to use `diff_method` rather than `gradient_fn` as per the recent deprecation: https://github.com/PennyLaneAI/pennylane/pull/6549.

**Relevant references:**

Deprecation: https://github.com/PennyLaneAI/pennylane/pull/6549 

**Possible Drawbacks:** None.

[sc-77590]