### PR TITLE
fix-thumbnail-tutorial-learning-dynamics-incoherently

### DIFF
--- a/demonstrations_v2/tutorial_learning_dynamics_incoherently/metadata.json
+++ b/demonstrations_v2/tutorial_learning_dynamics_incoherently/metadata.json
@@ -13,11 +13,11 @@
     "previewImages": [
         {
             "type": "thumbnail",
-            "uri": "_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_learning_dynamics_incoherently.png"
+            "uri": "/_static/demo_thumbnails/regular_demo_thumbnails/thumbnail_learning_dynamics_incoherently.png"
         },
         {
             "type": "large_thumbnail",
-            "uri": "_static/demo_thumbnails/large_demo_thumbnails/thumbnail_large_learning_dynamics_incoherently.png"
+            "uri": "/_static/demo_thumbnails/large_demo_thumbnails/thumbnail_large_learning_dynamics_incoherently.png"
         }
     ],
     "seoDescription": "Learn how to reproduce an unknown quantum process with classical shadow measurements",


### PR DESCRIPTION
## Changes
- Fix thumbnail path and update date of modification

## Issue
- reported on [slack](https://xanaduhq.slack.com/archives/C05C2NU8QBY/p1762355215521149)