### PR TITLE
Update map_wires call

### DIFF
--- a/demonstrations_v2/tutorial_zx_calculus/demo.py
+++ b/demonstrations_v2/tutorial_zx_calculus/demo.py
@@ -774,7 +774,7 @@ qscript_opt = qml.transforms.from_zx(g)
 
 wires = qml.wires.Wires([4, 3, 0, 2, 1])
 wires_map = dict(zip(qscript_opt.wires, wires))
-qscript_opt_reorder, processing = qml.map_wires(input=qscript_opt, wire_map=wires_map)
+qscript_opt_reorder, processing = qml.map_wires(qscript_opt, wire_map=wires_map)
 
 @qml.qnode(device=dev)
 def mod_5_4():

--- a/demonstrations_v2/tutorial_zx_calculus/metadata.json
+++ b/demonstrations_v2/tutorial_zx_calculus/metadata.json
@@ -8,7 +8,7 @@
     "executable_stable": true,
     "executable_latest": true,
     "dateOfPublication": "2023-06-06T00:00:00+00:00",
-    "dateOfLastModification": "2025-12-10T15:48:14+00:00",
+    "dateOfLastModification": "2025-12-16T15:48:14+00:00",
     "categories": [
         "Quantum Computing",
         "Compilation"


### PR DESCRIPTION
**Title:**

**Summary:**
Now that `qml.map_wires` is a transform, the first argument is positional. Update `map_wires(input=...)` to `map_wires(...)`

**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**
