### PR TITLE
sc-94598-broken-docs-links-in-qml-demos

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -210,6 +210,6 @@ htmlhelp_basename = "QMLdoc"
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "doc": ("https://docs.pennylane.ai/en/stable/", None),
+    "pennylane": ("https://docs.pennylane.ai/en/stable/", None),
     "catalyst": ("https://docs.pennylane.ai/projects/catalyst/en/stable", None)
 }

--- a/conf.py
+++ b/conf.py
@@ -210,6 +210,6 @@ htmlhelp_basename = "QMLdoc"
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "pennylane": ("https://docs.pennylane.ai/en/stable/", None),
+    "doc": ("https://docs.pennylane.ai/en/stable/", None),
     "catalyst": ("https://docs.pennylane.ai/projects/catalyst/en/stable", None)
 }

--- a/conf.py
+++ b/conf.py
@@ -44,7 +44,7 @@ release = ""
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-needs_sphinx = "5.0.2"
+needs_sphinx = "1.8.5"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -85,10 +85,6 @@ sphinx_gallery_conf = {
     ),
     # thumbnail size
     "thumbnail_size": (400, 400),
-    "reference_url": {
-        # The module you locally document uses None
-        # "pennylane": None,  # Commented out to avoid conflict with intersphinx
-    },
     "backreferences_dir"  : "backreferences",
     "doc_module"          : ("pennylane"),
     "junit": "../test-results/sphinx-gallery/junit.xml",

