### PR TITLE
add from JSON to covert type

### DIFF
--- a/.github/workflows/v2-deploy-pr.yml
+++ b/.github/workflows/v2-deploy-pr.yml
@@ -87,7 +87,7 @@ jobs:
       environment: 'swc-dev' 
       artifact-name: demo-build-${{ needs.prepare-build-context.outputs.pr_ref }}
       workflow-run-id: ${{ github.event.workflow_run.id }}
-      pr_number: ${{ needs.prepare-build-context.outputs.pr_id }}
+      pr_number: ${{ fromJson(needs.prepare-build-context.outputs.pr_id) }}
     secrets: inherit
   
 


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/v2-deploy-pr.yml` file to improve the handling of the `pr_number` variable by parsing it as JSON.

* [`.github/workflows/v2-deploy-pr.yml`](diffhunk://#diff-bb1f887f50cfc7839e56ce823ccf5b9b7a4a07bfd475c5646b28105610511bf3L90-R90): Updated the `pr_number` assignment to use `fromJson` for parsing the `pr_id` output from the `prepare-build-context` step.