### PR TITLE
Add react master token

### DIFF
--- a/.github/workflows/build-json.yml
+++ b/.github/workflows/build-json.yml
@@ -39,7 +39,7 @@ jobs:
       aws_secret_access_key: ${{ secrets.PL_SITE_STAGING_NON_REACT_SECRET_ACCESS_KEY }}
       aws_json_s3_bucket_id: ${{ secrets.PL_SITE_STAGING_QML_JSON_S3_BUCKET_ID }}
       aws_html_s3_bucket_id: ${{ secrets.PL_SITE_STAGING_S3_BUCKET_NAME }}
-      qml_react_pat_token: ${{ secrets.PL_SITE_STAGING_QML_REACT_PAT }}
+      qml_react_pat_token: ${{ secrets.QML_REACT_MASTER }}
 
   upload-dev:
     if: github.ref_name == 'dev'
@@ -58,4 +58,4 @@ jobs:
       aws_secret_access_key: ${{ secrets.PL_SITE_DEV_NON_REACT_SECRET_ACCESS_KEY }}
       aws_json_s3_bucket_id: ${{ secrets.PL_SITE_DEV_QML_JSON_S3_BUCKET_ID }}
       aws_html_s3_bucket_id: ${{ secrets.PL_SITE_DEV_S3_BUCKET_NAME }}
-      qml_react_pat_token: ${{ secrets.PL_SITE_DEV_QML_REACT_PAT }}
+      qml_react_pat_token: ${{ secrets.QML_REACT_MASTER }}

--- a/.github/workflows/deploy-demos-to-prod.yml
+++ b/.github/workflows/deploy-demos-to-prod.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
-          token: ${{ secrets.PL_SITE_PROD_QML_REACT_PAT }}
+          token: ${{ secrets.QML_REACT_MASTER }}
           repository: XanaduAI/pennylane.ai-react
           event-type: build-pl-site-main
           client-payload: '{"actor": "${{ github.actor }}", "triggering_actor": "${{ github.triggering_actor }}", "source_run_url": "${{ env.RUN_URL }}"}'

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -91,7 +91,7 @@ jobs:
           repository: XanaduAI/pennylane.ai-react
           ref: main
           path: pennylane.ai-react
-          token: ${{ secrets.PL_SITE_DEV_QML_REACT_PAT }}
+          token: ${{ secrets.QML_REACT_MASTER }}
 
       - name: Clone QML
         if: steps.build_context.outputs.result != ''


### PR DESCRIPTION
The PAT tokens for pulling the PL REACT site keep getting overwritten by Terraform. These will be redundant soon as we switch to the new QML pipeline, so for now I am swapping these all out with a master token to keep builds moving. This token has already been provisioned and verified. It will expire in June, by which time the new pipeline should be ready.