### PR TITLE
Add references to new `qml.liealg` functionality in Lie algebraic demos

### DIFF
--- a/demonstrations/tutorial_fixed_depth_hamiltonian_simulation_via_cartan_decomposition.metadata.json
+++ b/demonstrations/tutorial_fixed_depth_hamiltonian_simulation_via_cartan_decomposition.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2024-12-19T00:00:00+00:00",
-    "dateOfLastModification": "2025-03-25T00:00:00+00:00",
+    "dateOfLastModification": "2025-03-26T00:00:00+00:00",
     "categories": [
         "Quantum Computing",
         "Algorithms"

--- a/demonstrations/tutorial_fixed_depth_hamiltonian_simulation_via_cartan_decomposition.metadata.json
+++ b/demonstrations/tutorial_fixed_depth_hamiltonian_simulation_via_cartan_decomposition.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2024-12-19T00:00:00+00:00",
-    "dateOfLastModification": "2025-01-10T00:00:00+00:00",
+    "dateOfLastModification": "2025-03-XXT00:00:00+00:00",
     "categories": [
         "Quantum Computing",
         "Algorithms"

--- a/demonstrations/tutorial_fixed_depth_hamiltonian_simulation_via_cartan_decomposition.metadata.json
+++ b/demonstrations/tutorial_fixed_depth_hamiltonian_simulation_via_cartan_decomposition.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2024-12-19T00:00:00+00:00",
-    "dateOfLastModification": "2025-03-XXT00:00:00+00:00",
+    "dateOfLastModification": "2025-03-25T00:00:00+00:00",
     "categories": [
         "Quantum Computing",
         "Algorithms"

--- a/demonstrations/tutorial_fixed_depth_hamiltonian_simulation_via_cartan_decomposition.py
+++ b/demonstrations/tutorial_fixed_depth_hamiltonian_simulation_via_cartan_decomposition.py
@@ -20,7 +20,7 @@ circuit optimization, and Hamiltonian simulation.
 Introduction
 ------------
 
-The :doc:`KAK theorem </demos/tutorial_kak_decomposition>` is an important result from Lie theory that states that any Lie group element :math:`U` can be decomposed
+The :doc:`KAK decomposition </demos/tutorial_kak_decomposition>` is an important result from Lie theory that states that any Lie group element :math:`U` can be decomposed
 as :math:`U = K_1 A K_2,` where :math:`K_{1, 2}` and :math:`A` are elements of two special sub-groups
 :math:`\mathcal{K}` and :math:`\mathcal{A},` respectively. In special cases, the decomposition simplifies to :math:`U = K A K^\dagger.`
 
@@ -36,14 +36,14 @@ just as is the case for diagonal matrices.
 We can use this general result from Lie theory as a powerful circuit decomposition technique.
 
 .. note:: We recommend a basic understanding of Lie algebras, see e.g. our :doc:`introduction to (dynamical) Lie algebras for quantum practitioners </demos/tutorial_liealgebra>`.
-    Otherwise, this demo should be self-contained, though for the mathematically inclined, we further recommend our :doc:`demo on the KAK theorem </demos/tutorial_kak_decomposition>`
-    that dives into the mathematical depths of the theorem and provides more background info.
+    Otherwise, this demo should be self-contained, though for the mathematically inclined, we further recommend our :doc:`demo on the KAK decomposition </demos/tutorial_kak_decomposition>`
+    that dives into the mathematical depths of the decomposition and provides more background info.
 
 Goal: Fast-forwarding time evolutions using the KAK decomposition
 -----------------------------------------------------------------
 
 Unitary gates in quantum computing are described by the special unitary Lie group :math:`SU(2^n),` so we can use the KAK
-theorem to decompose quantum gates into :math:`U = K_1 A K_2.` While the mathematical statement is rather straightforward,
+decomposition to factorize quantum gates into :math:`U = K_1 A K_2.` While the mathematical statement is rather straightforward,
 actually finding this decomposition is not. We are going to follow the recipe prescribed in 
 `Fixed Depth Hamiltonian Simulation via Cartan Decomposition <https://arxiv.org/abs/2104.00728>`__ [#Kökcü]_, 
 which tackles this decomposition on the level of the associated Lie algebra via Cartan decomposition.
@@ -111,6 +111,7 @@ g = [op.pauli_rep for op in g]
 # One common choice of involution is the so-called even-odd involution for Pauli words,
 # :math:`P = P_1 \otimes P_2 .. \otimes P_n,` where :math:`P_j \in \{I, X, Y, Z\}.`
 # It essentially counts whether the number of non-identity Pauli operators in the Pauli word is even or odd.
+# This involution also is readily available in PennyLane as :func:`~.pennylane.liealg.even_odd_involution`.
 
 def even_odd_involution(op):
     [pw] = op.pauli_rep
@@ -125,8 +126,9 @@ even_odd_involution(X(0)), even_odd_involution(X(0) @ Y(3))
 # So in order to perform the Cartan decomposition :math:`\mathfrak{g} = \mathfrak{k} \oplus \mathfrak{m},` we simply
 # sort the operators by whether or not they yield a plus or minus sign from the involution function.
 # This is possible because the operators and involution nicely align with the eigenspace decomposition.
+# The following is a copy of :func:`~.pennylane.liealg.cartan_decomp`.
 
-def cartan_decomposition(g, involution):
+def cartan_decomp(g, involution):
     """Cartan Decomposition g = k + m
     
     Args:
@@ -146,7 +148,7 @@ def cartan_decomposition(g, involution):
             m.append(op)
     return k, m
 
-k, m = cartan_decomposition(g, even_odd_involution)
+k, m = cartan_decomp(g, even_odd_involution)
 len(g), len(k), len(m)
 
 
@@ -188,6 +190,8 @@ for op in H.operands:
 #
 # We then obtain a further split of the vector space :math:`\mathfrak{m} = \tilde{\mathfrak{m}} \oplus \mathfrak{h},`
 # where :math:`\tilde{\mathfrak{m}}` is just the remainder of :math:`\mathfrak{m}.`
+# A more versatile function to compute Cartan subalgebras is available in PennyLane
+# as :func:`~.pennylane.liealg.cartan_subalgebra`.
 
 def _commutes_with_all(candidate, ops):
     r"""Check if ``candidate`` commutes with all ``ops``"""
@@ -241,7 +245,7 @@ len(g), len(k), len(mtilde), len(h)
 # Variational KhK decomposition
 # -----------------------------
 #
-# The KAK theorem is not constructive in the sense that it proves that there exists such a decomposition, but there is no general way of obtaining
+# The KAK decomposition is not constructive in the sense that it proves that there exists such a decomposition, but there is no general way of obtaining
 # it. In particular, there are no linear algebra subroutines implemented in ``numpy`` or ``scipy`` that just compute it for us.
 # Here, we follow the construction of [#Kökcü]_ for the special case of :math:`H` being in the horizontal space and the decomposition
 # simplifying to :math:`H = K^\dagger h K`.
@@ -478,7 +482,7 @@ plt.show()
 # Conclusion
 # ----------
 #
-# The KAK theorem is a very general mathematical result with far-reaching consequences.
+# The KAK decomposition is a very general mathematical result with far-reaching consequences.
 # While there is no canonical way of obtaining an actual decomposition in practice, we followed
 # the approach of [#Kökcü]_ which uses a specifically designed loss function and variational
 # optimization to find the decomposition.

--- a/demonstrations/tutorial_fixed_depth_hamiltonian_simulation_via_cartan_decomposition.py
+++ b/demonstrations/tutorial_fixed_depth_hamiltonian_simulation_via_cartan_decomposition.py
@@ -74,7 +74,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pennylane as qml
 from pennylane import X, Y, Z
-from pennylane.liealg import even_odd_involution, cartan_decomp, cartan_subalgebra
+from pennylane.liealg import even_odd_involution, cartan_decomp, horizontal_cartan_subalgebra
 
 import jax
 import jax.numpy as jnp
@@ -166,10 +166,10 @@ for op in H.operands:
 #
 # We then obtain a further split of the vector space :math:`\mathfrak{m} = \tilde{\mathfrak{m}} \oplus \mathfrak{h},`
 # where :math:`\tilde{\mathfrak{m}}` is just the remainder of :math:`\mathfrak{m}.` The function
-# :func:`~.pennylane.liealg.cartan_subalgebra` returns some additional information, which we will
+# :func:`~.pennylane.liealg.horizontal_cartan_subalgebra` returns some additional information, which we will
 # not use here.
 
-g, k, mtilde, h, _ = cartan_subalgebra(k, m)
+g, k, mtilde, h, _ = horizontal_cartan_subalgebra(k, m)
 len(g), len(k), len(mtilde), len(h)
 
 ##############################################################################

--- a/demonstrations/tutorial_fixed_depth_hamiltonian_simulation_via_cartan_decomposition.py
+++ b/demonstrations/tutorial_fixed_depth_hamiltonian_simulation_via_cartan_decomposition.py
@@ -169,7 +169,7 @@ for op in H.operands:
 # :func:`~.pennylane.liealg.cartan_subalgebra` returns some additional information, which we will
 # not use here.
 
-*_, mtilde, h, _ = cartan_subalgebra(k, m)
+g, k, mtilde, h, _ = cartan_subalgebra(k, m)
 len(g), len(k), len(mtilde), len(h)
 
 ##############################################################################

--- a/demonstrations/tutorial_kak_decomposition.metadata.json
+++ b/demonstrations/tutorial_kak_decomposition.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2024-11-25T00:00:00+00:00",
-    "dateOfLastModification": "2025-03-17T09:00:00+00:00",
+    "dateOfLastModification": "2025-03-XXT09:00:00+00:00",
     "categories": [
         "Quantum Computing",
         "Algorithms"

--- a/demonstrations/tutorial_kak_decomposition.metadata.json
+++ b/demonstrations/tutorial_kak_decomposition.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2024-11-25T00:00:00+00:00",
-    "dateOfLastModification": "2025-03-25T09:00:00+00:00",
+    "dateOfLastModification": "2025-03-26T09:00:00+00:00",
     "categories": [
         "Quantum Computing",
         "Algorithms"

--- a/demonstrations/tutorial_kak_decomposition.metadata.json
+++ b/demonstrations/tutorial_kak_decomposition.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2024-11-25T00:00:00+00:00",
-    "dateOfLastModification": "2025-03-XXT09:00:00+00:00",
+    "dateOfLastModification": "2025-03-25T09:00:00+00:00",
     "categories": [
         "Quantum Computing",
         "Algorithms"

--- a/demonstrations/tutorial_kak_decomposition.py
+++ b/demonstrations/tutorial_kak_decomposition.py
@@ -348,12 +348,13 @@ def is_orthogonal(op, basis):
 #
 # Let us define it in code, and check whether it gives rise to a Cartan decomposition.
 # As we want to look at another example later, we wrap everything in a function.
+# A similar function is available in PennyLane as :func:`~.pennylane.liealg.check_cartan_decomp`.
 #
 
 
-def check_cartan_decomposition(g, k, space_name):
+def check_cartan_decomp(g, k, space_name):
     """Given an algebra g and an operator subspace k, verify that k is a subalgebra
-    and gives rise to a Cartan decomposition."""
+    and gives rise to a Cartan decomposition. Similar to qml.liealg.check_cartan_decomp"""
     # Check Lie closure of k
     k_lie_closure = qml.lie_closure(k)
     k_is_closed = len(k_lie_closure) == len(k)
@@ -387,7 +388,7 @@ def check_cartan_decomposition(g, k, space_name):
 
 u1 = [Z(0)]
 space_name = "SU(2)/U(1)"
-p = check_cartan_decomposition(su2, u1, space_name)
+p = check_cartan_decomp(su2, u1, space_name)
 
 ######################################################################
 # Cartan subalgebras
@@ -811,7 +812,7 @@ print(f"su(4) is {len(su4)}-dimensional")
 # Define subalgebra su(2) ⊕ su(2)
 su2_su2 = [X(0), Y(0), Z(0), X(1), Y(1), Z(1)]
 space_name = "SU(4)/(SU(2)xSU(2))"
-p = check_cartan_decomposition(su4, su2_su2, space_name)
+p = check_cartan_decomp(su4, su2_su2, space_name)
 
 ######################################################################
 # .. admonition:: Math detail: involution for two-qubit decomposition

--- a/demonstrations/tutorial_liesim_extension.metadata.json
+++ b/demonstrations/tutorial_liesim_extension.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2024-06-18T00:00:00+00:00",
-    "dateOfLastModification": "2025-03-25T00:00:00+00:00",
+    "dateOfLastModification": "2025-03-26T00:00:00+00:00",
     "categories": [
         "Quantum Computing",
         "Quantum Machine Learning"

--- a/demonstrations/tutorial_liesim_extension.metadata.json
+++ b/demonstrations/tutorial_liesim_extension.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2024-06-18T00:00:00+00:00",
-    "dateOfLastModification": "2025-03-17T00:00:00+00:00",
+    "dateOfLastModification": "2025-03-25T00:00:00+00:00",
     "categories": [
         "Quantum Computing",
         "Quantum Machine Learning"

--- a/demonstrations/tutorial_liesim_extension.py
+++ b/demonstrations/tutorial_liesim_extension.py
@@ -100,8 +100,8 @@ def TFIM(n):
     generators = [op.pauli_rep for op in generators]
 
     dla = qml.lie_closure(generators, pauli=True)
-    dim_dla = len(dla)
-    return generators, dla, dim_dla
+    dim_g = len(dla)
+    return generators, dla, dim_g
 
 generators, dla, dim_g = TFIM(n=4)
 


### PR DESCRIPTION
**Context**
Recently, Lie algebraic functionality was promoted from `qml.labs` to `qml.liealg` module.
Some demos related to Lie algebras code up their own variants of some of this functionality.

**Changes**

- This PR adds references to the PL functionalities and removes their copies within the "Fixed-depth Hamiltonian simulation via Cartan decomposition" demo.
- The names of the variants in the demos are updated if there is a corresponding PennyLane pendant.
- Naming change from "KAK theorem" to "KAK decomposition", following #1287 