### PR TITLE
Typo in clifford simulation demo

### DIFF
--- a/demonstrations_v2/tutorial_clifford_circuit_simulations/demo.py
+++ b/demonstrations_v2/tutorial_clifford_circuit_simulations/demo.py
@@ -22,7 +22,7 @@ In classical computation, one can define a universal set of logic gate operation
 ``{AND, NOT, OR}`` that can be used to perform any boolean function. A similar analogue
 in quantum computation is to have a set of quantum gates that can approximate any unitary
 transformation up to the desired accuracy. One such universal quantum gate set is the
-:math:`\textrm{Clifford + T}` set, ``{H, S, CNOT, T}``, where the gates ``H``, ``S`,` and
+:math:`\textrm{Clifford + T}` set, ``{H, S, CNOT, T}``, where the gates ``H``, ``S``, and
 ``CNOT`` are the generators of the *Clifford group*. The elements of this group are
 called *Clifford gates*, which transform *Pauli* words to *Pauli* words under
 `conjugation <https://mathworld.wolfram.com/Conjugation.html>`__. This means an

--- a/demonstrations_v2/tutorial_clifford_circuit_simulations/metadata.json
+++ b/demonstrations_v2/tutorial_clifford_circuit_simulations/metadata.json
@@ -8,7 +8,7 @@
     "executable_stable": true,
     "executable_latest": true,
     "dateOfPublication": "2024-04-12T00:00:00+00:00",
-    "dateOfLastModification": "2025-09-09T17:41:50+00:00",
+    "dateOfLastModification": "2025-09-16T17:41:50+00:00",
     "categories": [
         "Devices and Performance"
     ],


### PR DESCRIPTION
This pull request contains a typo fix for the Clifford circuit simulation tutorial.

**Fix:**
* Fixed a typo in the description of the Clifford + T gate set in `demo.py` by changing "S,`" to "S``,", ensuring consistent punctuation and improved readability.

**Metadata update:**

* Updated the `dateOfLastModification` field in `metadata.json` to reflect the most recent change.

From original PR here https://github.com/PennyLaneAI/qml/pull/1359