### PR TITLE
Fix v2 actions

### DIFF
--- a/.github/workflows/v2-deploy-demos.yml
+++ b/.github/workflows/v2-deploy-demos.yml
@@ -14,12 +14,6 @@ on:
         type: string
         required: false
         default: ''
-      github-token: 
-        description: |
-          GitHub token. Required for pulling artifacts from separate workflows.
-          Set this if using 'workflow-run-id'.
-        type: string
-        required: false
       preview:
         description: Whether to deploy demos as preview.
         type: boolean
@@ -39,12 +33,6 @@ on:
         type: string
         required: false
         default: ''
-      github-token: 
-        description: |
-          GitHub token. Required for pulling artifacts from separate workflows.
-          Set this if using 'workflow-run-id'.        
-        type: string
-        required: false
       preview:
         description: Whether to deploy demos as preview.
         type: boolean
@@ -83,7 +71,7 @@ jobs:
         with:
           name: ${{ inputs.artifact-name }}
           run-id: ${{ inputs.workflow-run-id }}
-          github-token: ${{ inputs.github-token }}
+          github-token: ${{ github.token }}
           path: _build/pack
 
       - name: Fetch demo build artifact from this workflow

--- a/.github/workflows/v2-deploy-pr.yml
+++ b/.github/workflows/v2-deploy-pr.yml
@@ -87,7 +87,6 @@ jobs:
       environment: 'swc-staging' 
       artifact-name: demo-build-${{ needs.prepare-build-context.outputs.pr_ref }}
       workflow-run-id: ${{ github.event.workflow_run.id }}
-      github-token: ${{ github.token }}
       preview: true
     secrets: inherit
   


### PR DESCRIPTION
The download artifact Action needs a token to pull an artifact from a separate workflow. Passing the default token doesn't seem to work, so trying to use it directly as it should be available for all workflows.