### PR TITLE
bump for 3.10 or greater

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 description = "Introductions to key concepts in quantum machine learning, as well as tutorials and implementations from cutting-edge QML research."
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = "~3.10.0"
+requires-python = ">=3.10.0"
 authors = [
     { name = "PennyLaneAI", email = "info@pennylane.ai" }
 ]


### PR DESCRIPTION
This pull request updates the Python version requirement in the project configuration to be more flexible, allowing for any Python version 3.10 or higher rather than requiring exactly version 3.10.0. This change improves compatibility with newer Python releases.

- Project configuration update:
  * Relaxed the `requires-python` field in `pyproject.toml` from `~3.10.0` to `>=3.10.0`, allowing the project to be used with any Python version 3.10 or above.