### PR TITLE
Fix remaining `QNode` call with `shots` kwarg

### DIFF
--- a/demonstrations/tutorial_clifford_circuit_simulations.metadata.json
+++ b/demonstrations/tutorial_clifford_circuit_simulations.metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "dateOfPublication": "2024-04-12T00:00:00+00:00",
-    "dateOfLastModification": "2025-07-22T00:00:00+00:00",
+    "dateOfLastModification": "2025-07-30T00:00:00+00:00",
     "categories": [
         "Devices and Performance"
     ],

--- a/demonstrations/tutorial_clifford_circuit_simulations.py
+++ b/demonstrations/tutorial_clifford_circuit_simulations.py
@@ -232,7 +232,7 @@ shots_times = np.zeros((len(num_shots), len(num_wires)))
 for ind, num_shot in enumerate(num_shots):
     for idx, num_wire in enumerate(num_wires):
         shots_times[ind][idx] = timeit(
-            "GHZStatePrep(num_wire, shots=num_shot)", number=5, globals=globals()
+            "qml.set_shots(GHZStatePrep, shots=num_shot)(num_wire)", number=5, globals=globals()
         ) / 5 # average over 5 trials
 
 # Figure set up


### PR DESCRIPTION
**Title:**
After the deprecation of `shots` kwarg in `QNode.__call__`, we need to make sure all the demos have no such usage. This is the second patch for a remaining `demonstrations/tutorial_clifford_circuit_simulations.py` that was missed by the original correction round https://github.com/PennyLaneAI/qml/pull/1460

**Summary:**

**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[[sc-95617](https://app.shortcut.com/xanaduai/story/95617)]
----
If you are writing a demonstration, please answer these questions to facilitate the marketing process.

* GOALS — Why are we working on this now?

  *Eg. Promote a new PL feature or show a PL implementation of a recent paper.*


* AUDIENCE — Who is this for?

  *Eg. Chemistry researchers, PL educators, beginners in quantum computing.*


* KEYWORDS — What words should be included in the marketing post?


* Which of the following types of documentation is most similar to your file? 
(more details [here](https://www.notion.so/xanaduai/Different-kinds-of-documentation-69200645fe59442991c71f9e7d8a77f8))
    
- [ ] Tutorial
- [ ] Demo
- [ ] How-to