### PR TITLE
Continue demo builds

### DIFF
--- a/.github/workflows/v2-build-demos.yml
+++ b/.github/workflows/v2-build-demos.yml
@@ -157,6 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [generate-build-variables]
     strategy:
+      fail-fast: false
       matrix:
         chunk-index: ${{ fromJson(needs.generate-build-variables.outputs.chunk-indexes) }}
     steps:


### PR DESCRIPTION
This PR adds the `fail-fast: false` configuration to the v2 build demo Action. Currently, when building multiple demos (e.g. master or dev branch builds) a single failing demo will halt the build process. With this configuration, the build will continue and attempt to build all demos, even if one or more fails. All demos must still build successfully for further steps of the pipeline to be triggered.