### PR TITLE
Patch filters

### DIFF
--- a/documentation/reference_demo/demo.py
+++ b/documentation/reference_demo/demo.py
@@ -571,8 +571,8 @@ Unsupported directives:
 #     Example of an admonition directive.
 
 # %%
-# Links
-# -----
+# Links and Inlines
+# -----------------
 #
 # Example of an `external link <https://pennylane.ai/qml>`_.
 #
@@ -597,6 +597,8 @@ Unsupported directives:
 # Same as above, but without a custom label: :mod:`~pennylane.qnn`.
 #
 # Example of a reference link: :ref:`reference_link`. These aren't supported in the demos.
+#
+# Example of an inline html directive: :html:`<a href="https://pennylane.ai" target="_blank">An inline HTML link to pennylane.ai</a>`.
 
 # %%
 # Make some reference like this [#Jordan2024]_ and this [#Bartschi2019]_ in the demo and they 

--- a/lib/filter_links.py
+++ b/lib/filter_links.py
@@ -5,7 +5,7 @@ Pandoc filter to process intersphinx links.
 """
 from typing import Any, Dict
 import sphobjinv as soi
-from pandocfilters import toJSONFilter, Link
+from pandocfilters import toJSONFilter, Link, RawInline
 
 DEMOS_URL = "https://pennylane.ai/qml/demos/"
 PL_OBJ_INV_URL = "https://docs.pennylane.ai/en/stable/"
@@ -67,15 +67,17 @@ def filter_links(key, value, format, _):
         [[_, classes, role], body] = value
 
         if "interpreted-text" in classes:
-            text, key = parse_body(body)
-            
-            # The doc type could be a demo, so needs special treatment
-            if "doc" in role[0]:
-                name, link = process_doc_link(text, key)
+            if "html" in role[0]:
+                return RawInline("markdown", body)
             else:
-                name, link = process_link(text, key)
+                text, key = parse_body(body)
+                # The doc type could be a demo, so needs special treatment
+                if "doc" in role[0]:
+                    name, link = process_doc_link(text, key)
+                else:
+                    name, link = process_link(text, key)
 
-            return Link(["",[],[]], pandocify_string(name), [link,""])
+                return Link(["",[],[]], pandocify_string(name), [link,""])
 
 if __name__ == '__main__':
     pl_obj_inv = make_named_inventory(soi.Inventory(url=PL_OBJ_INV_URL+"objects.inv"))


### PR DESCRIPTION
This PR adds a patch to the `filter_links` Pandoc filter to process inline HTML. Two demos use this directive and are crashing the objects.inv build.

Verified that all demos now build [here](https://github.com/PennyLaneAI/qml/actions/runs/17861828175).