### PR TITLE
Update stateprep decomposition in tutorial_how_to_quantum_just_in_time_compile_vqe_catalyst demo

### DIFF
--- a/demonstrations/tutorial_how_to_quantum_just_in_time_compile_vqe_catalyst.metadata.json
+++ b/demonstrations/tutorial_how_to_quantum_just_in_time_compile_vqe_catalyst.metadata.json
@@ -9,7 +9,7 @@
         }
     ],
     "dateOfPublication": "2024-04-26T00:00:00+00:00",
-    "dateOfLastModification": "2024-11-08T00:00:00+00:00",
+    "dateOfLastModification": "2025-03-12T00:00:00+00:00",
     "categories": [
         "Quantum Machine Learning",
         "Optimization",

--- a/demonstrations/tutorial_how_to_quantum_just_in_time_compile_vqe_catalyst.py
+++ b/demonstrations/tutorial_how_to_quantum_just_in_time_compile_vqe_catalyst.py
@@ -123,7 +123,7 @@ hf = np.array(dataset.hf_state)
 @qml.qjit
 @qml.qnode(dev)
 def cost(params):
-    qml.BasisState.compute_decomposition(hf, wires=range(qubits))
+    qml.BasisState(hf, wires=range(qubits))
     qml.DoubleExcitation(params[0], wires=[0, 1, 2, 3])
     qml.DoubleExcitation(params[1], wires=[0, 1, 4, 5])
     return qml.expval(H)


### PR DESCRIPTION
**Title:**
Update tutorial_how_to_quantum_just_in_time_compile_vqe_catalyst demo.

**Summary:**
Update a demo to reflect changes in this [PR](https://github.com/PennyLaneAI/catalyst/pull/1562).  
Remove compute_decomposition for the state prep instruction as it will happen automatically when in a gradient method.

**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**

----
If you are writing a demonstration, please answer these questions to facilitate the marketing process.

* GOALS — Why are we working on this now?

  *Eg. Promote a new PL feature or show a PL implementation of a recent paper.*


* AUDIENCE — Who is this for?

  *Eg. Chemistry researchers, PL educators, beginners in quantum computing.*


* KEYWORDS — What words should be included in the marketing post?


* Which of the following types of documentation is most similar to your file? 
(more details [here](https://www.notion.so/xanaduai/Different-kinds-of-documentation-69200645fe59442991c71f9e7d8a77f8))
    
- [ ] Tutorial
- [] Demo
- [ ] How-to