### PR TITLE
Fix/falqon demo issue 1726

### DIFF
--- a/demonstrations_v2/tutorial_falqon/demo.py
+++ b/demonstrations_v2/tutorial_falqon/demo.py
@@ -320,7 +320,7 @@ plt.show()
 # We define the following circuit, feeding in the optimal values of :math:`\beta_k:`
 
 
-@qml.qnode(dev, interface="autograd")
+@qml.qnode(dev)
 def prob_circuit():
     ansatz = build_maxclique_ansatz(cost_h, driver_h, delta_t)
     ansatz(res_beta)

--- a/demonstrations_v2/tutorial_falqon/demo.py
+++ b/demonstrations_v2/tutorial_falqon/demo.py
@@ -208,6 +208,9 @@ def build_hamiltonian(graph):
     return H
 
 
+print("MaxClique Commutator")
+print(build_hamiltonian(graph))
+
 ######################################################################
 # .. note::
 #
@@ -220,9 +223,6 @@ def build_hamiltonian(graph):
 #         cost_h, driver_h = qaoa.max_clique(graph, constrained=False)
 #         comm_h = qml.simplify(1j * qml.commutator(driver_h, cost_h))
 #
-
-print("MaxClique Commutator")
-print(build_hamiltonian(graph))
 
 ######################################################################
 # We can now build the FALQON algorithm. Our goal is to evolve some initial state under the Hamiltonian :math:`H,`

--- a/demonstrations_v2/tutorial_falqon/demo.py
+++ b/demonstrations_v2/tutorial_falqon/demo.py
@@ -136,13 +136,16 @@ plt.show()
 ######################################################################
 # We must first encode this combinatorial problem into a cost Hamiltonian :math:`H_c.` This ends up being
 #
-# .. math:: H_c = 3 \sum_{(i, j) \in E(\bar{G})} (Z_i Z_j - Z_i - Z_j) + \displaystyle\sum_{i \in V(G)} Z_i,
+# .. math:: H_c = \frac{3}{4} \sum_{(i, j) \in E(\bar{G})} (Z_i Z_j - Z_i - Z_j) + \displaystyle\sum_{i \in V(G)} Z_i,
 #
 # where each qubit is a node in the graph, and the states :math:`|0\rangle` and :math:`|1\rangle`
 # represent whether the vertex has been marked as part of the clique, as is the case for `most standard QAOA encoding
 # schemes <https://arxiv.org/abs/1709.03489>`__.
 # Note that :math:`\bar{G}` is the complement of :math:`G:` the graph formed by connecting all nodes that **do not** share
 # an edge in :math:`G.`
+# The factor of :math:`\frac{3}{4}` (rather than :math:`3`) comes from a normalization applied
+# internally by :func:`~pennylane.qaoa.cost.edge_driver`, which is used by
+# :func:`~pennylane.qaoa.cost.max_clique` to build the edge penalty terms.
 #
 # In addition to defining :math:`H_c,` we also require a driver Hamiltonian :math:`H_d` which does not commute
 # with :math:`H_c.` The driver Hamiltonian's role is similar to that of the mixer Hamiltonian in QAOA.
@@ -164,8 +167,8 @@ print(driver_h)
 # One of the main ingredients in the FALQON algorithm is the operator :math:`i [H_d, H_c].` In
 # the case of MaxClique, we can write down the commutator :math:`[H_d, H_c]` explicitly:
 #
-# .. math:: [H_d, H_c] = 3 \displaystyle\sum_{k \in V(G)} \displaystyle\sum_{(i, j) \in E(\bar{G})} \big( [X_k, Z_i Z_j] - [X_k, Z_i]
-#           - [X_k, Z_j] \big) + 3 \displaystyle\sum_{i \in V(G)} \displaystyle\sum_{j \in V(G)} [X_i, Z_j].
+# .. math:: [H_d, H_c] = \frac{3}{4} \displaystyle\sum_{k \in V(G)} \displaystyle\sum_{(i, j) \in E(\bar{G})} \big( [X_k, Z_i Z_j] - [X_k, Z_i]
+#           - [X_k, Z_j] \big) + \displaystyle\sum_{i \in V(G)} \displaystyle\sum_{j \in V(G)} [X_i, Z_j].
 #
 # There are two distinct commutators that we must calculate, :math:`[X_k, Z_j]` and :math:`[X_k, Z_i Z_j].`
 # This is straightforward as we know exactly what the
