### PR TITLE
Fix shots use in `tutorial_quantum_circuit_cutting`

### DIFF
--- a/demonstrations/tutorial_quantum_circuit_cutting.metadata.json
+++ b/demonstrations/tutorial_quantum_circuit_cutting.metadata.json
@@ -12,7 +12,7 @@
         }
     ],
     "dateOfPublication": "2022-09-02T00:00:00+00:00",
-    "dateOfLastModification": "2024-11-12T00:00:00+00:00",
+    "dateOfLastModification": "2024-07-17T00:00:00+00:00",
     "categories": [
         "Algorithms", "Quantum Computing"
     ],

--- a/demonstrations/tutorial_quantum_circuit_cutting.metadata.json
+++ b/demonstrations/tutorial_quantum_circuit_cutting.metadata.json
@@ -12,7 +12,7 @@
         }
     ],
     "dateOfPublication": "2022-09-02T00:00:00+00:00",
-    "dateOfLastModification": "2024-07-17T00:00:00+00:00",
+    "dateOfLastModification": "2025-07-17T00:00:00+00:00",
     "categories": [
         "Algorithms", "Quantum Computing"
     ],

--- a/demonstrations/tutorial_quantum_circuit_cutting.py
+++ b/demonstrations/tutorial_quantum_circuit_cutting.py
@@ -584,7 +584,7 @@ shot_counts = np.logspace(1, 4, num=20, dtype=int, requires_grad=False)
 pauli_cost_values = np.zeros_like(shot_counts, dtype=float)
 
 for i, shots in enumerate(shot_counts):
-    pauli_cost_values[i] = qaoa(optimal_params, shots=shots)
+    pauli_cost_values[i] = qml.set_shots(qaoa, int(shots))(optimal_params)
 
 
 ######################################################################


### PR DESCRIPTION
**Title:**

**Summary:**

`tutorial_quantum_circuit_cutting.py` was providing shots as a pennylane numpy tensor.  A change in pennylane makes it so the demo could no longer get away with that.

**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**
