### PR TITLE
Use github ref for build concurrency

### DIFF
--- a/.github/workflows/v2-build-pr.yml
+++ b/.github/workflows/v2-build-pr.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: build-v2-demos-${{ github.event.pull_request.head.sha }}
+  group: build-v2-demos-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
The current "concurrency" string for pull request builds uses the `sha` of the commit rather than the ref of the branch. This means the concurrency group changes with every commit, so commits to the same branch in quick succession do not cancel running jobs as they should. For example, I made changes to the same demo and pushed to the branch 3 times in the span of a few minutes, and all the builds ran to completion. 
<img width="1296" height="235" alt="Screenshot 2025-08-11 at 3 43 39 PM" src="https://github.com/user-attachments/assets/68b8de94-d107-41ff-835e-727748c9e709" />

The desired behaviour is that the most recent push should cancel any running build for that branch and start again using the latest changes. This PR uses the PR ref for the concurrency group, which will have the desired effect of new changes pushed to the branch cancelling any in-progress builds for that branch and trigger a fresh build.