### PR TITLE
Decrease MBQC demo size

### DIFF
--- a/demonstrations/tutorial_mbqc.metadata.json
+++ b/demonstrations/tutorial_mbqc.metadata.json
@@ -9,7 +9,7 @@
         }
     ],
     "dateOfPublication": "2022-12-05T00:00:00+00:00",
-    "dateOfLastModification": "2024-11-06T00:00:00+00:00",
+    "dateOfLastModification": "2025-05-27T00:00:00+00:00",
     "categories": [
         "Quantum Hardware",
         "Quantum Computing"

--- a/demonstrations_v2/tutorial_mbqc/metadata.json
+++ b/demonstrations_v2/tutorial_mbqc/metadata.json
@@ -9,7 +9,7 @@
         }
     ],
     "dateOfPublication": "2022-12-05T00:00:00+00:00",
-    "dateOfLastModification": "2024-11-06T00:00:00+00:00",
+    "dateOfLastModification": "2025-05-27T00:00:00+00:00",
     "categories": [
         "Quantum Hardware",
         "Quantum Computing"


### PR DESCRIPTION
The MBQC demo is ~15MB, which is too large to be uploaded to our V2 demo backend (10MB max). This is also a bad experience for any users with a slower internet connection, as this demo page will take a long time to load. The biggest contributor is the .gif, which is ~14MB. I've cut it down in time so it's shorter and under 5MB.