@@ -177,12 +180,13 @@ print(driver_h)
 # where :math:`\delta_{kj}` is the `Kronecker delta <https://en.wikipedia.org/wiki/Kronecker_delta>`__. Therefore it
 # follows from substitution into the above equation and multiplication by :math:`i` that:
 #
-# .. math:: i [H_d, H_c] = 6 \displaystyle\sum_{k \in V(G)} \displaystyle\sum_{(i, j) \in E(\bar{G})} \big( \delta_{ki} Y_k Z_j +
-#          \delta_{kj} Z_{i} Y_{k} - \delta_{ki} Y_k - \delta_{kj} Y_k \big) + 6 \displaystyle\sum_{i \in V(G)} Y_{i}.
+# .. math:: i [H_d, H_c] = \frac{3}{2} \displaystyle\sum_{k \in V(G)} \displaystyle\sum_{(i, j) \in E(\bar{G})} \big( \delta_{ki} Y_k Z_j +
+#          \delta_{kj} Z_{i} Y_{k} - \delta_{ki} Y_k - \delta_{kj} Y_k \big) + 2 \displaystyle\sum_{i \in V(G)} Y_{i}.
 #
 # This new operator has quite a few terms! Therefore, we write a short method which computes it for us, and returns
 # a :class:`~.pennylane.Hamiltonian` object. Note that this method works for any graph:
 #
+
 
 def build_hamiltonian(graph):
     H = qml.Hamiltonian([], [])
@@ -191,18 +195,31 @@ def build_hamiltonian(graph):
     graph_c = nx.complement(graph)
 
     for k in graph_c.nodes:
-        # Adds the terms in the first sum
+        # Adds the terms in the first sum (coefficient 3/2 = i * 2 * 3/4)
         for edge in graph_c.edges:
             i, j = edge
             if k == i:
-                H += 6 * (qml.PauliY(k) @ qml.PauliZ(j) - qml.PauliY(k))
+                H += 1.5 * (qml.PauliY(k) @ qml.PauliZ(j) - qml.PauliY(k))
             if k == j:
-                H += 6 * (qml.PauliZ(i) @ qml.PauliY(k) - qml.PauliY(k))
-        # Adds the terms in the second sum
-        H += 6 * qml.PauliY(k)
+                H += 1.5 * (qml.PauliZ(i) @ qml.PauliY(k) - qml.PauliY(k))
+        # Adds the terms in the second sum (coefficient 2 = i * 2 * 1)
+        H += 2 * qml.PauliY(k)
 
     return H
 
+
+######################################################################
+# .. note::
+#
+#     For general graphs, the commutator :math:`i[H_d, H_c]` can also be computed
+#     directly using :func:`~pennylane.commutator`, which is more concise and avoids
+#     the need to expand the algebra manually:
+#
+#     .. code-block:: python
+#
+#         cost_h, driver_h = qaoa.max_clique(graph, constrained=False)
+#         comm_h = qml.simplify(1j * qml.commutator(driver_h, cost_h))
+#
 
 print("MaxClique Commutator")
 print(build_hamiltonian(graph))
@@ -212,28 +229,24 @@ print(build_hamiltonian(graph))
 # with our chosen :math:`\beta(t).` We first define one layer of the Trotterized time evolution, which is of
 # the form :math:`U_d(\beta_k) U_c.` Note that we can use the :class:`~.pennylane.templates.ApproxTimeEvolution` template:
 
+
 def falqon_layer(beta_k, cost_h, driver_h, delta_t):
     qml.ApproxTimeEvolution(cost_h, delta_t, 1)
     qml.ApproxTimeEvolution(driver_h, delta_t * beta_k, 1)
+
 
 ######################################################################
 # We then define a method which returns a FALQON ansatz corresponding to a particular cost Hamiltonian, driver
 # Hamiltonian, and :math:`\Delta t.` This involves multiple repetitions of the "FALQON layer" defined above. The
 # initial state of our circuit is an even superposition:
 
