### PR TITLE
Update concurrency group and workflow ref

### DIFF
--- a/.github/workflows/v2-build-branch-dev.yml
+++ b/.github/workflows/v2-build-branch-dev.yml
@@ -5,12 +5,12 @@ on:
     - cron: '0 0 * * 0,2,4,6' # At 00:00 on Sunday, Tuesday, Thursday, and Saturday.
 
 concurrency:
-  group: build-qml-demo-branch-dev
+  group: v2-build-qml-demo-branch-dev
   cancel-in-progress: true
 
 jobs:
   build_dev:
-    uses: ./.github/workflows/v2-build-demos.yml
+    uses: PennyLaneAI/qml/.github/workflows/v2-build-demos.yml@dev
     with:
       ref: dev
       dev: true

--- a/.github/workflows/v2-build-branch-master.yml
+++ b/.github/workflows/v2-build-branch-master.yml
@@ -5,12 +5,12 @@ on:
     - cron: '0 0 * * 0,2,4,6' # At 00:00 on Sunday, Tuesday, Thursday, and Saturday.
 
 concurrency:
-  group: build-qml-demo-branch-master
+  group: v2-build-qml-demo-branch-master
   cancel-in-progress: true
 
 jobs:
-  build_master:
-    uses: ./.github/workflows/v2-build-demos.yml
+  build_master: 
+    uses: PennyLaneAI/qml/.github/workflows/v2-build-demos.yml@master
     with:
       ref: master
       dev: false


### PR DESCRIPTION
This PR updates the workflow files for building the V2 demos from dev and master to pul them from the respective branches rather than relying on the local versions that get checked out (see [the V1 workflows](https://github.com/PennyLaneAI/qml/blob/master/.github/workflows/build-branch-master.yml#L17) for reference.)

This also updates the concurrency groups, which were named the same as the V1 groups and were getting cancelled by those runs.