### PR TITLE
`recursive=False` for `cancel_inverse` of `tutorial_circuit_compilation`

### DIFF
--- a/demonstrations_v2/tutorial_circuit_compilation/demo.py
+++ b/demonstrations_v2/tutorial_circuit_compilation/demo.py
@@ -129,7 +129,7 @@ plt.show()
 @qml.qnode(dev)
 @partial(qml.transforms.merge_rotations, atol=1e-8, include_gates=None)
 @qml.transforms.cancel_inverses
-@partial(qml.transforms.commute_controlled, direction="right", recursive=False)
+@partial(qml.transforms.commute_controlled, direction="right")
 def q_fun(angles):
     qml.Hadamard(wires=1)
     qml.Hadamard(wires=2)

--- a/demonstrations_v2/tutorial_circuit_compilation/demo.py
+++ b/demonstrations_v2/tutorial_circuit_compilation/demo.py
@@ -163,7 +163,12 @@ plt.show()
 # :func:`~pennylane.compile` function, which yields the same final circuit.
 #
 
-compiled_circuit = qml.compile(circuit)
+pipelines = [
+    partial(qml.transforms.commute_controlled, direction="right"),
+    partial(qml.transforms.cancel_inverses, recursive=False),
+    partial(qml.transforms.merge_rotations, atol=1e-8, include_gates=None),
+]
+compiled_circuit = qml.compile(circuit, pipeline=pipelines)
 
 qnode = qml.QNode(compiled_circuit, dev)
 qml.draw_mpl(qnode, decimals=1, style="sketch")(angles)
@@ -178,7 +183,7 @@ plt.show()
 # Let us see the resulting circuit with two passes.
 #
 
-compiled_circuit = qml.compile(circuit, num_passes=2)
+compiled_circuit = qml.compile(circuit, pipeline=pipelines, num_passes=2)
 
 qnode = qml.QNode(compiled_circuit, dev)
 qml.draw_mpl(qnode, decimals=1, style="sketch")(angles)

--- a/demonstrations_v2/tutorial_circuit_compilation/demo.py
+++ b/demonstrations_v2/tutorial_circuit_compilation/demo.py
@@ -128,7 +128,7 @@ plt.show()
 
 @qml.qnode(dev)
 @partial(qml.transforms.merge_rotations, atol=1e-8, include_gates=None)
-@qml.transforms.cancel_inverses
+@qml.transforms.cancel_inverses(recursive=False)
 @partial(qml.transforms.commute_controlled, direction="right")
 def q_fun(angles):
     qml.Hadamard(wires=1)
@@ -197,7 +197,7 @@ compiled_circuit = qml.compile(
     pipeline=[
         partial(qml.transforms.commute_controlled, direction="left"),  # Opposite direction
         partial(qml.transforms.merge_rotations, include_gates=["RZ"]),  # Different threshold
-        partial(qml.transforms.cancel_inverses, recursive=False),  # Cancel inverses after rotations
+        qml.transforms.cancel_inverses(recursive=False),  # Cancel inverses after rotations
     ],
     num_passes=3,
 )

--- a/demonstrations_v2/tutorial_circuit_compilation/demo.py
+++ b/demonstrations_v2/tutorial_circuit_compilation/demo.py
@@ -197,7 +197,7 @@ compiled_circuit = qml.compile(
     pipeline=[
         partial(qml.transforms.commute_controlled, direction="left"),  # Opposite direction
         partial(qml.transforms.merge_rotations, include_gates=["RZ"]),  # Different threshold
-        qml.transforms.cancel_inverses(recursive=False),  # Cancel inverses after rotations
+        partial(qml.transforms.cancel_inverses, recursive=False),  # Cancel inverses after rotations
     ],
     num_passes=3,
 )

--- a/demonstrations_v2/tutorial_circuit_compilation/demo.py
+++ b/demonstrations_v2/tutorial_circuit_compilation/demo.py
@@ -93,7 +93,7 @@ plt.show()
 # transform, which removes consecutive inverse operations.
 #
 
-cancelled_circuit = qml.transforms.cancel_inverses(commuted_circuit)
+cancelled_circuit = qml.transforms.cancel_inverses(commuted_circuit, recursive=False)
 
 
 qnode = qml.QNode(cancelled_circuit, dev)
@@ -129,7 +129,7 @@ plt.show()
 @qml.qnode(dev)
 @partial(qml.transforms.merge_rotations, atol=1e-8, include_gates=None)
 @qml.transforms.cancel_inverses
-@partial(qml.transforms.commute_controlled, direction="right")
+@partial(qml.transforms.commute_controlled, direction="right", recursive=False)
 def q_fun(angles):
     qml.Hadamard(wires=1)
     qml.Hadamard(wires=2)
@@ -197,7 +197,7 @@ compiled_circuit = qml.compile(
     pipeline=[
         partial(qml.transforms.commute_controlled, direction="left"),  # Opposite direction
         partial(qml.transforms.merge_rotations, include_gates=["RZ"]),  # Different threshold
-        qml.transforms.cancel_inverses,  # Cancel inverses after rotations
+        partial(qml.transforms.cancel_inverses, recursive=False),  # Cancel inverses after rotations
     ],
     num_passes=3,
 )


### PR DESCRIPTION
This demo has a story-telling teaching the audience step-by-step how to use Pennylane's cancel inverse and there are tight bound between the rendered circuit visualization and the texts.
However, a recent upgrade to cancel inverse changed too much to these visualization.
Therefore we would like to try disable the upgrade inplace to recover the previous images.