### PR TITLE
Dev build fix

### DIFF
--- a/lib/inventories.py
+++ b/lib/inventories.py
@@ -22,7 +22,7 @@ def _load_inventory_from_path(path: Path) -> soi.Inventory | None:
     if not path.is_file():
         return None
     try:
-        return soi.Inventory(path)
+        return soi.Inventory(fname_zlib=path)
     except Exception:
         return None
 
@@ -43,7 +43,7 @@ def _load_inventory_from_url(
             time.sleep(delay * attempt)
     # sphobjinv accepts zlib-compressed bytes from objects.inv
     raw = response.content
-    return soi.Inventory(raw), raw
+    return soi.Inventory(zlib=raw), raw
 
 
 def _make_named_inventory(inv: soi.Inventory) -> dict[str, Any]:


### PR DESCRIPTION
The latest `objects.inv` file for PennyLane seems to be confusing the library we use to load and parse this file when creating the demo notebooks, and as a result the recent scheduled dev branch build failed.

This PR adds explicit specification of what type of data to expect for this file, rather than previously relying on the library's ability to sort it out for itself.

[Dev](https://github.com/PennyLaneAI/qml/actions/runs/22112653904) and [Master](https://github.com/PennyLaneAI/qml/actions/runs/22112840985) builds have been tested and now build successfully ✅ 