+
 def build_maxclique_ansatz(cost_h, driver_h, delta_t):
     def ansatz(beta, **kwargs):
         layers = len(beta)
         for w in dev.wires:
             qml.Hadamard(wires=w)
-        qml.layer(
-            falqon_layer,
-            layers,
-            beta,
-            cost_h=cost_h,
-            driver_h=driver_h,
-            delta_t=delta_t
-        )
+        qml.layer(falqon_layer, layers, beta, cost_h=cost_h, driver_h=driver_h, delta_t=delta_t)
 
     return ansatz
 
@@ -243,26 +256,35 @@ def expval_circuit(beta, measurement_h):
     ansatz(beta)
     return qml.expval(measurement_h)
 
+
 ######################################################################
 # Finally, we implement the recursive process, where FALQON is able to determine the values
 # of :math:`\beta_k,` feeding back into itself as the number of layers increases. This is
 # straightforward using the methods defined above:
 
-def max_clique_falqon(graph, n, beta_1, delta_t, dev):
-    comm_h = build_hamiltonian(graph) # Builds the commutator
-    cost_h, driver_h = qaoa.max_clique(graph, constrained=False) # Builds H_c and H_d
-    cost_fn = qml.QNode(expval_circuit, dev, interface="autograd") # The ansatz + measurement circuit is executable
 
-    beta = [beta_1] # Records each value of beta_k
-    energies = [] # Records the value of the cost function at each step
+def max_clique_falqon(graph, n, beta_1, delta_t, dev):
+    comm_h = build_hamiltonian(graph)  # Builds the commutator
+    cost_h, driver_h = qaoa.max_clique(graph, constrained=False)  # Builds H_c and H_d
+    cost_fn = qml.QNode(
+        expval_circuit, dev, interface="autograd"
+    )  # The ansatz + measurement circuit is executable
+
+    beta = [beta_1]  # Records each value of beta_k
+    energies = []  # Records the value of the cost function at each step
 
     for i in range(n):
         # Adds a value of beta to the list and evaluates the cost function
-        beta.append(-1 * cost_fn(beta, measurement_h=comm_h))  # this call measures the expectation of the commuter hamiltonian
-        energy = cost_fn(beta, measurement_h=cost_h)  # this call measures the expectation of the cost hamiltonian
+        beta.append(
+            -1 * cost_fn(beta, measurement_h=comm_h)
+        )  # this call measures the expectation of the commuter hamiltonian
+        energy = cost_fn(
+            beta, measurement_h=cost_h
+        )  # this call measures the expectation of the cost hamiltonian
         energies.append(energy)
 
     return beta, energies
+
 
 ######################################################################
 # Note that we return both the list of :math:`\beta_k` values, as well as the expectation value of the cost Hamiltonian
@@ -277,7 +299,7 @@ n = 40
 beta_1 = 0.0
 delta_t = 0.03
 
-dev = qml.device("default.qubit", wires=graph.nodes) # Creates a device for the simulation
+dev = qml.device("default.qubit", wires=graph.nodes)  # Creates a device for the simulation
 res_beta, res_energies = max_clique_falqon(graph, n, beta_1, delta_t, dev)
 
 ######################################################################
@@ -285,7 +307,7 @@ res_beta, res_energies = max_clique_falqon(graph, n, beta_1, delta_t, dev)
 # iterations of the algorithm:
 #
 
-plt.plot(range(n+1)[1:], res_energies)
+plt.plot(range(n + 1)[1:], res_energies)
 plt.xlabel("Iteration")
 plt.ylabel("Cost Function Value")
 plt.show()
@@ -297,18 +319,20 @@ plt.show()
 # we can create a graph showing the probability of measuring each possible bit string.
 # We define the following circuit, feeding in the optimal values of :math:`\beta_k:`
 
+
 @qml.qnode(dev, interface="autograd")
 def prob_circuit():
     ansatz = build_maxclique_ansatz(cost_h, driver_h, delta_t)
     ansatz(res_beta)
     return qml.probs(wires=dev.wires)
 
+
 ######################################################################
 # Running this circuit gives us the following probability distribution:
 #
 
 probs = prob_circuit()
-plt.bar(range(2**len(dev.wires)), probs)
+plt.bar(range(2 ** len(dev.wires)), probs)
 plt.xlabel("Bit string")
 plt.ylabel("Measurement Probability")
 plt.show()
