### PR TITLE
FIX: unused import in `tutorial_annni` causing v2 build failure, and not used in demo

### DIFF
--- a/demonstrations/tutorial_annni.metadata.json
+++ b/demonstrations/tutorial_annni.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2025-04-28T00:00:00+00:00",
-    "dateOfLastModification": "2025-04-28T00:00:00+00:00",
+    "dateOfLastModification": "2025-05-06T00:00:00+00:00",
     "categories": [
         "Quantum Machine Learning"
     ],

--- a/demonstrations/tutorial_annni.py
+++ b/demonstrations/tutorial_annni.py
@@ -50,7 +50,6 @@ import optax
 
 import matplotlib.pyplot as plt
 from matplotlib.colors import ListedColormap, BoundaryNorm
-from IPython.display import Image, display
 
 config.update("jax_enable_x64", True)
 


### PR DESCRIPTION
**Title:**
Delete unused import from `tutorial_annni`

**Summary:**
There was an unused import causing the v2 pipeline failure. The new pipeline will require that modules be installed, since this package is not required to run this demo, it will be deleted.

**Related GitHub Issues:**
_N/A_