--- a/conf.py
+++ b/conf.py
@@ -44,7 +44,7 @@ release = ""
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-needs_sphinx = "1.8.5"
+needs_sphinx = "5.0.2"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -87,7 +87,7 @@ sphinx_gallery_conf = {
     "thumbnail_size": (400, 400),
     "reference_url": {
         # The module you locally document uses None
-        "pennylane": None,  # "https://docs.pennylane.ai/en/stable",
+        # "pennylane": None,  # Commented out to avoid conflict with intersphinx
     },
     "backreferences_dir"  : "backreferences",
     "doc_module"          : ("pennylane"),
@@ -213,3 +213,6 @@ intersphinx_mapping = {
     "pennylane": ("https://docs.pennylane.ai/en/stable/", None),
     "catalyst": ("https://docs.pennylane.ai/projects/catalyst/en/stable", None)
 }
+
+# Enable :doc: references for intersphinx (disabled by default in Sphinx 5.0+)
+intersphinx_disabled_reftypes = []

--- a/demonstrations/how_to_use_qiskit1_with_pennylane.py
+++ b/demonstrations/how_to_use_qiskit1_with_pennylane.py
@@ -34,7 +34,7 @@ aforementioned jump like it’s nothing 😌.
 # -----------------------------------------------------
 #
 # If you want to distill how a PennyLane plugin works down to one thing, it’s all in the provided devices! In
-# PennyLane, you just :doc:`create your circuit (a quantum function) </introduction/circuits>` and decorate it with
+# PennyLane, you just :external+pennylane:doc:`create your circuit (a quantum function) </introduction/circuits>` and decorate it with
 # the QNode decorator :func:`@qml.qnode(dev) <pennylane.qnode>`, where ``dev`` is (one of) the plugin’s device(s).
 #
 # In PennyLane and its plugins,

--- a/demonstrations/pytorch_noise.py
+++ b/demonstrations/pytorch_noise.py
@@ -20,7 +20,7 @@ PyTorch and noisy devices
     
 
 Let's revisit the original :ref:`qubit rotation <qubit_rotation>` tutorial, but instead of
-using the default NumPy/autograd QNode interface, we'll use the :doc:`introduction/interfaces/torch`.
+using the default NumPy/autograd QNode interface, we'll use the :external+pennylane:doc:`PyTorch interface <introduction/interfaces/torch>`.
 We'll also replace the ``default.qubit`` device with a noisy ``rigetti.qvm``
 device, to see how the optimization responds to noisy qubits. At the end of the
 demonstration, we will also show a way of how Rigetti's QPU can be used via

--- a/demonstrations/qnn_module_tf.py
+++ b/demonstrations/qnn_module_tf.py
@@ -91,8 +91,8 @@ plt.show()
 # <code/api/pennylane.qnn.KerasLayer>` including having an argument called ``inputs``. All other
 # arguments must be arrays or tensors and are treated as trainable weights in the model. We fix a
 # two-qubit QNode using the
-# :doc:`default.qubit <code/api/pennylane.devices.default_qubit.DefaultQubit>` simulator and
-# operations from the :doc:`templates <introduction/templates>` module.
+# :external+pennylane:doc:`default.qubit <code/api/pennylane.devices.default_qubit.DefaultQubit>` simulator and
+# operations from the :external+pennylane:doc:`templates <introduction/templates>` module.
 
 import pennylane as qml
 

--- a/demonstrations/tutorial_guide_to_pennylane_knowing_qiskit.py
+++ b/demonstrations/tutorial_guide_to_pennylane_knowing_qiskit.py
@@ -192,7 +192,7 @@ print(pl_circuit())
 #
 #
 # As for measurements in PennyLane, they are quite different from Qiskit's V2 primitives. 
-# :doc:`PennyLane's measurement API <introduction/measurements>` comprises ergonomic functions that a QNode 
+# :external+pennylane:doc:`PennyLane's measurement API <introduction/measurements>` comprises ergonomic functions that a QNode 
 # can return, including
 # 
 # - :func:`~pennylane.state`: returns the quantum state vector,

--- a/demonstrations/tutorial_qnn_module_torch.py
+++ b/demonstrations/tutorial_qnn_module_torch.py
@@ -75,8 +75,8 @@ plt.show()
 # <code/api/pennylane.qnn.TorchLayer>` including having an argument called ``inputs``. All other
 # arguments must be arrays or tensors and are treated as trainable weights in the model. We fix a
 # two-qubit QNode using the
-# :doc:`default.qubit <code/api/pennylane.devices.default_qubit.DefaultQubit>` simulator and
-# operations from the :doc:`templates <introduction/templates>` module.
+# :external+pennylane:doc:`default.qubit <code/api/pennylane.devices.default_qubit.DefaultQubit>` simulator and
+# operations from the :external+pennylane:doc:`templates <introduction/templates>` module.
 
 import pennylane as qml
 

--- a/demonstrations/tutorial_qubit_rotation.py
+++ b/demonstrations/tutorial_qubit_rotation.py
@@ -176,15 +176,15 @@ def circuit(params):
 #   by passing the ``wires`` argument; this may be a list or an integer, depending
 #   on how many wires the operation acts on.
 #
-#   For a full list of quantum operations, see :doc:`the documentation <introduction/operations>`.
+#   For a full list of quantum operations, see :external+pennylane:doc:`the documentation <introduction/operations>`.
 #
 # * **Quantum functions must return either a single or a tuple of measured observables**.
 #
 #   As a result, the quantum function always returns a classical quantity, allowing
 #   the QNode to interface with other classical functions (and also other QNodes).
 #
-#   For a full list of observables, see :doc:`the documentation <introduction/operations>`.
-#   The documentation also provides details on supported :doc:`measurement return types <introduction/measurements>`.
+#   For a full list of observables, see :external+pennylane:doc:`the documentation <introduction/operations>`.
+#   The documentation also provides details on supported :external+pennylane:doc:`measurement return types <introduction/measurements>`.
 #
 # .. note::
 #
@@ -290,7 +290,7 @@ print(dcircuit(phi1, phi2))
 #
 # .. tip::
 #
-#    *See* :doc:`introduction/interfaces` *for details and documentation of available optimizers*
+#    *See* :external+pennylane:doc:`introduction/interfaces` *for details and documentation of available optimizers*
 #
 # Next, let's make use of PennyLane's built-in optimizers to optimize the two circuit
 # parameters :math:`\phi_1` and :math:`\phi_2` such that the qubit, originally in state
@@ -362,7 +362,7 @@ print("Optimized rotation angles: {}".format(params))
 #
 #     Some optimizers, such as :class:`~.pennylane.AdagradOptimizer`, have
 #     internal hyperparameters that are stored in the optimizer instance. These can
-#     be reset using the :meth:`reset` method.
+#     be reset using the :meth:`~.pennylane.AdagradOptimizer.reset` method.
 #
 # Continue on to the next tutorial, :ref:`gaussian_transformation`, to see a similar example using
 # continuous-variable (CV) quantum nodes.

--- a/demonstrations/tutorial_qubit_rotation.py
+++ b/demonstrations/tutorial_qubit_rotation.py
@@ -290,7 +290,7 @@ print(dcircuit(phi1, phi2))
 #
 # .. tip::
 #
-#    *See* :external+pennylane:doc:`introduction/interfaces` *for details and documentation of available optimizers*
+#    *See* :doc:`introduction/interfaces` *for details and documentation of available optimizers*
 #
 # Next, let's make use of PennyLane's built-in optimizers to optimize the two circuit
 # parameters :math:`\phi_1` and :math:`\phi_2` such that the qubit, originally in state

--- a/demonstrations/tutorial_qubit_rotation.py
+++ b/demonstrations/tutorial_qubit_rotation.py
@@ -176,15 +176,15 @@ def circuit(params):
 #   by passing the ``wires`` argument; this may be a list or an integer, depending
 #   on how many wires the operation acts on.
 #
-#   For a full list of quantum operations, see :external+pennylane:doc:`the documentation <introduction/operations>`.
+#   For a full list of quantum operations, see :doc:`the documentation <pennylane:introduction/operations>`.
 #
 # * **Quantum functions must return either a single or a tuple of measured observables**.
 #
 #   As a result, the quantum function always returns a classical quantity, allowing
 #   the QNode to interface with other classical functions (and also other QNodes).
 #
-#   For a full list of observables, see :external+pennylane:doc:`the documentation <introduction/operations>`.
-#   The documentation also provides details on supported :external+pennylane:doc:`measurement return types <introduction/measurements>`.
+#   For a full list of observables, see :doc:`the documentation <pennylane:introduction/operations>`.
+#   The documentation also provides details on supported :doc:`measurement return types <pennylane:introduction/measurements>`.
 #
 # .. note::
 #


### PR DESCRIPTION
## Changes
- Fix broken interlinking to docs within qml demos