### PR TITLE
Update qml references to demos in templates and README

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 #### Before posting an issue
 
 Search existing GitHub issues to make sure the issue does not already exist:
-https://github.com/XanaduAI/qml/issues
+https://github.com/PennyLaneAI/demos/issues
 
 If posting an issue, delete everything above the dashed line, and fill
 in the template.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -10,7 +10,7 @@ assignees: ''
 #### Before posting an issue
 
 Search existing GitHub issues to make sure the issue does not already exist:
-https://github.com/XanaduAI/qml/issues
+https://github.com/PennyLaneAI/demos/issues
 
 Delete everything above the dashed line, and fill in the template.
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -10,6 +10,6 @@ assignees: ''
 #### Before posting a feature request
 
 Search existing GitHub issues to make sure the issue does not already exist:
-https://github.com/XanaduAI/qml/issues
+https://github.com/PennyLaneAI/demos/issues
 
 Delete everything in this box and describe, in detail, the feature and why it is needed.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Explore the full collection of [PennyLane demos](https://pennylane.ai/qml/demons
 
 ## Support
 
-- **Source Code:** https://github.com/PennyLaneAI/qml
-- **Issue Tracker:** https://github.com/PennyLaneAI/qml/issues
+- **Source Code:** https://github.com/PennyLaneAI/demos
+- **Issue Tracker:** https://github.com/PennyLaneAI/demos/issues
 
 If you encounter any issues, have questions, or wish to suggest improvements, please report them on our GitHub issue tracker.
 


### PR DESCRIPTION
## Changes
- Update `qml` links to `demos` to be in sync with repo name change