### PR TITLE
Install graphviz

### DIFF
--- a/.github/workflows/v2-build-demos.yml
+++ b/.github/workflows/v2-build-demos.yml
@@ -156,11 +156,12 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: 1
 
-      - name: Install pandoc and opencl
+      - name: Install pandoc, opencl, and graphviz
         run: |
           sudo apt-get install -y \
             ocl-icd-opencl-dev \
-            pandoc 
+            pandoc \
+            graphviz
 
       - name: Setup Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
This demo requires graphviz, which needs to be installed on the VM. Adding it to the build demo workflow step that installs pandoc has been verified to work.