### PR TITLE
Enable daily dev builds

### DIFF
--- a/.github/workflows/v2-build-branch-dev.yml
+++ b/.github/workflows/v2-build-branch-dev.yml
@@ -2,8 +2,8 @@ name: V2 Build QML Branch - Dev
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 5 * * 1,3,5' # At 05:00 (12am EST) on Sunday (Monday am), Tuesday (Wednesday am), Thursday (Friday am).
-    #- cron: '0 10 * * *' # At 10:00 (5am EST) on every day-of-week. Use this during feature freeze.
+    #- cron: '0 5 * * 1,3,5' # At 05:00 (12am EST) on Sunday (Monday am), Tuesday (Wednesday am), Thursday (Friday am).
+    - cron: '0 10 * * *' # At 10:00 (5am EST) on every day-of-week. Use this during feature freeze.
 
 concurrency:
   group: v2-build-qml-demo-branch-dev


### PR DESCRIPTION
This PR updates the cron schedule for the dev builds to build every morning at 5am. The dev builds are now coming from the test-pypi releases, so this will provide a daily snapshot of the RC state.