### PR TITLE
Fix admontion on `tutorial_neutral_atoms`

### DIFF
--- a/demonstrations_v2/tutorial_neutral_atoms/demo.py
+++ b/demonstrations_v2/tutorial_neutral_atoms/demo.py
@@ -127,7 +127,7 @@ the work that still needs to be done to scale this technology even further.
 # energy state using lasers. If you need a refresher on how we change the electronic energy levels of atoms, do take
 # a look at the blue box below!
 #
-# .. container:: alert alert-block alert-info
+# .. tip::
 #
 #    **Atomic Physics Primer:** Atoms consist of a positively charged nucleus
 #    and negative electrons around it. The electrons inhabit energy

--- a/demonstrations_v2/tutorial_neutral_atoms/demo.py
+++ b/demonstrations_v2/tutorial_neutral_atoms/demo.py
@@ -29,7 +29,7 @@ discuss their strengths and weaknesses in terms of DiVincenzo's criteria, introd
 By the end of this tutorial, you will have obtained a high-level understanding of neutral atom technologies
 and be able to follow the new exciting developments that are bound to come.
 
-.. note::
+.. tip::
     
     **DiVincenzo's criteria**: In the year 2000, David DiVincenzo proposed a
     wishlist for the experimental characteristics of a quantum computer [#DiVincenzo2000]_.

--- a/demonstrations_v2/tutorial_neutral_atoms/demo.py
+++ b/demonstrations_v2/tutorial_neutral_atoms/demo.py
@@ -29,7 +29,7 @@ discuss their strengths and weaknesses in terms of DiVincenzo's criteria, introd
 By the end of this tutorial, you will have obtained a high-level understanding of neutral atom technologies
 and be able to follow the new exciting developments that are bound to come.
 
-.. container:: alert alert-block alert-info
+.. note::
     
     **DiVincenzo's criteria**: In the year 2000, David DiVincenzo proposed a
     wishlist for the experimental characteristics of a quantum computer [#DiVincenzo2000]_.

--- a/demonstrations_v2/tutorial_neutral_atoms/metadata.json
+++ b/demonstrations_v2/tutorial_neutral_atoms/metadata.json
@@ -8,7 +8,7 @@
     "executable_stable": true,
     "executable_latest": true,
     "dateOfPublication": "2023-05-30T00:00:00+00:00",
-    "dateOfLastModification": "2024-10-07T00:00:00+00:00",
+    "dateOfLastModification": "2025-08-20T21:00:00+00:00",
     "categories": [
         "Quantum Hardware",
         "Quantum Computing"

--- a/demonstrations_v2/tutorial_neutral_atoms/requirements.in
+++ b/demonstrations_v2/tutorial_neutral_atoms/requirements.in
@@ -1,2 +1,3 @@
 jax
 jaxlib
+autoray==0.6.11

--- a/demonstrations_v2/tutorial_neutral_atoms/requirements.in
+++ b/demonstrations_v2/tutorial_neutral_atoms/requirements.in
@@ -1,3 +1,3 @@
 jax
 jaxlib
-autoray==0.6.11
+autoray==0.6.11,<0.8


### PR DESCRIPTION
## Summary

Fixes issue where "blue" styling doesn't appear. The issue is that the container class rst conflicts with tailwind classes

## Change:
- convert blocks to tip admonition

## Issue
- https://app.shortcut.com/xanaduai/story/93788/update-tutorial-neutral-atoms-to-use-admonition-note-instead-of-alert-class