### PR TITLE
fix incorrect image paths

### DIFF
--- a/demonstrations_v2/gqe_training/metadata.json
+++ b/demonstrations_v2/gqe_training/metadata.json
@@ -15,7 +15,7 @@
     "previewImages": [
         {
             "type": "thumbnail",
-            "uri": "_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_generative_quantum_eigensolver.png"
+            "uri": "/_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_generative_quantum_eigensolver.png"
         },
         {
             "type": "large_thumbnail",

--- a/demonstrations_v2/ml_classical_shadows/metadata.json
+++ b/demonstrations_v2/ml_classical_shadows/metadata.json
@@ -14,11 +14,11 @@
     "previewImages": [
         {
             "type": "thumbnail",
-            "uri": "_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_machine_learning_quantum_manybody_problems.png"
+            "uri": "/_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_machine_learning_quantum_manybody_problems.png"
         },
         {
             "type": "large_thumbnail",
-            "uri": "_static/demo_thumbnails/large_demo_thumbnails/thumbnail_large_machine_learning_quantum_manybody_problems.png"
+            "uri": "/_static/demo_thumbnails/large_demo_thumbnails/thumbnail_large_machine_learning_quantum_manybody_problems.png"
         }
     ],
     "seoDescription": "Learn how to apply machine learning to quantum many-body problems by using classical shadow formalism and ML to predict the ground-state properties of the 2D antiferromagnetic Heisenberg model.",

--- a/demonstrations_v2/tutorial_learning_dynamics_incoherently/metadata.json
+++ b/demonstrations_v2/tutorial_learning_dynamics_incoherently/metadata.json
@@ -15,7 +15,7 @@
     "previewImages": [
         {
             "type": "thumbnail",
-            "uri": "_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_learning_dynamics_incoherently.png"
+            "uri": "/_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_learning_dynamics_incoherently.png"
         },
         {
             "type": "large_thumbnail",

--- a/demonstrations_v2/tutorial_post-variational_quantum_neural_networks/metadata.json
+++ b/demonstrations_v2/tutorial_post-variational_quantum_neural_networks/metadata.json
@@ -19,11 +19,11 @@
     "previewImages": [
         {
             "type": "thumbnail",
-            "uri": "_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_post-variational_quantum_neural_networks.png"
+            "uri": "/_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_post-variational_quantum_neural_networks.png"
         },
         {
             "type": "large_thumbnail",
-            "uri": "_static/demo_thumbnails/large_demo_thumbnails/thumbnail_large_post-variational_quantum_neural_networks.png"
+            "uri": "/_static/demo_thumbnails/large_demo_thumbnails/thumbnail_large_post-variational_quantum_neural_networks.png"
         }
     ],
     "seoDescription": "Learn about post-variational quantum neural networks",


### PR DESCRIPTION
## Issue:
Images in v2, need to begin with a forward `/` or they are unable to be resolved when uploading.

## Fix:
Add forward slash where required in `demonstrations_v2`

## Test
Verify via graphql.