### PR TITLE
Circuits as a Fourier series fixes

### DIFF
--- a/_static/demonstration_assets/circuits_as_fourier_series/sketch.js
+++ b/_static/demonstration_assets/circuits_as_fourier_series/sketch.js
@@ -1,4 +1,5 @@
-const url_prefix = '/_static/demonstration_assets/circuits_as_fourier_series/src/';
+/* This demo requires special image handling, we will move all images to an internal asset lib */
+const url_prefix = 'https://assets.cloud.pennylane.ai/demos/circuits_as_fourier_series/';
 
 ///// Sketch 0
 

--- a/demonstrations_v2/circuits_as_fourier_series/demo.py
+++ b/demonstrations_v2/circuits_as_fourier_series/demo.py
@@ -796,4 +796,3 @@ Handily, both references have an associated PennyLane demo!
 Finally, PennyLane is jam-packed with tools for analyzing circuits as Fourier series.
 Check out the documentation on the `Fourier module <https://docs.pennylane.ai/en/stable/code/qml_fourier.html>`__ to learn more!
 """
-

--- a/demonstrations_v2/circuits_as_fourier_series/demo.py
+++ b/demonstrations_v2/circuits_as_fourier_series/demo.py
@@ -796,3 +796,4 @@ Handily, both references have an associated PennyLane demo!
 Finally, PennyLane is jam-packed with tools for analyzing circuits as Fourier series.
 Check out the documentation on the `Fourier module <https://docs.pennylane.ai/en/stable/code/qml_fourier.html>`__ to learn more!
 """
+

--- a/demonstrations_v2/circuits_as_fourier_series/metadata.json
+++ b/demonstrations_v2/circuits_as_fourier_series/metadata.json
@@ -8,7 +8,7 @@
     "executable_stable": false,
     "executable_latest": false,
     "dateOfPublication": "2023-09-11T00:00:00+00:00",
-    "dateOfLastModification": "2025-09-09T17:41:50+00:00",
+    "dateOfLastModification": "2025-09-17T17:41:50+00:00",
     "categories": [
         "Optimization",
         "Quantum Machine Learning"


### PR DESCRIPTION
This pull request updates asset handling for the "Circuits as Fourier Series" demonstration.

Asset management issue fix:
* Updated the `url_prefix` in `sketch.js` to point to the centralized asset library at `https://assets.cloud.pennylane.ai/demos/circuits_as_fourier_series/` instead of a local path.