### PR TITLE
Bump checkout Action to v5

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Run CircleCI artifacts redirector
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Get artifact URL
         id: getArtifact

--- a/.github/workflows/update-dev.yml
+++ b/.github/workflows/update-dev.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.NIGHTLY_TOKEN }}
           fetch-depth: 0  # We want entire git-history to avoid any merge conflicts

--- a/.github/workflows/v1-deprecation-warning.yml
+++ b/.github/workflows/v1-deprecation-warning.yml
@@ -14,7 +14,7 @@ jobs:
       demonstrations-v1-changes-detected: ${{ steps.determine-changes.outputs.demonstrations-v1-changes-detected }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/v2-build-demos-swc-env.yml
+++ b/.github/workflows/v2-build-demos-swc-env.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get changed demos
         id: get-changed-demos

--- a/.github/workflows/v2-build-demos.yml
+++ b/.github/workflows/v2-build-demos.yml
@@ -120,7 +120,7 @@ jobs:
       chunk-indexes: ${{ steps.get-chunk-indexes.outputs.chunk-indexes }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 1
@@ -162,7 +162,7 @@ jobs:
         chunk-index: ${{ fromJson(needs.generate-build-variables.outputs.chunk-indexes) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 1
@@ -212,7 +212,7 @@ jobs:
     needs: [generate-build-variables, build-demos]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 1

--- a/.github/workflows/v2-build-pr.yml
+++ b/.github/workflows/v2-build-pr.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get changed demos
         id: get-changed-demos

--- a/.github/workflows/v2-deploy-demos.yml
+++ b/.github/workflows/v2-deploy-demos.yml
@@ -44,7 +44,7 @@ jobs:
       DEPLOYMENT_ENDPOINT_URL: ${{ secrets.DEPLOYMENT_ENDPOINT_URL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
       

--- a/.github/workflows/v2-sync-objects-dot-inv.yml
+++ b/.github/workflows/v2-sync-objects-dot-inv.yml
@@ -53,7 +53,7 @@ jobs:
       any_changed: ${{ github.event_name == 'workflow_call' || steps.get-changed-demos.outputs.updated != '' || steps.get-changed-demos.outputs.deleted != '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.branch || github.event.workflow_run.head_sha }}
           fetch-depth: ${{ github.event_name == 'workflow_run' && 2 || 1 }}
@@ -120,7 +120,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ env.TARGET_REF }}
           fetch-depth: 1

--- a/.github/workflows/v2-validate-demo-metadata.yml
+++ b/.github/workflows/v2-validate-demo-metadata.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           ref: ${{ inputs.branch }}
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           ref: ${{ inputs.branch }}


### PR DESCRIPTION
Github runners will no longer support Node 20 later this year, and are already starting to warn us about it. This PR bumps the "checkout" Action to [v5](https://github.com/actions/checkout?tab=readme-ov-file#checkout-v5), which uses Node 24 and introduces no other changes.

Tested successfully using the build-demo action.