### PR TITLE
Handle new sphx-gallery format

### DIFF
--- a/lib/filter_directives.py
+++ b/lib/filter_directives.py
@@ -18,10 +18,13 @@ def filter_directives(key, value, format, _):
             return []
         elif "rst-class" in classes:
             metadata = body[0]
-            content = body[1]
             rst_class_type = metadata.get("c")[0].get("c")
             if rst_class_type == "sphx-glr-script-out":
-                return content
+                if len(body) == 1:
+                # This is the new format for sphx-glr-script-out.
+                # Just discard this block.
+                    return []
+                return body[1]
             else:
                 return
         else:

--- a/lib/filter_tables.py
+++ b/lib/filter_tables.py
@@ -70,10 +70,10 @@ def filter_tables(key, value, format, _):
         [[_, classes, _], body] = value
         if  "rst-class" in classes:
             metadata = body[0]
-            content = body[1]
             rst_class_type = metadata.get("c")[0].get("c")
             if rst_class_type == "docstable":
                 caption = []
+                content = body[1]
                 if len(body) > 2:
                     caption.append(body[2])
                 return make_markdown_table(content.get("c"), caption)


### PR DESCRIPTION
After the update to Sphinx, Sphinx Gallery now outputs a different format for generated code blocks, where the code block is now part of an entirely separate element and no longer nested in `rst-class` directive. This PR adds a fix to be able to handle both the new and old `sphx-glr-script-out` formats. It has been tested on #1592 . 