### PR TITLE
Update deprecated usage of `tape` and `qtape` properties in `QNode`

### DIFF
--- a/demonstrations/qnspsa.metadata.json
+++ b/demonstrations/qnspsa.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2022-07-18T00:00:00+00:00",
-    "dateOfLastModification": "2024-11-06T00:00:00+00:00",
+    "dateOfLastModification": "2024-11-14T00:00:00+00:00",
     "categories": [
         "Optimization"
     ],

--- a/demonstrations/qnspsa.py
+++ b/demonstrations/qnspsa.py
@@ -356,13 +356,11 @@ print("Estimated SPSA gradient:\n", grad)
 # 0 (minimum overlap) and 1 (perfect overlap).
 #
 
-from copy import copy
-
 def get_overlap_tape(qnode, params1, params2):
     tape_forward = qml.workflow.construct_tape(qnode)(*params1)
     tape_inv = qml.workflow.construct_tape(qnode)(*params2)
 
-    ops = tape_forward.operations + list(qml.adjoint(copy(op)) for op in reversed(tape_inv.operations))
+    ops = tape_forward.operations + list(qml.adjoint(op) for op in reversed(tape_inv.operations))
     return qml.tape.QuantumTape(ops, [qml.probs(wires=tape_forward.wires)])
 
 def get_state_overlap(tape):

--- a/demonstrations/qnspsa.py
+++ b/demonstrations/qnspsa.py
@@ -363,14 +363,7 @@ def get_overlap_tape(qnode, params1, params2):
     tape_inv = qml.workflow.construct_tape(qnode)(*params2)
 
     ops = tape_forward.operations + list(qml.adjoint(copy(op)) for op in reversed(tape_inv.operations))
-
-    with qml.tape.QuantumTape() as tape:
-        for op in ops:
-            qml.apply(op)
-        qml.probs(wires=tape_forward.wires.labels)
-
-    return tape
-
+    return qml.tape.QuantumTape(ops, [qml.probs(wires=tape_forward.wires)])
 
 def get_state_overlap(tape):
     return qml.execute([tape], dev, None)[0][0]

--- a/demonstrations/tutorial_apply_qsvt.metadata.json
+++ b/demonstrations/tutorial_apply_qsvt.metadata.json
@@ -9,7 +9,7 @@
         }
     ],
     "dateOfPublication": "2023-08-22T00:00:00+00:00",
-    "dateOfLastModification": "2024-11-06T00:00:00+00:00",
+    "dateOfLastModification": "2024-11-14T00:00:00+00:00",
     "categories": [
         "Quantum Computing",
         "Algorithms",

--- a/demonstrations/tutorial_apply_qsvt.py
+++ b/demonstrations/tutorial_apply_qsvt.py
@@ -55,7 +55,7 @@ def my_circuit(phase_angles):
 ###############################################################################
 # We can now execute the circuit and visualize it.
 
-my_circuit(phase_angles)
+tape = qml.workflow.construct_tape(my_circuit)(phase_angles)
 print(qml.draw(my_circuit)(phase_angles))
 
 ###############################################################################
@@ -63,7 +63,7 @@ print(qml.draw(my_circuit)(phase_angles))
 # operation is composed of repeated applications of the :class:`~.pennylane.BlockEncode` and
 # :class:`~.pennylane.PCPhase` (:math:`\Pi_{\phi}`) operations.
 
-print(my_circuit.tape.expand().draw())
+print(tape.expand().draw())
 
 ###############################################################################
 # Now let's look at an application of QSVT --- solving a linear system of equations.

--- a/demonstrations/tutorial_clifford_circuit_simulations.metadata.json
+++ b/demonstrations/tutorial_clifford_circuit_simulations.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2024-04-12T00:00:00+00:00",
-    "dateOfLastModification": "2024-10-07T00:00:00+00:00",
+    "dateOfLastModification": "2024-11-14T00:00:00+00:00",
     "categories": [
         "Devices and Performance"
     ],

--- a/demonstrations/tutorial_clifford_circuit_simulations.py
+++ b/demonstrations/tutorial_clifford_circuit_simulations.py
@@ -381,7 +381,8 @@ print("Applying X(0): ", tableau_to_pauli_rep(snapshots[1]))
 # Let's examine the remaining operations to confirm this.
 #
 
-circuit_ops = circuit.tape.operations
+tape = qml.workflow.construct_tape(circuit)()
+circuit_ops = tape.operations
 print("Circ. Ops: ", circuit_ops)
 
 for step in range(1, len(circuit_ops)):


### PR DESCRIPTION
Summary:

Updating deprecated code that was introduced from a recent deprecation https://github.com/PennyLaneAI/pennylane/pull/6583.

[sc-76836]