### PR TITLE
Fix `tutorial_pulse_programming101.py` to type cast `expval`

### DIFF
--- a/demonstrations/tutorial_pulse_programming101.metadata.json
+++ b/demonstrations/tutorial_pulse_programming101.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2023-03-08T00:00:00+00:00",
-    "dateOfLastModification": "2024-10-07T00:00:00+00:00",
+    "dateOfLastModification": "2025-02-14T00:00:00+00:00",
     "categories": [
         "Quantum Hardware",
         "Quantum Computing"

--- a/demonstrations/tutorial_pulse_programming101.py
+++ b/demonstrations/tutorial_pulse_programming101.py
@@ -327,7 +327,8 @@ dev = qml.device("default.qubit", wires=range(n_wires))
 
 
 def qnode(theta, t=duration):
-    @qml.qnode(dev, interface="jax")
+
+    @qml.qnode(dev)
     def _qnode_inner(theta, t=duration):
         qml.BasisState(jnp.array(data.tapered_hf_state), wires=H_obj.wires)
         qml.evolve(H_pulse)(params=(*theta, *theta), t=t)

--- a/demonstrations/tutorial_pulse_programming101.py
+++ b/demonstrations/tutorial_pulse_programming101.py
@@ -322,9 +322,10 @@ H_pulse = H_D + H_C
 
 ##############################################################################
 # Now we define the ``qnode`` that computes the expectation value of the molecular Hamiltonian.
+# We need to wrap the ``qnode`` in a function so that we can convert the expectation value to a real number.
+# This will enable use to make use of gradient descent methods that require real-valued loss functions.
 
 dev = qml.device("default.qubit", wires=range(n_wires))
-
 
 def qnode(theta, t=duration):
 
@@ -335,8 +336,7 @@ def qnode(theta, t=duration):
         return qml.expval(H_obj)
 
     expectation_value = _qnode_inner(theta, t)  # Execute the qnode
-    return jnp.real(expectation_value)  # Extract real part
-
+    return jnp.real(expectation_value)  # Typecast to real number
 
 value_and_grad = jax.jit(jax.value_and_grad(qnode))
 


### PR DESCRIPTION
**Context:**

In https://github.com/PennyLaneAI/pennylane/pull/6939, a fix was made to `qml.expval` so that it no longer silently converts the result to a real number. However, in `tutorial_pulse_programming101.py` we use a Hamiltonian with complex-typed coefficients. This resulted in an imaginary expectation value (`X+0j`) and broke the `jax.value_and_grad` function.

**Description of change:**

Wrap the `qnode` function to get the expectation value and convert it to a real number. This allows `jax.value_and_grad` to be used and fixes the demo.