### PR TITLE
Fix: incorrect conditon for build and deploy

### DIFF
--- a/.github/workflows/v2-build-and-deploy.yml
+++ b/.github/workflows/v2-build-and-deploy.yml
@@ -53,11 +53,14 @@ jobs:
       - name: Validate preview input
         id: validate-preview
         run: |
+          ENV="${{ github.event.inputs.environment }}"
+          TARGET="${{ github.event.inputs.target }}"
+          PR_NUMBER=${{ github.event.inputs.pr_number }}
+
           if [[ 
-            ("${{ github.event.inputs.environment }}" == "swc-staging" || 
-            "${{ github.event.inputs.environment }}" == "swc-prod") && 
-            "${{ github.event.inputs.target }}" == "latest" && 
-            "${{ github.event.inputs.pr_number }}" == "0" 
+            ("$ENV" == "swc-staging" || "$ENV" == "swc-prod") && 
+            "$TARGET" == "latest" && 
+            "$PR_NUMBER" -eq 0
           ]]; then
             echo "========================="
             echo "🚫 Invalid input detected:"

--- a/.github/workflows/v2-build-and-deploy.yml
+++ b/.github/workflows/v2-build-and-deploy.yml
@@ -57,7 +57,7 @@ jobs:
             ("${{ github.event.inputs.environment }}" == "swc-staging" || 
             "${{ github.event.inputs.environment }}" == "swc-prod") && 
             "${{ github.event.inputs.target }}" == "latest" && 
-            "${{ github.event.inputs.as-previews }}" == "false" 
+            "${{ github.event.inputs.pr_number }}" == "0" 
           ]]; then
             echo "========================="
             echo "🚫 Invalid input detected:"


### PR DESCRIPTION
This pull request updates the `.github/workflows/v2-build-and-deploy.yml` file to improve the clarity and maintainability of the "Validate preview input" job by introducing intermediate variables for GitHub event inputs and refining the validation logic.

### Workflow improvements:
* Introduced intermediate variables (`ENV`, `TARGET`, and `PR_NUMBER`) to store GitHub event inputs, improving code readability and maintainability. (`[.github/workflows/v2-build-and-deploy.ymlR56-R63](diffhunk://#diff-924e8738afa8b3a1299cd57b68a91d294dd95d10fb2d7968c253012a83e32b7cR56-R63)`)
* Modified the validation logic to replace the `as-previews` input check with a check for `pr_number` being equal to 0, ensuring more precise validation. (`[.github/workflows/v2-build-and-deploy.ymlR56-R63](diffhunk://#diff-924e8738afa8b3a1299cd57b68a91d294dd95d10fb2d7968c253012a83e32b7cR56-R63)`)