### PR TITLE
Updated all instances of upload/download artifact to use v4

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -224,7 +224,7 @@ jobs:
           echo "strategy-matrix=$matrix" >> $GITHUB_OUTPUT
 
       - name: Upload Workers Load Data as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.compute-strategy-matrix.outputs.worker_load_artifact_name }}
           path: ${{ steps.compute-strategy-matrix.outputs.worker_load_file_name }}
@@ -323,7 +323,7 @@ jobs:
           sudo apt install ocl-icd-opencl-dev
       
       - name: Download Worker Load Data Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.compute-build-strategy-matrix.outputs.worker-load-artifact-name }}
 
@@ -466,7 +466,7 @@ jobs:
 
       - name: Upload Execution Times
         if: inputs.skip_execution_of_examples == false
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: execution_times_${{ matrix.offset }}.zip
           if-no-files-found: error
@@ -500,7 +500,7 @@ jobs:
 
       - name: Upload Html
         if: matrix.offset == 0
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: html-${{ matrix.offset }}.zip
           if-no-files-found: error
@@ -513,7 +513,7 @@ jobs:
       # The step above this is executed by only one worker which uploads all static content.
       - name: Upload Demo Html
         if: matrix.offset != 0
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: html-${{ matrix.offset }}.zip
           if-no-files-found: error
@@ -534,7 +534,7 @@ jobs:
       - build-branch
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 
@@ -564,7 +564,7 @@ jobs:
 
       - name: Upload Sphinx Build files
         if: inputs.skip_sphinx_build_file_aggregation == false
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.sphinx_build_output_format }}.zip
           if-no-files-found: error
@@ -572,7 +572,7 @@ jobs:
 
       - name: Upload Execution Times
         if: inputs.skip_execution_of_examples == false && inputs.skip_execution_times_aggregation == false
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: execution_times.zip
           path: /tmp/execution_times

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -149,7 +149,7 @@ jobs:
           EOL
       - name: Upload Pull Request Event Context as Artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr_info
           path: /tmp/pr

--- a/.github/workflows/demo_diff_check.yml
+++ b/.github/workflows/demo_diff_check.yml
@@ -67,7 +67,7 @@ jobs:
           make html
           zip -r /tmp/qml_demos.zip demos
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: built-website-dev
           path: |
@@ -136,7 +136,7 @@ jobs:
           make html
           zip -r /tmp/qml_demos.zip demos
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: built-website-master
           path: |
@@ -156,7 +156,7 @@ jobs:
     - name: Create dev dir
       run: mkdir /tmp/dev/
 
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
         name: built-website-dev
         path: /tmp/dev/
@@ -164,7 +164,7 @@ jobs:
     - name: Create master dir
       run: mkdir /tmp/master/
 
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
         name: built-website-master
         path: /tmp/master/
@@ -186,7 +186,7 @@ jobs:
         git commit -m "Update the demonstration differences found"
         git push
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: demo_diffs
         path: |

--- a/.github/workflows/upload-json.yml
+++ b/.github/workflows/upload-json.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Download HTML
         id: qml_json
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
           path: qml_json

--- a/.github/workflows/upload-text.yml
+++ b/.github/workflows/upload-text.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Download Text
         id: qml_text
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
           path: qml_text


### PR DESCRIPTION
**Title:** Updated all instances of upload/download artifact to use v4

**Summary:**
All versions of `actions/upload-artifact` and `actions/download-artifact` that are older than major version `v4` are no longer supported by GitHub: [See Blogpost](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

This PR updates all instances of these actions within the QML CI to use the v4 version.

**Relevant references:**
[sc-81821]

**Possible Drawbacks:**
Though on the slight chance some hiccups can be encountered, we have no choice but for fall forwards on this change.

**Related GitHub Issues:**
None.
