### PR TITLE
`chore` - bump v2 workflows to python `3.11`

### DIFF
--- a/.github/workflows/v2-build-demos.yml
+++ b/.github/workflows/v2-build-demos.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: pip install . && poetry config warnings.export false

--- a/.github/workflows/v2-deploy-demos.yml
+++ b/.github/workflows/v2-deploy-demos.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       
       - name: Install python requirements
         run: pip install -r .github/workflows/qml_pipeline_v2/requirements.txt

--- a/.github/workflows/v2-deploy-pr.yml
+++ b/.github/workflows/v2-deploy-pr.yml
@@ -119,6 +119,8 @@ jobs:
           comment+="There was an issue deploying your changes. Please check the related `v2-deploy-pr` logs for more details.\n\n"
           comment+="If you need assistance, please reach out to the team.\n\n"
 
+          comment+="> Attempted deployment at: $(date +'%Y-%m-%d %H:%M:%S') UTC\n\n"
+
           echo "markdown=$comment" >> $GITHUB_OUTPUT
 
       - name: Comment on PR

--- a/.github/workflows/v2-deploy-pr.yml
+++ b/.github/workflows/v2-deploy-pr.yml
@@ -107,6 +107,8 @@ jobs:
           comment="### Your preview is ready :tada:!\n\n"
           comment+="You can view your changes [here](https://pennylane.ai/qml/demonstrations?pr=${{ needs.prepare-build-context.outputs.pr_id }})\n\n"
 
+          comment+="> Deployed at: $(date +'%Y-%m-%d %H:%M:%S') UTC\n\n"
+
           echo "markdown=$comment" >> $GITHUB_OUTPUT
 
       - name: Generate Markdown Comment for Failed Deployment

--- a/.github/workflows/v2-sync-objects-dot-inv.yml
+++ b/.github/workflows/v2-sync-objects-dot-inv.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: pip install . && poetry config warnings.export false

--- a/.github/workflows/v2-validate-demo-metadata.yml
+++ b/.github/workflows/v2-validate-demo-metadata.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       
       - name: Install Poetry
         id: poetry

--- a/.github/workflows/validate-demo-metadata.yml
+++ b/.github/workflows/validate-demo-metadata.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       
       - name: Install Poetry
         id: poetry
@@ -119,7 +119,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install QML Pipeline Utils
         run: pip install .github/workflows/qml_pipeline_utils


### PR DESCRIPTION
This pull request updates the CI/CD workflows to use Python 3.11 instead of Python 3.10 and improves deployment PR comments by including timestamps. These changes help keep the project up-to-date with the latest Python version and make deployment logs more informative.

**Python version updates:**

* Updated the `python-version` from `3.10` to `3.11` in the following workflow files:  
  * `.github/workflows/v2-build-demos.yml`  
  * `.github/workflows/v2-deploy-demos.yml`  
  * `.github/workflows/v2-sync-objects-dot-inv.yml`  
  * `.github/workflows/v2-validate-demo-metadata.yml`  
  * `.github/workflows/validate-demo-metadata.yml` [[1]](diffhunk://#diff-fed394207123ffcef344cef277478a04dc4afdf40f38cd985381dec4034323e8L85-R85) [[2]](diffhunk://#diff-fed394207123ffcef344cef277478a04dc4afdf40f38cd985381dec4034323e8L122-R122)

**Deployment workflow improvements:**

* Added deployment and attempted deployment timestamps to PR comments in `.github/workflows/v2-deploy-pr.yml` to provide clearer tracking of deployment events. [[1]](diffhunk://#diff-bb1f887f50cfc7839e56ce823ccf5b9b7a4a07bfd475c5646b28105610511bf3R110-R111) [[2]](diffhunk://#diff-bb1f887f50cfc7839e56ce823ccf5b9b7a4a07bfd475c5646b28105610511bf3R122-R123)

**Note**
We will be updating the master workflows to `3.11` pre-emptively. If this causes issues we will revert.