### PR TITLE
Fix controlled qubit unitary usage

### DIFF
--- a/demonstrations/tutorial_classically_boosted_vqe.metadata.json
+++ b/demonstrations/tutorial_classically_boosted_vqe.metadata.json
@@ -9,7 +9,7 @@
         }
     ],
     "dateOfPublication": "2022-10-31T00:00:00+00:00",
-    "dateOfLastModification": "2024-12-13T00:00:00+00:00",
+    "dateOfLastModification": "2025-01-23T00:00:00+00:00",
     "categories": [
         "Quantum Chemistry"
     ],

--- a/demonstrations/tutorial_classically_boosted_vqe.py
+++ b/demonstrations/tutorial_classically_boosted_vqe.py
@@ -449,7 +449,7 @@ def hadamard_test(Uq, Ucl, component="real"):
 
     qml.Hadamard(wires=[0])
     qml.ControlledQubitUnitary(
-        Uq.conjugate().T @ Ucl, control_wires=[0], wires=wires[1:]
+        Uq.conjugate().T @ Ucl, wires
     )
     qml.Hadamard(wires=[0])
 

--- a/demonstrations/tutorial_classically_boosted_vqe.py
+++ b/demonstrations/tutorial_classically_boosted_vqe.py
@@ -449,7 +449,7 @@ def hadamard_test(Uq, Ucl, component="real"):
 
     qml.Hadamard(wires=[0])
     qml.ControlledQubitUnitary(
-        Uq.conjugate().T @ Ucl, wires
+        Uq.conjugate().T @ Ucl, wires=wires
     )
     qml.Hadamard(wires=[0])
 

--- a/demonstrations/tutorial_testing_symmetry.metadata.json
+++ b/demonstrations/tutorial_testing_symmetry.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2023-01-24T00:00:00+00:00",
-    "dateOfLastModification": "2024-11-06T00:00:00+00:00",
+    "dateOfLastModification": "2025-01-23T00:00:00+00:00",
     "categories": [
         "Algorithms",
         "Quantum Computing"

--- a/demonstrations/tutorial_testing_symmetry.py
+++ b/demonstrations/tutorial_testing_symmetry.py
@@ -308,14 +308,14 @@ def prep_plus():
 
 # Implement controlled symmetry operations on system
 def CU_sys():
-    qml.ControlledQubitUnitary(c_mat @ c_mat, control_wires=[aux[0]], wires=system)
-    qml.ControlledQubitUnitary(c_mat, control_wires=[aux[1]], wires=system)
+    qml.ControlledQubitUnitary(c_mat @ c_mat, wires=[aux[0]] + system)
+    qml.ControlledQubitUnitary(c_mat, wires=[aux[1]] + system)
 
 
 # Implement controlled symmetry operations on copy
 def CU_cpy():
-    qml.ControlledQubitUnitary(c_mat @ c_mat, control_wires=[aux[0]], wires=copy)
-    qml.ControlledQubitUnitary(c_mat, control_wires=[aux[1]], wires=copy)
+    qml.ControlledQubitUnitary(c_mat @ c_mat, wires=[aux[0]] + copy)
+    qml.ControlledQubitUnitary(c_mat, wires=[aux[1]] + copy)
 
 ######################################################################
 # Let’s combine everything and actually run our circuit!

--- a/demonstrations/tutorial_testing_symmetry.py
+++ b/demonstrations/tutorial_testing_symmetry.py
@@ -308,14 +308,14 @@ def prep_plus():
 
 # Implement controlled symmetry operations on system
 def CU_sys():
-    qml.ControlledQubitUnitary(c_mat @ c_mat, wires=[aux[0]] + system)
-    qml.ControlledQubitUnitary(c_mat, wires=[aux[1]] + system)
+    qml.ControlledQubitUnitary(c_mat @ c_mat, wires=[aux[0]] + list(system))
+    qml.ControlledQubitUnitary(c_mat, wires=[aux[1]] + list(system))
 
 
 # Implement controlled symmetry operations on copy
 def CU_cpy():
-    qml.ControlledQubitUnitary(c_mat @ c_mat, wires=[aux[0]] + copy)
-    qml.ControlledQubitUnitary(c_mat, wires=[aux[1]] + copy)
+    qml.ControlledQubitUnitary(c_mat @ c_mat, wires=[aux[0]] + list(copy))
+    qml.ControlledQubitUnitary(c_mat, wires=[aux[1]] + list(copy))
 
 ######################################################################
 # Let’s combine everything and actually run our circuit!


### PR DESCRIPTION
**Title:**
Adjust interface of `ControlledQubitUnitary` to be compatible with PennyLane v0.41

**Summary:**
changed 5 occurences in demonstrations/tutorial_classically_boosted_vqe.py and demonstrations/tutorial_testing_symmetry.py

**Related Shortcut Stories:**
[sc-80842]