### PR TITLE
Update outdated demo link from `/plugins.html` to `/devices`

### DIFF
--- a/demonstrations/plugins_hybrid.metadata.json
+++ b/demonstrations/plugins_hybrid.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2019-10-11T00:00:00+00:00",
-    "dateOfLastModification": "2024-10-07T00:00:00+00:00",
+    "dateOfLastModification": "2025-05-29T00:00:00+00:00",
     "categories": [
         "Devices and Performance"
     ],

--- a/demonstrations/plugins_hybrid.py
+++ b/demonstrations/plugins_hybrid.py
@@ -124,7 +124,7 @@ Loading the plugin device
 
 While PennyLane provides a basic qubit simulator (``'default.qubit'``) and a basic CV
 Gaussian simulator (``'default.gaussian'``), the true power of PennyLane comes from its
-`plugin ecosystem <https://pennylane.ai/plugins.html>`_, allowing quantum computations
+`device ecosystem <https://pennylane.ai/devices>`_, allowing quantum computations
 to be run on a variety of quantum simulator and hardware devices.
 
 For this circuit, we will be using the ``'strawberryfields.fock'`` device to construct


### PR DESCRIPTION
**Summary:**
- Update outdated demo link from `/plugins.html` to `/devices`

**Relevant references:**

In data review, we found that there are still some links to `/plugins.html`: https://www.notion.so/xanaduai/Apr-15-May-15-2025-1f3bc6bd17648018a8a3e338619dd913?pvs=4

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A