### PR TITLE
[QA v0.40.0] Fix liesim_extension demo

### DIFF
--- a/demonstrations/tutorial_liesim_extension.metadata.json
+++ b/demonstrations/tutorial_liesim_extension.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2024-06-18T00:00:00+00:00",
-    "dateOfLastModification": "2024-10-07T00:00:00+00:00",
+    "dateOfLastModification": "2025-01-13T00:00:00+00:00",
     "categories": [
         "Quantum Computing",
         "Quantum Machine Learning"

--- a/demonstrations/tutorial_liesim_extension.py
+++ b/demonstrations/tutorial_liesim_extension.py
@@ -133,7 +133,7 @@ U = expm(theta * gate)
 #
 # For that, let us construct a concrete example. First we pick two elements from :math:`\mathfrak{g}` such that their product is not in :math:`\mathfrak{g}.`
 
-p = dla[-5] @ dla[-2]
+p = dla[-5] @ dla[-1]
 p = next(iter(p)) # strip any scalar coefficients
 dla_vspace = qml.pauli.PauliVSpace(dla, dtype=complex)
 dla_vspace.is_independent(p.pauli_rep)
@@ -414,9 +414,11 @@ adjoint_repr = qml.structure_constants(Moment[comp_moment])
 #
 # We can now choose arbitrary DLA gates and a maximum of `one` :math:`P` gate to evolve the expectation value vector.
 
+P_index = Moment[comp_moment].index(1.*p) # pick the gate in the Moment space that p corrresponds to
+
 e_t = e_in
 e_t = expm(0.5 * adjoint_repr[dim_g-1]) @ e_t # the same U gate
-e_t = expm(0.5 * adjoint_repr[74]) @ e_t      # the same P gate
+e_t = expm(0.5 * adjoint_repr[P_index]) @ e_t      # the same P gate
 e_t = expm(0.5 * adjoint_repr[dim_g-2]) @ e_t # the same V gate
 
 ##############################################################################


### PR DESCRIPTION
The order of the operators in the lie closure changed with https://github.com/PennyLaneAI/pennylane/pull/6724 such that the hard-coded indices are not correct anymore.

I changed the latter part where we pick the gate in the moment space according to the $p = O_1 O_2$ that is not in the moment space to automatically pick it from the list (instead of hard-coding the index). However, the first choice of $p$ is hard to automate, the only thing that matters is that $p = O_1 O_2$ is not in the DLA

Note for reviewers:
The important thing to look at is that the outputs are now again `True`