### PR TITLE
Remove the redundant `pennylane-qrack` from the `constraints-stable.txt`

### DIFF
--- a/dependencies/constraints-stable.txt
+++ b/dependencies/constraints-stable.txt
@@ -5,7 +5,6 @@ pennylane-cirq==0.44.*
 pennylane-qiskit==0.44.*
 pennylane-qulacs==0.44.*
 pennylane-catalyst==0.14.*
-pennylane-qrack==0.11.*
 
 # Install external packages
 matplotlib==3.10.0


### PR DESCRIPTION
Tested here: https://github.com/PennyLaneAI/qml/actions/runs/21185658009
