### PR TITLE
Unsupported function in the notebook

### DIFF
--- a/demonstrations/quantum_neural_net.py
+++ b/demonstrations/quantum_neural_net.py
@@ -84,7 +84,7 @@ def quantum_neural_net(var, x):
     for v in var:
         layer(v)
 
-    return qml.expval(qml.QuadX(0))
+    return qml.expval(qml.X(0))
 
 
 ##############################################################################


### PR DESCRIPTION
**Title:**
Unsupported function in the notebook
**Summary:**
qml.quadX is not supported in pennylane≤0.29 and results in error. Change to qml.X
**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**