### PR TITLE
More v2 fixes

### DIFF
--- a/.github/workflows/v2-build-pr.yml
+++ b/.github/workflows/v2-build-pr.yml
@@ -32,12 +32,6 @@ jobs:
           echo "Updated Demos: ${{ steps.get-changed-demos.outputs.updated }}"
           echo "Deleted Demos: ${{ steps.get-changed-demos.outputs.deleted }}"
 
-      - name: Exit if no changes
-        if: steps.get-changed-demos.outputs.updated == ''
-        run: |
-          echo "No changes found in demos. Exiting workflow."
-          exit 1
-
   # Step 2: Build demos
   build:
     if: needs.identify-changed-demos.outputs.updated != ''
@@ -56,6 +50,7 @@ jobs:
 
   # Step 3: Save build context
   save-build-context:
+    if: needs.identify-changed-demos.outputs.updated != ''
     runs-on: ubuntu-latest
     needs:
       - build

--- a/.github/workflows/v2-build-pr.yml
+++ b/.github/workflows/v2-build-pr.yml
@@ -36,6 +36,7 @@ jobs:
         if: steps.get-changed-demos.outputs.updated == ''
         run: |
           echo "No changes found in demos. Exiting workflow."
+          exit 1
 
   # Step 2: Build demos
   build:

--- a/.github/workflows/v2-deploy-demos.yml
+++ b/.github/workflows/v2-deploy-demos.yml
@@ -3,28 +3,49 @@ on:
   workflow_call:
     inputs:
       environment:
-        description: Environment to deploy to
+        description: Environment to deploy to.
         type: string
         required: true
       artifact-name:
-        description: Name of artifact containing demo zip files
+        description: Name of artifact containing demo zip files.
         type: string
+      workflow-run-id:
+        description: ID of the workflow run the artifact is from. Needed for PR previews.
+        type: string
+        required: false
+        default: ''
+      github-token: 
+        description: |
+          GitHub token. Required for pulling artifacts from separate workflows.
+          Set this if using 'workflow-run-id'.
+        type: string
+        required: false
       preview:
-        description: Whether to deploy demos as preview
+        description: Whether to deploy demos as preview.
         type: boolean
         required: true
 
   workflow_dispatch:
     inputs:
       environment:
-        description: Environment to deploy to
+        description: Environment to deploy to.
         type: environment
         required: true
       artifact-name:
         description: Name of artifact containing demo zip files.
         type: string
+      workflow-run-id:
+        description: ID of the workflow run the artifact is from. Needed for PR previews.
+        type: string
+        required: false
+        default: ''
+      github-token: 
+        description: |
+          GitHub token. Required for pulling artifacts from separate workflows.
+          Set this if using 'workflow-run-id'.        type: string
+        required: false
       preview:
-        description: Whether to deploy demos as preview
+        description: Whether to deploy demos as preview.
         type: boolean
         required: true
 
@@ -55,7 +76,17 @@ jobs:
       - name: Install python requirements
         run: pip install -r .github/workflows/qml_pipeline_v2/requirements.txt
       
-      - name: Fetch demo build artifact
+      - name: Fetch demo build artifact from another workflow
+        if: ${{ inputs.workflow-run-id }} != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          run-id: ${{ inputs.workflow-run-id }}
+          github-token: ${{ inputs.github-token }}
+          path: _build/pack
+
+      - name: Fetch demo build artifact from this workflow
+        if: ${{ inputs.workflow-run-id }} == ''
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}

--- a/.github/workflows/v2-deploy-demos.yml
+++ b/.github/workflows/v2-deploy-demos.yml
@@ -42,7 +42,8 @@ on:
       github-token: 
         description: |
           GitHub token. Required for pulling artifacts from separate workflows.
-          Set this if using 'workflow-run-id'.        type: string
+          Set this if using 'workflow-run-id'.        
+        type: string
         required: false
       preview:
         description: Whether to deploy demos as preview.

--- a/.github/workflows/v2-deploy-pr.yml
+++ b/.github/workflows/v2-deploy-pr.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           workflow_run_id: ${{ github.event.workflow_run.id }}
           artifact_name_regex: '^pr_info$'
-          artifact_download_dir: '/tmp/pr'
           github_token: ${{ github.token }}
 
       - name: Check if Build Context file exists

--- a/.github/workflows/v2-deploy-pr.yml
+++ b/.github/workflows/v2-deploy-pr.yml
@@ -76,7 +76,10 @@ jobs:
 
   # Step 2: Deploy the demos to SWC
   deploy-preview-demos:
-    if: github.event.workflow_run.event == 'pull_request' && needs.prepare-build-context.result == 'success'
+    if: |
+      github.event.workflow_run.event == 'pull_request' && 
+      needs.prepare-build-context.result == 'success' &&
+      needs.prepare-build-context.outputs.pr_ref != ''
     uses: ./.github/workflows/v2-deploy-demos.yml
     needs: prepare-build-context
     with:

--- a/.github/workflows/v2-deploy-pr.yml
+++ b/.github/workflows/v2-deploy-pr.yml
@@ -83,6 +83,8 @@ jobs:
       # TODO: Update SWC environment to "swc-prod"
       environment: 'swc-staging' 
       artifact-name: demo-build-${{ needs.prepare-build-context.outputs.pr_ref }}
+      workflow-run-id: ${{ github.event.workflow_run.id }}
+      github-token: ${{ github.token }}
       preview: true
     secrets: inherit
   


### PR DESCRIPTION
More fixes for the V2 pipeline:
- Reverts the addition from #1374 . This was erroneously identified as the cause for the failures.
- Adds `workflow-run-id` and `github-token` to the `actions/download-artifact@v4` Action as these are needed to pull artifacts from external workflow runs (true cause of the failures).
- Separates the downloading artifact step into two: One for PRs (separate workflow) and one for same-workflow deployments.
- Adds a few more early checks to the workflows if:
  - There are no changed demos.
  - There are no artifacts to download. 