### PR TITLE
Require at least one `category` for demos

### DIFF
--- a/.github/workflows/validate-demo-metadata.yml
+++ b/.github/workflows/validate-demo-metadata.yml
@@ -101,7 +101,7 @@ jobs:
           METADATA_FILE_LIST: ${{ needs.generate-metadata-file-list.outputs.metadata_files }}
         run: |
           cd metadata_schemas
-          ${{ steps.poetry.outputs.bin }} run check-jsonschema -v --traceback-mode full --schemafile demo.metadata.schema.0.1.5.json $METADATA_FILE_LIST
+          ${{ steps.poetry.outputs.bin }} run check-jsonschema -v --traceback-mode full --schemafile demo.metadata.schema.0.1.6.json $METADATA_FILE_LIST
 
   validate-metadata-preview-images:
     runs-on: ubuntu-latest

--- a/demonstrations/adjoint_diff_benchmarking.metadata.json
+++ b/demonstrations/adjoint_diff_benchmarking.metadata.json
@@ -7,7 +7,9 @@
     ],
     "dateOfPublication": "2021-11-23T00:00:00+00:00",
     "dateOfLastModification": "2024-10-07T00:00:00+00:00",
-    "categories": [],
+    "categories": [
+        "Getting Started"
+    ],
     "tags": [],
     "previewImages": [
         {

--- a/demonstrations/adjoint_diff_benchmarking.py
+++ b/demonstrations/adjoint_diff_benchmarking.py
@@ -16,7 +16,7 @@ Adjoint Differentiation
 
 ##############################################################################
 # This page is supplementary material to the
-# `Adjoint Differentiation <https://pennylane.ai/qml/demos/tutorial_adjoint_diff.html>`__
+# `Adjoint Differentiation <https://pennylane.ai/qml/demos/tutorial_adjoint_diff>`__
 # demonstration.  The below script produces the benchmarking images used.
 
 import timeit

--- a/demonstrations/tutorial_adjoint_diff.py
+++ b/demonstrations/tutorial_adjoint_diff.py
@@ -423,7 +423,7 @@ print(jax.grad(circuit_adjoint)(x))
 # With adjoint differentiation on ``"lightning.qubit"``, you can get the best of both worlds: fast and
 # memory efficient.
 #
-# But how fast? The provided script `here <https://pennylane.ai/qml/demos/adjoint_diff_benchmarking.html>`__
+# But how fast? The provided script `here <https://pennylane.ai/qml/demos/adjoint_diff_benchmarking>`__
 # generated the following images on a mid-range laptop.
 # The backpropagation times were produced with the Python simulator ``"default.qubit"``, while parameter-shift
 # and adjoint differentiation times were calculated with ``"lightning.qubit"``.

--- a/demonstrations_v2/adjoint_diff_benchmarking/demo.py
+++ b/demonstrations_v2/adjoint_diff_benchmarking/demo.py
@@ -16,7 +16,7 @@ Adjoint Differentiation
 
 ##############################################################################
 # This page is supplementary material to the
-# `Adjoint Differentiation <https://pennylane.ai/qml/demos/tutorial_adjoint_diff.html>`__
+# `Adjoint Differentiation <https://pennylane.ai/qml/demos/tutorial_adjoint_diff>`__
 # demonstration.  The below script produces the benchmarking images used.
 
 import timeit

--- a/demonstrations_v2/adjoint_diff_benchmarking/metadata.json
+++ b/demonstrations_v2/adjoint_diff_benchmarking/metadata.json
@@ -7,7 +7,9 @@
     ],
     "dateOfPublication": "2021-11-23T00:00:00+00:00",
     "dateOfLastModification": "2024-10-07T00:00:00+00:00",
-    "categories": [],
+    "categories": [
+        "Getting Started"
+    ],
     "tags": [],
     "previewImages": [
         {

--- a/demonstrations_v2/tutorial_adjoint_diff/demo.py
+++ b/demonstrations_v2/tutorial_adjoint_diff/demo.py
@@ -423,7 +423,7 @@ print(jax.grad(circuit_adjoint)(x))
 # With adjoint differentiation on ``"lightning.qubit"``, you can get the best of both worlds: fast and
 # memory efficient.
 #
-# But how fast? The provided script `here <https://pennylane.ai/qml/demos/adjoint_diff_benchmarking.html>`__
+# But how fast? The provided script `here <https://pennylane.ai/qml/demos/adjoint_diff_benchmarking>`__
 # generated the following images on a mid-range laptop.
 # The backpropagation times were produced with the Python simulator ``"default.qubit"``, while parameter-shift
 # and adjoint differentiation times were calculated with ``"lightning.qubit"``.

--- a/metadata_schemas/demo.metadata.schema.0.1.6.json
+++ b/metadata_schemas/demo.metadata.schema.0.1.6.json
@@ -1,0 +1,128 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "demo.metadata.schema.0.1.5.json",
+    "title": "Demo Metadata",
+    "description": "A QML demo's metadata",
+    "type": "object",
+    "properties": {
+      "title": {
+        "description": "The title of the demo.",
+        "type": "string",
+        "minLength": 2
+      },
+      "slug": {
+        "description": "The slug of the demo. This should match the base name of the metadata file.",
+        "type": "string",
+        "minLength": 1
+      },
+      "authors": {
+        "description": "The author(s) of the demo. This array must contain at least one item.",
+        "type": "array",
+        "items": {
+          "$ref": "file:./objects/author.schema.0.2.0.json"
+        },
+        "minItems": 1
+      },
+      "dateOfPublication": {
+        "description": "The date on which the demo was first published, in the form YYYY-MM-DDTHH:MM:SS+00:00.",
+        "type": "string",
+        "format": "date-time",
+        "minLength": 25,
+        "maxLength": 25
+      },
+      "dateOfLastModification": {
+        "description": "The date on which the demo was last modified, in the form YYYY-MM-DDTHH:MM:SS+00:00.",
+        "type": "string",
+        "format": "date-time",
+        "minLength": 25,
+        "maxLength": 25
+      },
+      "categories": {
+        "description": "An array of the categories that this demo is in.",
+        "type": "array",
+        "items": {
+          "enum": [
+            "Algorithms",
+            "Getting Started",
+            "Optimization",
+            "Quantum Machine Learning",
+            "Quantum Chemistry",
+            "Devices and Performance",
+            "Quantum Computing",
+            "Quantum Hardware",
+            "How-to"
+          ]
+        },
+        "minItems": 1
+      },
+      "tags": {
+        "description": "An array of the tags that the demo has. An empty array is allowed.",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "previewImages": {
+        "description": "An array of the different images that can be used as previews for this demo - e.g., thumbnails, social media cards (perhaps of different aspect ratios).",
+        "type": "array",
+        "items": {
+          "$ref": "file:./objects/preview.image.schema.0.1.0.json"
+        },
+        "minItems": 1
+      },
+      "seoDescription": {
+        "description": "A description of the demo suitable for SEO purposes. Ideally this should be less than 150 characters, but this is not a strict limit. It should be a full, grammatically-correct sentence ending in a full stop.",
+        "type": "string",
+        "minLength": 2
+      },
+      "doi": {
+        "description": "The DOI for the demo.",
+        "type": "string",
+        "pattern": "^$|^10[.]"
+      },
+      "references": {
+        "description": "An array of the references used for the demo.",
+        "type": "array",
+        "items": {
+          "$ref": "file:./objects/reference.schema.0.1.0.json"
+        }
+      },
+      "basedOnPapers": {
+        "description": "An array of the DOIs for the papers the demo is based on. An empty array is allowed.",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "referencedByPapers": {
+        "description": "An array of the DOIs of any papers that reference the demo. An empty array is allowed.",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "relatedContent": {
+        "description": "An array of objects describing the content related to the demo. An empty array is allowed.",
+        "type": "array",
+        "items": {
+          "$ref": "file:./objects/related.content.schema.0.1.0.json"
+        }
+      },
+      "hardware": {
+        "description": "An array of objects representing third-party vendors who can run the demo on their hardware. An empty array is allowed.",
+        "type": "array",
+        "items": {
+          "$ref": "file:./objects/hardware.schema.0.1.0.json"
+        }
+      },
+      "discussionForumUrl": {
+        "description": "Link to dedicated discussion forum thread on https://discuss.pennylane.ai/ for this demo",
+        "type": "string",
+        "format": "uri",
+        "pattern": "(^https?:\/\/(www.)?discuss.pennylane.ai(?:\/.*)?$)"
+      }
+    },
+    "required": [
+      "title", "authors", "dateOfPublication", "dateOfLastModification", "categories", "tags", "previewImages", "seoDescription", "doi", "references", "basedOnPapers", "referencedByPapers", "relatedContent"
+    ]
+  }

--- a/metadata_schemas/demo.metadata.schema.0.1.6.json
+++ b/metadata_schemas/demo.metadata.schema.0.1.6.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "demo.metadata.schema.0.1.5.json",
+    "$id": "demo.metadata.schema.0.1.6.json",
     "title": "Demo Metadata",
     "description": "A QML demo's metadata",
     "type": "object",


### PR DESCRIPTION
Currently demos are technically allowed to define an empty `categories` array in their metadata. In practice every demo defines at least one category, except for the `adjoint_diff_benchmarking` demo. This was a hack to avoid surfacing it in search because it is supplementary material. 

The new V2 pipeline requires demos to have a category, and we have better ways to omit this demo from search, so this PR adds a category (same as the parent demo) to this demo and updates the metadata schema (the relevant change [is here](https://github.com/PennyLaneAI/qml/pull/1379/files#diff-e8a88baa22c87205641827678200ebd8b54e8f640baad11e2b828783aef0f2d4R56).) and Action to require a category for demos. It also fixes issues (trailing .html) with the links in these demos.