### PR TITLE
Add User-Agent for pulling objects.inv

### DIFF
--- a/lib/filter_links.py
+++ b/lib/filter_links.py
@@ -17,6 +17,7 @@ DEMOS_URL = "https://pennylane.ai/qml/demos/"
 PL_OBJ_INV_URL = "https://docs.pennylane.ai/en/stable/"
 CAT_OBJ_INV_URL = "https://docs.pennylane.ai/projects/catalyst/en/stable/"
 
+# Readthedocs has started rate limiting requests without proper User-Agent.
 # Mirror Sphinx's sphinx.util.requests: use GET with User-Agent and timeout.
 # Sphinx uses requests.get()/head() via sphinx.util.requests.get(), which sets
 # User-Agent (Firefox-like + Sphinx version) and intersphinx_timeout.


### PR DESCRIPTION
It seems Readthedocs is now blocking get requests from Github runners that don't have a proper User-Agent set. In our Actions Sphinx is able to load the objects.inv files successfully, but our custom pandoc filters get hit with a 429 error immediately.

This PR refactors the filter_links pandoc filter to download the objects.inv file in a separate step with a proper User-Agent set in the header. This has been tested successfully [here](https://github.com/PennyLaneAI/qml/actions/runs/21677476872/job/62501914610).