### PR TITLE
Retain build for 3 days

### DIFF
--- a/.github/workflows/v2-build-demos.yml
+++ b/.github/workflows/v2-build-demos.yml
@@ -208,7 +208,7 @@ jobs:
         with:
           name: ${{ needs.generate-build-variables.outputs.artifact-name }}
           path: _build/pack/*.zip
-          retention-days: 1
+          retention-days: 3
           overwrite: true
       
       - name: Delete partial artifacts


### PR DESCRIPTION
The V2 pipeline build artifacts are currently only retained for 1 day, but we only run the master and dev branch builds every 2 to 3 days, so the artifact goes stale between builds and can't be pulled. This PR bumps the retention period to 3 days so the artifact stays fresh and available until the next build.