### PR TITLE
Update `tutorial_noisy_circuits.py` to port `default.mixed` free of legacy interfaces

### DIFF
--- a/demonstrations/tutorial_noisy_circuits.metadata.json
+++ b/demonstrations/tutorial_noisy_circuits.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2021-02-22T00:00:00+00:00",
-    "dateOfLastModification": "2024-10-07T00:00:00+00:00",
+    "dateOfLastModification": "2024-12-18T00:00:00+00:00",
     "categories": [
         "Getting Started"
     ],

--- a/demonstrations/tutorial_noisy_circuits.py
+++ b/demonstrations/tutorial_noisy_circuits.py
@@ -144,13 +144,13 @@ def bitflip_circuit(p):
     qml.CNOT(wires=[0, 1])
     qml.BitFlip(p, wires=0)
     qml.BitFlip(p, wires=1)
-    return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1)), qml.state()
+    return {"expval": qml.expval(qml.PauliZ(0) @ qml.PauliZ(1)), "state": qml.state()}
 
 
 ps = [0.001, 0.01, 0.1, 0.2]
 for p in ps:
-    v, state = bitflip_circuit(p)
-    print(f"QNode output for bit flip probability {p} is v:.4f}")
+    result = bitflip_circuit(p)
+    print(f"QNode output for bit flip probability {result["expval"]} is v:.4f}")
 
 
 ######################################################################
@@ -159,7 +159,7 @@ for p in ps:
 # mitigation and error correction are so important. We can use PennyLane to look under the hood and
 # see the output state of the circuit for the largest noise parameter
 
-print(f"Output state for bit flip probability {p} is \n{state}")
+print(f"Output state for bit flip probability {p} is \n{result["state"]}")
 
 ######################################################################
 # Besides the bit flip channel, PennyLane supports several other noisy channels that are commonly

--- a/demonstrations/tutorial_noisy_circuits.py
+++ b/demonstrations/tutorial_noisy_circuits.py
@@ -150,7 +150,7 @@ def bitflip_circuit(p):
 ps = [0.001, 0.01, 0.1, 0.2]
 for p in ps:
     result = bitflip_circuit(p)
-    print(f"QNode output for bit flip probability {result["expval"]} is v:.4f}")
+    print(f"QNode output for bit flip probability {p} is {result["expval"]:.4f}")
 
 
 ######################################################################

--- a/demonstrations/tutorial_noisy_circuits.py
+++ b/demonstrations/tutorial_noisy_circuits.py
@@ -144,12 +144,13 @@ def bitflip_circuit(p):
     qml.CNOT(wires=[0, 1])
     qml.BitFlip(p, wires=0)
     qml.BitFlip(p, wires=1)
-    return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
+    return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1)), qml.state()
 
 
 ps = [0.001, 0.01, 0.1, 0.2]
 for p in ps:
-    print(f"QNode output for bit flip probability {p} is {bitflip_circuit(p):.4f}")
+    v, state = bitflip_circuit(p)
+    print(f"QNode output for bit flip probability {p} is v:.4f}")
 
 
 ######################################################################
@@ -158,7 +159,7 @@ for p in ps:
 # mitigation and error correction are so important. We can use PennyLane to look under the hood and
 # see the output state of the circuit for the largest noise parameter
 
-print(f"Output state for bit flip probability {p} is \n{np.real(dev.state)}")
+print(f"Output state for bit flip probability {p} is \n{state}")
 
 ######################################################################
 # Besides the bit flip channel, PennyLane supports several other noisy channels that are commonly

--- a/demonstrations/tutorial_noisy_circuits.py
+++ b/demonstrations/tutorial_noisy_circuits.py
@@ -144,13 +144,13 @@ def bitflip_circuit(p):
     qml.CNOT(wires=[0, 1])
     qml.BitFlip(p, wires=0)
     qml.BitFlip(p, wires=1)
-    return {"expval": qml.expval(qml.PauliZ(0) @ qml.PauliZ(1)), "state": qml.state()}
+    return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1)), qml.state()
 
 
 ps = [0.001, 0.01, 0.1, 0.2]
 for p in ps:
     result = bitflip_circuit(p)
-    print(f"QNode output for bit flip probability {p} is {result["expval"]:.4f}")
+    print(f"QNode output for bit flip probability {p} is {result[0]:.4f}")
 
 
 ######################################################################
@@ -159,7 +159,7 @@ for p in ps:
 # mitigation and error correction are so important. We can use PennyLane to look under the hood and
 # see the output state of the circuit for the largest noise parameter
 
-print(f"Output state for bit flip probability {p} is \n{result["state"]}")
+print(f"Output state for bit flip probability {p} is \n{result[1]}")
 
 ######################################################################
 # Besides the bit flip channel, PennyLane supports several other noisy channels that are commonly


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] Ensure that your tutorial executes correctly, and conforms to the
      guidelines specified in the [README](../README.md).

- [ ] Remember to do a grammar check of the content you include.
- [ ] All tutorials conform to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      To auto format files, simply `pip install black`, and then
      run `black -l 100 path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Title:**
Update `tutorial_noisy_circuits.py` to port `default.mixed` free of legacy interfaces

**Summary:**
In the Tutorial of Noisy Circuits, there's a call `dev.state` which is a legacy-only interface. In our current standard, the device object will not store the state any more and we should return the latest state via the corresponding measure.

**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**

----
If you are writing a demonstration, please answer these questions to facilitate the marketing process.

* GOALS — Why are we working on this now?

  *Eg. Promote a new PL feature or show a PL implementation of a recent paper.*


* AUDIENCE — Who is this for?

  *Eg. Chemistry researchers, PL educators, beginners in quantum computing.*


* KEYWORDS — What words should be included in the marketing post?


* Which of the following types of documentation is most similar to your file? 
(more details [here](https://www.notion.so/xanaduai/Different-kinds-of-documentation-69200645fe59442991c71f9e7d8a77f8))
    
- [ ] Tutorial
- [ ] Demo
- [ ] How-to