### PR TITLE
make tutorial_shors_algorithm_catalyst non-executable on latest

### DIFF
--- a/demonstrations_v2/tutorial_shors_algorithm_catalyst/metadata.json
+++ b/demonstrations_v2/tutorial_shors_algorithm_catalyst/metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "executable_stable": true,
-    "executable_latest": true,
+    "executable_latest": false,
     "dateOfPublication": "2025-04-04T09:00:00+00:00",
     "dateOfLastModification": "2025-09-09T17:41:50+00:00",
     "categories": [

--- a/demonstrations_v2/tutorial_shors_algorithm_catalyst/metadata.json
+++ b/demonstrations_v2/tutorial_shors_algorithm_catalyst/metadata.json
@@ -8,7 +8,7 @@
     "executable_stable": true,
     "executable_latest": false,
     "dateOfPublication": "2025-04-04T09:00:00+00:00",
-    "dateOfLastModification": "2025-09-09T17:41:50+00:00",
+    "dateOfLastModification": "2025-09-23T17:41:50+00:00",
     "categories": [
         "Algorithms",
         "Quantum Computing",


### PR DESCRIPTION
Make the tutorial non-executable so we can free `dev` actions to not hide any failures before release.

Here's a story to remind us to make it executable later: [sc-99942]