### PR TITLE
add referencing to docs

### DIFF
--- a/documentation/contributing.md
+++ b/documentation/contributing.md
@@ -88,7 +88,7 @@ While you are encouraged to be creative with your demo, please keep the followin
 - **LaTeX Macros:** Avoid using LaTeX macros within your comments. Even if they appear to work in development, they will not be displayed correctly once the demo is published.
 - **Author Information:** Include the author's information in the metadata.json file. See the metadata guidelines below.
 - **Code Formatting:** Before submitting, run your script through the [Black Python formatter](https://github.com/psf/black):
-- **Referencing Other Demos in `demo.py`:** You can reference other demos in your `demo.py` file using `:doc:`demos/<demo_name>` syntax. This will create a link to the specified demo in the documentation. For example, to reference the `tutorial_qft` demo, use `:doc:`demos/tutorial_qft``.
+- **Referencing Other Demos in `demo.py`:** You can reference other demos in your `demo.py` file using ``:doc:\`demos/<demo_name>\``` syntax. This will create a link to the specified demo in the documentation. For example, to reference the `tutorial_qft` demo, use ``:doc:\`demos/tutorial_qft\``` .
 
     ```bash
     pip install black

--- a/documentation/contributing.md
+++ b/documentation/contributing.md
@@ -88,7 +88,7 @@ While you are encouraged to be creative with your demo, please keep the followin
 - **LaTeX Macros:** Avoid using LaTeX macros within your comments. Even if they appear to work in development, they will not be displayed correctly once the demo is published.
 - **Author Information:** Include the author's information in the metadata.json file. See the metadata guidelines below.
 - **Code Formatting:** Before submitting, run your script through the [Black Python formatter](https://github.com/psf/black):
-- **Referencing Other Demos in `demo.py`** You can reference other demos in your `demo.py` file using `:doc:`demos/<demo_name>` syntax. This will create a link to the specified demo in the documentation. For example, to reference the `tutorial_qft` demo, use `:doc:`demos/tutorial_qft``.
+- **Referencing Other Demos in `demo.py`:** You can reference other demos in your `demo.py` file using `:doc:`demos/<demo_name>` syntax. This will create a link to the specified demo in the documentation. For example, to reference the `tutorial_qft` demo, use `:doc:`demos/tutorial_qft``.
 
     ```bash
     pip install black

--- a/documentation/contributing.md
+++ b/documentation/contributing.md
@@ -88,6 +88,7 @@ While you are encouraged to be creative with your demo, please keep the followin
 - **LaTeX Macros:** Avoid using LaTeX macros within your comments. Even if they appear to work in development, they will not be displayed correctly once the demo is published.
 - **Author Information:** Include the author's information in the metadata.json file. See the metadata guidelines below.
 - **Code Formatting:** Before submitting, run your script through the [Black Python formatter](https://github.com/psf/black):
+- **Referencing Other Demos in `demo.py`** You can reference other demos in your `demo.py` file using `:doc:`demos/<demo_name>` syntax. This will create a link to the specified demo in the documentation. For example, to reference the `tutorial_qft` demo, use `:doc:`demos/tutorial_qft``.
 
     ```bash
     pip install black


### PR DESCRIPTION
This pull request adds documentation to help contributors reference other demos in their `demo.py` files. The update provides clear instructions and an example of how to create cross-links between demos using the `:doc:`demos/<demo_name>` syntax.

Documentation improvements:

* Added a section to `documentation/contributing.md` explaining how to reference other demos in `demo.py` files using the `:doc:`demos/<demo_name>` syntax, including a concrete example.