@@ -320,7 +344,7 @@ plt.show()
 #
 
 graph = nx.Graph(edges)
-cmap = ["#00b4d9"]*3 + ["#e377c2"]*2
+cmap = ["#00b4d9"] * 3 + ["#e377c2"] * 2
 positions = nx.spring_layout(graph, seed=1)
 nx.draw(graph, with_labels=True, node_color=cmap, pos=positions)
 plt.show()
@@ -411,10 +435,12 @@ dev = qml.device("default.qubit", wires=new_graph.nodes)
 # Creates the cost and mixer Hamiltonians
 cost_h, mixer_h = qaoa.max_clique(new_graph, constrained=False)
 
+
 # Creates a layer of QAOA
 def qaoa_layer(gamma, beta):
     qaoa.cost_layer(gamma, cost_h)
     qaoa.mixer_layer(beta, mixer_h)
+
 
 # Creates the full QAOA circuit as an executable cost function
 def qaoa_circuit(params, **kwargs):
@@ -428,13 +454,14 @@ def qaoa_expval(params):
     qaoa_circuit(params)
     return qml.expval(cost_h)
 
+
 ######################################################################
 # Now all we have to do is run FALQON for :math:`5` steps to get our initial QAOA parameters.
 # We set :math:`\Delta t = 0.02:`
 
 delta_t = 0.02
 
-res, res_energy = max_clique_falqon(new_graph, depth-1, 0.0, delta_t, dev)
+res, res_energy = max_clique_falqon(new_graph, depth - 1, 0.0, delta_t, dev)
 
 params = np.array([[delta_t for k in res], [delta_t * k for k in res]], requires_grad=True)
 
@@ -455,13 +482,15 @@ for s in range(steps):
 # define a circuit which outputs the probabilities of measuring each bit string, and
 # create a bar graph:
 
+
 @qml.qnode(dev, interface="autograd")
 def prob_circuit(params):
     qaoa_circuit(params)
     return qml.probs(wires=dev.wires)
 
+
 probs = prob_circuit(params)
-plt.bar(range(2**len(dev.wires)), probs)
+plt.bar(range(2 ** len(dev.wires)), probs)
 plt.xlabel("Bit string")
 plt.ylabel("Measurement Probability")
 plt.show()

--- a/demonstrations_v2/tutorial_falqon/demo.py
+++ b/demonstrations_v2/tutorial_falqon/demo.py
@@ -195,7 +195,7 @@ def build_hamiltonian(graph):
     graph_c = nx.complement(graph)
 
     for k in graph_c.nodes:
-        # Adds the terms in the first sum (coefficient 3/2 = i * 2 * 3/4)
+        # Adds the terms in the first sum
         for edge in graph_c.edges:
             i, j = edge
             if k == i:

--- a/demonstrations_v2/tutorial_falqon/demo.py
+++ b/demonstrations_v2/tutorial_falqon/demo.py
@@ -222,7 +222,6 @@ print(build_hamiltonian(graph))
 #
 #         cost_h, driver_h = qaoa.max_clique(graph, constrained=False)
 #         comm_h = qml.simplify(1j * qml.commutator(driver_h, cost_h))
-#
 
 ######################################################################
 # We can now build the FALQON algorithm. Our goal is to evolve some initial state under the Hamiltonian :math:`H,`

--- a/demonstrations_v2/tutorial_falqon/demo.py
+++ b/demonstrations_v2/tutorial_falqon/demo.py
@@ -483,7 +483,7 @@ for s in range(steps):
 # create a bar graph:
 
 
-@qml.qnode(dev, interface="autograd")
+@qml.qnode(dev)
 def prob_circuit(params):
     qaoa_circuit(params)
     return qml.probs(wires=dev.wires)

--- a/demonstrations_v2/tutorial_falqon/demo.py
+++ b/demonstrations_v2/tutorial_falqon/demo.py
@@ -449,7 +449,7 @@ def qaoa_circuit(params, **kwargs):
     qml.layer(qaoa_layer, depth, params[0], params[1])
 
 
