### PR TITLE
crons added for bi-daily builds

### DIFF
--- a/.github/workflows/v2-build-branch-dev.yml
+++ b/.github/workflows/v2-build-branch-dev.yml
@@ -1,0 +1,21 @@
+name: V2 Build QML Branch - Dev
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0,2,4,6' # At 00:00 on Sunday, Tuesday, Thursday, and Saturday.
+
+concurrency:
+  group: build-qml-demo-branch-dev
+  cancel-in-progress: true
+
+jobs:
+  build_dev:
+    uses: ./.github/workflows/v2-build-demos.yml
+    with:
+      ref: build-branch-dev
+      dev: true
+      save-artifact: true
+      artifact-name: build-branch-dev
+      keep-going: false
+      quiet: false
+      batch_size: 10

--- a/.github/workflows/v2-build-branch-master.yml
+++ b/.github/workflows/v2-build-branch-master.yml
@@ -1,0 +1,21 @@
+name: V2 Build QML Branch - Dev
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0,2,4,6' # At 00:00 on Sunday, Tuesday, Thursday, and Saturday.
+
+concurrency:
+  group: build-qml-demo-branch-master
+  cancel-in-progress: true
+
+jobs:
+  build_dev:
+    uses: ./.github/workflows/v2-build-demos.yml
+    with:
+      ref: build-branch-master
+      dev: false
+      save-artifact: true
+      artifact-name: build-branch-master
+      keep-going: false
+      quiet: false
+      batch_size: 10

--- a/.github/workflows/v2-build-branch-master.yml
+++ b/.github/workflows/v2-build-branch-master.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_dev:
+  build_master:
     uses: ./.github/workflows/v2-build-demos.yml
     with:
       ref: build-branch-master


### PR DESCRIPTION
## Summary:
Workflows added to build the `master` and `dev` branch on a bi-daily basis (every two days).

Please note, we will need to check out the `dev` version of the workflow once this change is merged to `dev` 
