### PR TITLE
Fix for V2 demo deployment Action

### DIFF
--- a/.github/workflows/v2-deploy-pr.yml
+++ b/.github/workflows/v2-deploy-pr.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           workflow_run_id: ${{ github.event.workflow_run.id }}
           artifact_name_regex: '^pr_info$'
+          artifact_download_dir: '/tmp/pr'
           github_token: ${{ github.token }}
 
       - name: Check if Build Context file exists


### PR DESCRIPTION
Debugging some issues with the V2 Actions. The deployment step was missing the directory for where to look for the Artifact, so couldn't find it. This PR specifies [the artifact's uploaded directory](https://github.com/PennyLaneAI/qml/blob/master/.github/workflows/v2-build-pr.yml#L80) in the workflow.

<img width="1101" alt="Screenshot 2025-05-21 at 10 15 24 AM" src="https://github.com/user-attachments/assets/0192da5c-70b2-4205-8757-cc8b013ebc13" />