-@qml.qnode(dev, interface="autograd")
+@qml.qnode(dev)
 def qaoa_expval(params):
     qaoa_circuit(params)
     return qml.expval(cost_h)

--- a/demonstrations_v2/tutorial_falqon/demo.py
+++ b/demonstrations_v2/tutorial_falqon/demo.py
@@ -267,7 +267,7 @@ def max_clique_falqon(graph, n, beta_1, delta_t, dev):
     comm_h = build_hamiltonian(graph)  # Builds the commutator
     cost_h, driver_h = qaoa.max_clique(graph, constrained=False)  # Builds H_c and H_d
     cost_fn = qml.QNode(
-        expval_circuit, dev, interface="autograd"
+        expval_circuit, dev
     )  # The ansatz + measurement circuit is executable
 
     beta = [beta_1]  # Records each value of beta_k

--- a/demonstrations_v2/tutorial_falqon/demo.py
+++ b/demonstrations_v2/tutorial_falqon/demo.py
@@ -202,7 +202,7 @@ def build_hamiltonian(graph):
                 H += 1.5 * (qml.PauliY(k) @ qml.PauliZ(j) - qml.PauliY(k))
             if k == j:
                 H += 1.5 * (qml.PauliZ(i) @ qml.PauliY(k) - qml.PauliY(k))
-        # Adds the terms in the second sum (coefficient 2 = i * 2 * 1)
+        # Adds the terms in the second sum
         H += 2 * qml.PauliY(k)
 
     return H

--- a/demonstrations_v2/tutorial_falqon/metadata.json
+++ b/demonstrations_v2/tutorial_falqon/metadata.json
@@ -11,7 +11,7 @@
     "executable_stable": true,
     "executable_latest": true,
     "dateOfPublication": "2021-05-21T00:00:00+00:00",
-    "dateOfLastModification": "2025-09-22T15:48:14+00:00",
+    "dateOfLastModification": "2026-03-27T00:00:00+00:00",
     "categories": [
         "Optimization"
     ],


### PR DESCRIPTION
**Title:** fix: correct Hc and commutator formulas, and [build_hamiltonian](cci:1://file:///e:/ARPA/OpenSource/qml/demonstrations_v2/tutorial_falqon/demo.py:190:0-207:12) coefficients in FALQON demo

**Summary:**
The FALQON demo's cost Hamiltonian formula, commutator formula, and [build_hamiltonian()](cci:1://file:///e:/ARPA/OpenSource/qml/demonstrations_v2/tutorial_falqon/demo.py:190:0-207:12) function all used incorrect coefficients. The root cause is a hidden 1/4 normalization applied by `pennylane.qaoa.cost.edge_driver` (used internally by `qaoa.max_clique`) that was not reflected in the demo's written math.

Specific corrections:
- `H_c` formula: edge coefficient `3` → `3/4`; added a note explaining the `edge_driver` normalization
- `[H_d, H_c]` formula: first-sum coefficient `3` → `3/4`, second-sum `3` → `1`
- `i[H_d, H_c]` formula: first-sum coefficient `6` → `3/2`, second-sum `6` → `2`
- [build_hamiltonian()](cci:1://file:///e:/ARPA/OpenSource/qml/demonstrations_v2/tutorial_falqon/demo.py:190:0-207:12): edge term coefficients `6` → `1.5`, second-sum `6` → `2`
- Added a `.. note::` block showing `qml.commutator` as a concise general-purpose alternative
- Bumped `dateOfLastModification` in [metadata.json](cci:7://file:///e:/ARPA/OpenSource/qml/demonstrations_v2/tutorial_falqon/metadata.json:0:0-0:0)

The FALQON algorithm converged correctly before and after this fix — the sign of β_k is preserved by the operator structure, so the guarantee d/dt ⟨H_c⟩ ≤ 0 holds regardless. This PR makes the written math match the actual code output.

**Relevant references:**
- Forum report: https://discuss.pennylane.ai/t/an-issue-in-the-falqon-demo/9290
- `edge_driver` API: https://docs.pennylane.ai/en/stable/code/api/pennylane.qaoa.cost.edge_driver.html

**Possible Drawbacks:**
None. The algorithm behaviour is unchanged; only the mathematical exposition is corrected.

**Related GitHub Issues:**
Closes #1726