### PR TITLE
Dev test higher qiskit ibm runtime

### DIFF
--- a/dependencies/constraints-stable.txt
+++ b/dependencies/constraints-stable.txt
@@ -21,7 +21,7 @@ openfermionpyscf==0.5
 openqaoa-core==0.2.5
 qiskit>=2.0
 qiskit-aer>=0.17
-qiskit_ibm_runtime==0.41.1
+qiskit_ibm_runtime==0.43.0
 torch==2.1.2+cpu ; sys_platform != 'darwin'
 torch==2.1.2 ; sys_platform == 'darwin'
 torchvision==0.16.2+cpu ; sys_platform != 'darwin'


### PR DESCRIPTION
Test if pinning qiskit ibm runtime to 0.43 would fix