### PR TITLE
try udpate constraint

### DIFF
--- a/dependencies/constraints-dev.txt
+++ b/dependencies/constraints-dev.txt
@@ -8,8 +8,8 @@ pennylane-cirq @ git+https://github.com/PennyLaneAI/pennylane-cirq.git#egg=penny
 pennylane-qiskit @ git+https://github.com/PennyLaneAI/pennylane-qiskit.git#egg=pennylane-qiskit
 pennylane-qulacs @ git+https://github.com/PennyLaneAI/pennylane-qulacs.git#egg=pennylane-qulacs
 iqpot @ git+https://github.com/XanaduAI/iqpopt.git#egg=iqpopt
-pennylane-catalyst
-pennylane-lightning
+pennylane-lightning @ git+https://github.com/PennyLaneAI/pennylane-lightning.git#egg=pennylane-lightning
+pennylane-catalyst @ git+https://github.com/PennyLaneAI/catalyst.git#egg=pennylane-catalyst
 
 
 chex<1.0.0


### PR DESCRIPTION
**Context:**
Typically, Latest pennylane + Stable lightning + Stable catalyst won't work atl, for example during the developement of 0.43 where we only have S/S/S or L/L/L working well.

**Summary:**

**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**
