### PR TITLE
Install dev pennylane for dev builds

### DIFF
--- a/demonstrations_v2/tutorial_iqp_circuit_optimization_jax/metadata.json
+++ b/demonstrations_v2/tutorial_iqp_circuit_optimization_jax/metadata.json
@@ -11,7 +11,7 @@
     "executable_stable": true,
     "executable_latest": true,
     "dateOfPublication": "2025-02-14T09:00:00+00:00",
-    "dateOfLastModification": "2025-09-08T00:00:00+00:00",
+    "dateOfLastModification": "2025-08-21T09:00:00+00:00",
     "categories": [
         "Optimization",
         "Algorithms"

--- a/demonstrations_v2/zne_catalyst/metadata.json
+++ b/demonstrations_v2/zne_catalyst/metadata.json
@@ -11,7 +11,7 @@
     "executable_stable": false,
     "executable_latest": true,
     "dateOfPublication": "2024-11-15T00:00:00+00:00",
-    "dateOfLastModification": "2025-09-08T00:00:00+00:00",
+    "dateOfLastModification": "2025-08-21T00:00:00+00:00",
     "categories": [
         "Algorithms",
         "Quantum Computing"


### PR DESCRIPTION
~For some reason, importing these deprecation warnings directly from pennylane breaks when building the html. Unclear if this is a versioning issue in the pipeline, but importing it from qml (which has already been imported above) works.~

Found the real culprit. The issue was that we only install the dev version of PennyLane if we're executing the demos, but the workflow to build the objects.inv file doesn't execute the demos (because it doesn't need to). Sphinx still needs the dev version of PennyLane to build the demos though, as it imports the deprecation warning in the conf file, hence the errors raised by the two demos that use the deprecation warning.

This PR moves the install of the dev version of PennyLane outside the `execute` requirement, so it is installed for dev builds regardless. I've tested this locally and it solves the issue. 