### PR TITLE
Upgrading tj-actions version to 46

### DIFF
--- a/.github/actions/get-changed-demos/action.yml
+++ b/.github/actions/get-changed-demos/action.yml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - id: changed-files
-      uses: tj-actions/changed-files@v45
+      uses: tj-actions/changed-files@v46
       with:
         # Exclude changes outside the current 
         # directory and show path names 

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Get Changed Demos
         id: changed_demos
         if: env.BUILD_ALL_DEMOS == 'false'
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@v46
         with:
           files: demonstrations/*.py
 


### PR DESCRIPTION
------------------------------------------------------------------------------------------------------------

**Title:** Upgrading tj-actions to version 46

**Summary:**
- Harden-Runner detection: tj-actions/changed-files action is compromised. This vulnerability exposed build secrets by printing CI/CD secrets in GitHub Actions build logs. This change upgrades the tj-actions to a version with the vulnerability fixed.

**Relevant references:**
[Security Issue Summary](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised).
- **Possible Drawbacks:**
- None
**Related GitHub Issues:**
