### PR TITLE
Math typo QSVT intro

### DIFF
--- a/demonstrations/tutorial_intro_qsvt.metadata.json
+++ b/demonstrations/tutorial_intro_qsvt.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2023-05-23T00:00:00+00:00",
-    "dateOfLastModification": "2024-12-05T00:00:00+00:00",
+    "dateOfLastModification": "2025-01-21T00:00:00+00:00",
     "categories": [
         "Algorithms",
         "Quantum Computing"

--- a/demonstrations/tutorial_intro_qsvt.py
+++ b/demonstrations/tutorial_intro_qsvt.py
@@ -73,8 +73,8 @@ transformed to a polynomial of higher degree, and by interleaving signal-process
 it's possible to tune the coefficients of the polynomial. For example
 
 .. math:: S(-\pi/2) U(a) S(\pi/2) U(a) S(0) = \begin{pmatrix}
-    2a^2-1 & 0\\
-    0 & 2a^2 -1
+    2a^2-1 & 2a\sqrt{1-a^2}\\
+    -2a\sqrt{1-a^2} & 2a^2 -1
     \end{pmatrix}.
 
 The main quantum signal processing theorem states that it is possible to find


### PR DESCRIPTION
**Summary:**
The intro to QSVT computes a manual example with 2x2 matrices. There is a tiny (not impactful) mistake in a matrix equation for that example.