### PR TITLE
Fix link to contributing guidelines in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Explore the full collection of [PennyLane demos](https://pennylane.ai/qml/demons
 
 ## Table of Contents
 
-- [Contributing to Demos](contributing.md)
+- [Contributing to Demos](CONTRIBUTING.md)
 - [QML CLI Tool](/documentation/qml-cli.md)
 - [Dependency Management](/dependencies/README.md)
 - [Support](#support)


### PR DESCRIPTION
This pull request updates a documentation link in the `README.md` file to ensure consistency and correct navigation for contributors.

- Documentation update:
  * Changed the "Contributing to Demos" link in `README.md` from `contributing.md` to `CONTRIBUTING.md` for proper file reference.