### PR TITLE
Fix Jax bump upgrading numpy as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,8 @@ environment:
 			$$PYTHON_VENV_PATH/bin/python -m pip install --extra-index-url https://test.pypi.org/simple/ PennyLane-Lightning --pre --upgrade;\
 			$$PYTHON_VENV_PATH/bin/python -m pip install --upgrade git+https://github.com/PennyLaneAI/pennylane.git#egg=pennylane;\
 			$$PYTHON_VENV_PATH/bin/python -m pip install --upgrade git+https://github.com/XanaduAI/iqpopt.git#egg=iqpopt;\
+			# TODO: Remove this on next release. Currently Catalyst 0.11 pins jaxlib to 0.4.8
+			$$PYTHON_VENV_PATH/bin/python -m pip install 'numpy<2';\
 		fi;\
 	fi
 


### PR DESCRIPTION
**Title:**
Temp workaround for pinning numpy outside of poetry

**Summary:**
Currently, catalyst is hard pinning JAX 0.4.28. But upgrading it also upgrades numpy to 2.x which is breaking matplotlib.


**Relevant references:**
[sc-91141]

[Previous Failure](https://github.com/PennyLaneAI/qml/actions/runs/14910534756/job/41883635938?pr=1355)

**Possible Drawbacks:**
We need to roll this back prior to next release.

**Related GitHub Issues:**
None.