### PR TITLE
V2 deploy on push

### DIFF
--- a/.github/workflows/v2-build-master.yml
+++ b/.github/workflows/v2-build-master.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   # Step 1: Identify changed demos
-   identify-changed-demos:
+  identify-changed-demos:
     runs-on: ubuntu-latest
     outputs:
       updated: ${{ steps.get-changed-demos.outputs.updated }}
@@ -48,7 +48,7 @@ jobs:
   build:
     if: needs.identify-changed-demos.outputs.updated != ''
     uses: ./.github/workflows/v2-build-demos.yml
-    needs: 
+    needs:
       - identify-changed-demos
     with:
       ref: ${{ github.sha }}
@@ -68,14 +68,12 @@ jobs:
       - build
       - identify-changed-demos
     steps:
-      - name: Save Pull Request Event Context
+      - name: Save Merge Commit Information
         run: |
           mkdir -p /tmp/pr
           cat >/tmp/pr/pr_info.json <<EOL
           {
-            "id": "${{ github.event.pull_request.number }}",
-            "ref": "${{ github.event.pull_request.head.sha }}",
-            "ref_name": "${{ github.event.pull_request.head.ref }}",
+            "ref": "${{ github.sha }}",
             "updated_demos": "${{ needs.identify-changed-demos.outputs.updated }}",
             "deleted_demos": "${{ needs.identify-changed-demos.outputs.deleted }}"
           }

--- a/.github/workflows/v2-build-master.yml
+++ b/.github/workflows/v2-build-master.yml
@@ -13,6 +13,7 @@ on:
     branches:
       - master
       - test-v2-master # A master branch for testing purposes
+      - v2-deploy-on-push # A branch for testing purposes
 
 permissions:
   contents: read

--- a/.github/workflows/v2-build-master.yml
+++ b/.github/workflows/v2-build-master.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Save Merge Commit Information
         run: |
           mkdir -p /tmp/pr
