### PR TITLE
Use Cloud download action

### DIFF
--- a/.github/workflows/v2-build-and-deploy.yml
+++ b/.github/workflows/v2-build-and-deploy.yml
@@ -98,4 +98,5 @@ jobs:
     with:
       environment: ${{ github.event.inputs.environment }}
       artifact-name: build-and-deploy-${{ github.event.inputs.target }}
+      workflow-run-id: ${{ github.run_id }}
       preview: ${{ github.event.inputs.as-previews == 'true' }}

--- a/.github/workflows/v2-deploy-demos.yml
+++ b/.github/workflows/v2-deploy-demos.yml
@@ -10,10 +10,9 @@ on:
         description: Name of artifact containing demo zip files.
         type: string
       workflow-run-id:
-        description: ID of the workflow run the artifact is from. Needed for PR previews.
+        description: ID of the workflow run the artifact is from.
         type: string
-        required: false
-        default: ''
+        required: true
       preview:
         description: Whether to deploy demos as preview.
         type: boolean
@@ -29,10 +28,9 @@ on:
         description: Name of artifact containing demo zip files.
         type: string
       workflow-run-id:
-        description: ID of the workflow run the artifact is from. Needed for PR previews.
+        description: ID of the workflow run the artifact is from.
         type: string
-        required: false
-        default: ''
+        required: true
       preview:
         description: Whether to deploy demos as preview.
         type: boolean
@@ -65,21 +63,13 @@ jobs:
       - name: Install python requirements
         run: pip install -r .github/workflows/qml_pipeline_v2/requirements.txt
       
-      - name: Fetch demo build artifact from another workflow
-        if: ${{ inputs.workflow-run-id }} != ''
-        uses: actions/download-artifact@v4
+      - name: Fetch demo build artifact
+        uses: XanaduAI/cloud-actions/download-github-workflow-artifact@main
         with:
-          name: ${{ inputs.artifact-name }}
-          run-id: ${{ inputs.workflow-run-id }}
-          github-token: ${{ github.token }}
-          path: _build/pack
-
-      - name: Fetch demo build artifact from this workflow
-        if: ${{ inputs.workflow-run-id }} == ''
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ inputs.artifact-name }}
-          path: _build/pack
+          artifact_name_regex: ${{ inputs.artifact-name }}
+          workflow_run_id: ${{ inputs.workflow-run-id }}
+          github_token: ${{ github.token }}
+          artifact_download_dir: _build/pack
 
       - name: Deploy demos
         run: |

--- a/.github/workflows/v2-deploy-demos.yml
+++ b/.github/workflows/v2-deploy-demos.yml
@@ -64,12 +64,12 @@ jobs:
         run: pip install -r .github/workflows/qml_pipeline_v2/requirements.txt
       
       - name: Fetch demo build artifact
-        uses: XanaduAI/cloud-actions/download-github-workflow-artifact@main
+        uses: actions/download-artifact@v4
         with:
-          artifact_name_regex: ${{ inputs.artifact-name }}
-          workflow_run_id: ${{ inputs.workflow-run-id }}
-          github_token: ${{ github.token }}
-          artifact_download_dir: _build/pack
+          name: ${{ inputs.artifact-name }}
+          run-id: ${{ inputs.workflow-run-id }}
+          github-token: ${{ github.token }}
+          path: _build/pack
 
       - name: Deploy demos
         run: |

--- a/.github/workflows/v2-deploy-demos.yml
+++ b/.github/workflows/v2-deploy-demos.yml
@@ -64,12 +64,12 @@ jobs:
         run: pip install -r .github/workflows/qml_pipeline_v2/requirements.txt
       
       - name: Fetch demo build artifact
-        uses: actions/download-artifact@v4
+        uses: XanaduAI/cloud-actions/download-github-workflow-artifact@main
         with:
-          name: ${{ inputs.artifact-name }}
-          run-id: ${{ inputs.workflow-run-id }}
-          github-token: ${{ github.token }}
-          path: _build/pack
+          artifact_name_regex: ${{ inputs.artifact-name }}
+          workflow_run_id: ${{ inputs.workflow-run-id }}
+          github_token: ${{ github.token }}
+          artifact_download_dir: _build/pack
 
       - name: Deploy demos
         run: |


### PR DESCRIPTION
The V2 pipeline is [successfully pulling the artifact](https://github.com/PennyLaneAI/qml/actions/runs/15192683498/job/42729230531), but my last PR was using clunky branching logic that isn't really needed. This PR removes the branching logic. 

EDIT: Looks like the subsequent job uploads the .zip artifact to the server, so no need to unpack it here. Switching back to the XanaduAI flavour after all 🥳 

This should be the last of these PRs 🤞 