### PR TITLE
Add concurrency group for objects.inv upload Action

### DIFF
--- a/.github/workflows/v2-sync-objects-dot-inv.yml
+++ b/.github/workflows/v2-sync-objects-dot-inv.yml
@@ -1,4 +1,9 @@
 name: V2 Sync objects.inv
+
+concurrency:
+  group: v2-sync-objects-inv-${{ inputs.branch || github.event.workflow_run.head_branch || github.ref }}
+  cancel-in-progress: true
+
 on:
   # Allow existing reusable use.
   workflow_call:


### PR DESCRIPTION
Follow-up to #1666, this PR adds a concurrency group to the Action so overlapping triggers will cancel in-progress runs.  