-          cat >/tmp/pr/pr_info.json <<EOL
+          cat >/tmp/pr/master_build_context.json <<EOL
           {
             "ref": "${{ github.sha }}",
             "updated_demos": "${{ needs.identify-changed-demos.outputs.updated }}",
@@ -83,6 +83,6 @@ jobs:
       - name: Upload Pull Request Event Context as Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: pr_info
+          name: master_build_context
           path: /tmp/pr
           retention-days: 30

--- a/.github/workflows/v2-build-master.yml
+++ b/.github/workflows/v2-build-master.yml
@@ -1,0 +1,89 @@
+name: V2 Build Master for Production Environment
+
+# WIP #
+# The folling workflow is reponsible for the following:
+# 1. Identifying changed demos in the master branch when a PR is merged.
+# 2. Building the demos that have changed.
+# 3. Save the build context in a articfact for later use in the V2 Deploy Production workflow.
+# 4. If successful, trigger the V2 Deploy Production workflow.
+# Notes: We want to ensure that the builds are queued and not cancelled if a new PR is merged while the build is in progress.
+
+on:
+  push:
+    branches:
+      - master
+      - test-v2-master # A master branch for testing purposes
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+concurrency:
+  group: build-v2-demos-master-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  # Step 1: Identify changed demos
+   identify-changed-demos:
+    runs-on: ubuntu-latest
+    outputs:
+      updated: ${{ steps.get-changed-demos.outputs.updated }}
+      deleted: ${{ steps.get-changed-demos.outputs.deleted }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get changed demos
+        id: get-changed-demos
+        uses: ./.github/actions/get-changed-demos
+
+      - name: Output changed demos
+        run: |
+          echo "Updated Demos: ${{ steps.get-changed-demos.outputs.updated }}"
+          echo "Deleted Demos: ${{ steps.get-changed-demos.outputs.deleted }}"
+
+  # Step 2: Build demos
+  build:
+    if: needs.identify-changed-demos.outputs.updated != ''
+    uses: ./.github/workflows/v2-build-demos.yml
+    needs: 
+      - identify-changed-demos
+    with:
+      ref: ${{ github.sha }}
+      demo-names: ${{ needs.identify-changed-demos.outputs.updated }}
+      dev: false
+      save-artifact: true
+      artifact-name: demo-master-build-${{ github.sha }} # Specific name for master builds
+      keep-going: false
+      quiet: false
+      batch_size: 10
+
+  # Step 3: Save build context
+  save-build-context:
+    if: needs.identify-changed-demos.outputs.updated != ''
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - identify-changed-demos
+    steps:
+      - name: Save Pull Request Event Context
+        run: |
+          mkdir -p /tmp/pr
+          cat >/tmp/pr/pr_info.json <<EOL
+          {
+            "id": "${{ github.event.pull_request.number }}",
+            "ref": "${{ github.event.pull_request.head.sha }}",
+            "ref_name": "${{ github.event.pull_request.head.ref }}",
+            "updated_demos": "${{ needs.identify-changed-demos.outputs.updated }}",
+            "deleted_demos": "${{ needs.identify-changed-demos.outputs.deleted }}"
+          }
+          EOL
+
+      - name: Upload Pull Request Event Context as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr_info
+          path: /tmp/pr
+          retention-days: 30

--- a/.github/workflows/v2-deploy-master.yml
+++ b/.github/workflows/v2-deploy-master.yml
@@ -1,0 +1,84 @@
+name: V2 Deploy Master to Production Environment
+
+on:
+  workflow_run:
+    workflows:
+      - "V2 Build Master for Production Environment"
+    types:
+      - completed
+
+permissions:
+  actions: read
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: deploy-v2-demos-master-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  # Step 1: Prepare the build context
+  prepare-build-context:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Build Context
+        uses: XanaduAI/cloud-actions/download-github-workflow-artifact@main
+        with:
+          workflow_run_id: ${{ github.event.workflow_run.id }}
+          artifact_name_regex: '^master_build_context$'
+          github_token: ${{ github.token }}
+
+      - name: Check if Build Context file exists
+        id: build_context
+        env:
+          context_artifact_file_name: master_build_context.zip
+        run: |
+          if test -f "$context_artifact_file_name"; then
+            echo "result=$context_artifact_file_name" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Unpack Build Information
+        if: steps.build_context.outputs.result != ''
+        run: unzip ${{ steps.build_context.outputs.result }}
+
+      - name: Read Build Information
+        id: read_build_info
+        if: steps.build_context.outputs.result != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const buildData = fs.readFileSync('master_build_context.json', 'utf8');
+            return JSON.parse(buildData);
+
+      - name: Parse Push Event Information
+        id: pr_info
+        if: github.event.workflow_run.event == 'push' && steps.build_context.outputs.result != ''
+        run: |
+          echo '${{ steps.read_build_info.outputs.result }}' | jq -r '.ref' > merge_ref.txt
+          echo '${{ steps.read_build_info.outputs.result }}' | jq -c '.updated_demos' > updated_demos.json
+          echo '${{ steps.read_build_info.outputs.result }}' | jq -c '.deleted_demos' > deleted_demos.json
+
+          echo "merge_ref=$(cat merge_ref.txt)" >> $GITHUB_OUTPUT
+          echo "updated_demos=$(cat updated_demos.json)" >> $GITHUB_OUTPUT
+          echo "deleted_demos=$(cat deleted_demos.json)" >> $GITHUB_OUTPUT
+    outputs:
+      merge_ref: ${{ steps.pr_info.outputs.pr_ref }}
+      updated_demos: ${{ steps.pr_info.outputs.updated_demos }}
+      deleted_demos: ${{ steps.pr_info.outputs.deleted_demos }}
+
+  # Step 2: Deploy the demos to SWC production environment
+  deploy-production-demos:
+    if: |
+      github.event.workflow_run.event == 'push' &&
+      needs.prepare-build-context.result == 'success' &&
+      needs.prepare-build-context.outputs.merge_ref != ''
+    uses: ./.github/workflows/v2-deploy-demos.yml
+    needs: prepare-build-context
+    with:
+      environment: 'swc-dev' 
+      artifact-name: demo-master-build-${{ needs.prepare-build-context.outputs.merge_ref }}
+      workflow-run-id: ${{ github.event.workflow_run.id }}
+      pr_number: 0
+    secrets: inherit


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows to automate the build and deployment process for demos in the production environment. The first workflow identifies and builds changed demos when a pull request is merged into the master branch, while the second workflow deploys the built demos to the production environment. Below is a summary of the most important changes:

### Workflow for Building Demos (`v2-build-master.yml`)

* **New Workflow for Building Changed Demos**: Added a workflow to detect changes in demos on the master branch, build the affected demos, save the build context as an artifact, and trigger the deployment workflow. This includes steps for identifying updated and deleted demos, building the demos, and saving build metadata.

### Workflow for Deploying Demos (`v2-deploy-master.yml`)

* **New Workflow for Deploying Built Demos**: Added a workflow that is triggered by the completion of the build workflow. It prepares the build context by downloading and unpacking the artifact, parses metadata about the updated and deleted demos, and deploys the demos to the production environment.