### PR TITLE
Use download action

### DIFF
--- a/.github/workflows/v2-build-and-deploy.yml
+++ b/.github/workflows/v2-build-and-deploy.yml
@@ -25,7 +25,7 @@ on:
         required: true
         type: choice
       demos:
-        description: Demos to build and deploy, space-separated list of slugs (e.g. "demo1 demo2 demo3"), or leave empty for all demos.
+        description: Demos to build and deploy, space-separated list of slugs (e.g. demo1 demo2 demo3), or leave empty for all demos.
         required: false
         type: string
       as-previews:

--- a/.github/workflows/v2-deploy-demos.yml
+++ b/.github/workflows/v2-deploy-demos.yml
@@ -64,12 +64,12 @@ jobs:
         run: pip install -r .github/workflows/qml_pipeline_v2/requirements.txt
       
       - name: Fetch demo build artifact
-        uses: XanaduAI/cloud-actions/download-github-workflow-artifact@main
+        uses: actions/download-artifact@v4
         with:
-          artifact_name_regex: ${{ inputs.artifact-name }}
-          workflow_run_id: ${{ inputs.workflow-run-id }}
-          github_token: ${{ github.token }}
-          artifact_download_dir: _build/pack
+          name: ${{ inputs.artifact-name }}
+          run-id: ${{ inputs.workflow-run-id }}
+          github-token: ${{ github.token }}
+          path: _build/pack
 
       - name: Deploy demos
         run: |


### PR DESCRIPTION
Even though all the parameters appear to be correct (artifact id, workflow id, etc.) the cloud action can't find the artifact 😞 . Sorry @rashidnhm, going to switch back to the `actions/download-artifact` action.  

**Note:** This has been tested successfully by running the workflow dispatch version. Will test the PR version once this is merged in.