### PR TITLE
Fix `max_expansion` deprecation warnings

### DIFF
--- a/demonstrations/tutorial_intro_qrom.metadata.json
+++ b/demonstrations/tutorial_intro_qrom.metadata.json
@@ -9,7 +9,7 @@
         }
     ],
     "dateOfPublication": "2024-09-18T00:00:00+00:00",
-    "dateOfLastModification": "2024-10-07T00:00:00+00:00",
+    "dateOfLastModification": "2024-11-18T00:00:00+00:00",
     "categories": [
         "Algorithms",
         "Quantum Computing"

--- a/demonstrations/tutorial_intro_qrom.py
+++ b/demonstrations/tutorial_intro_qrom.py
@@ -225,7 +225,7 @@ work_wires = [5, 6, 7, 8, 9, 10, 11, 12]
 
 
 # Line added for drawing purposes only
-@partial(qml.transforms.decompose, max_expansion=1)
+@partial(qml.transforms.decompose, max_expansion=2)
 @qml.qnode(qml.device("default.qubit", shots=1))
 def circuit(index):
     qml.BasisState(index, wires=control_wires)

--- a/demonstrations/tutorial_intro_qrom.py
+++ b/demonstrations/tutorial_intro_qrom.py
@@ -75,7 +75,7 @@ dev = qml.device("default.qubit", shots=1)
 
 
 # This line is included for drawing purposes only.
-@partial(qml.devices.preprocess.decompose, stopping_condition=lambda obj: False, max_expansion=1)
+@partial(qml.transforms.decompose, max_expansion=1)
 
 @qml.qnode(dev)
 def circuit(index):
@@ -225,7 +225,7 @@ work_wires = [5, 6, 7, 8, 9, 10, 11, 12]
 
 
 # Line added for drawing purposes only
-@partial(qml.devices.preprocess.decompose, stopping_condition=lambda obj: False, max_expansion=2)
+@partial(qml.transforms.decompose, max_expansion=1)
 @qml.qnode(qml.device("default.qubit", shots=1))
 def circuit(index):
     qml.BasisState(index, wires=control_wires)

--- a/demonstrations/tutorial_qft.metadata.json
+++ b/demonstrations/tutorial_qft.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2024-04-16T00:00:00+00:00",
-    "dateOfLastModification": "2024-10-07T00:00:00+00:00",
+    "dateOfLastModification": "2024-11-18T00:00:00+00:00",
     "categories": [
         "Algorithms",
         "Quantum Computing"

--- a/demonstrations/tutorial_qft.py
+++ b/demonstrations/tutorial_qft.py
@@ -97,7 +97,7 @@ import matplotlib.pyplot as plt
 plt.style.use('pennylane.drawer.plot')
 
 # This line is to expand the circuit to see the operators
-@partial(qml.transforms.decompose, gate_set=lambda obj: False, max_expansion=1)
+@partial(qml.transforms.decompose, max_expansion=1)
 
 def circuit():
     qml.QFT(wires=range(4))

--- a/demonstrations/tutorial_qft.py
+++ b/demonstrations/tutorial_qft.py
@@ -97,7 +97,7 @@ import matplotlib.pyplot as plt
 plt.style.use('pennylane.drawer.plot')
 
 # This line is to expand the circuit to see the operators
-@partial(qml.devices.preprocess.decompose, stopping_condition = lambda obj: False, max_expansion=1)
+@partial(qml.transforms.decompose, gate_set=lambda obj: False, max_expansion=1)
 
 def circuit():
     qml.QFT(wires=range(4))

--- a/demonstrations/tutorial_vqe_vqd.metadata.json
+++ b/demonstrations/tutorial_vqe_vqd.metadata.json
@@ -9,7 +9,7 @@
         }
     ],
     "dateOfPublication": "2024-08-26T00:00:00+00:00",
-    "dateOfLastModification": "2024-10-07T00:00:00+00:00",
+    "dateOfLastModification": "2024-11-18T00:00:00+00:00",
     "categories": [
         "Quantum Chemistry",
         "How-to"

--- a/demonstrations/tutorial_vqe_vqd.py
+++ b/demonstrations/tutorial_vqe_vqd.py
@@ -100,7 +100,7 @@ print(f"Ground state energy: {circuit()}")
 from functools import partial
 
 # This line is added to better visualise the circuit
-@partial(qml.devices.preprocess.decompose, stopping_condition = lambda obj:False, max_expansion=1)
+@partial(qml.transforms.decompose, max_expansion=1)
 
 def ansatz(theta, wires):
     singles, doubles = qml.qchem.excitations(2, n_qubits)


### PR DESCRIPTION
As the name suggests.

Demo outputs were confirmed to look the same.