### PR TITLE
Fix typo in documentation

### DIFF
--- a/demonstrations_v2/tutorial_stochastic_parameter_shift/demo.py
+++ b/demonstrations_v2/tutorial_stochastic_parameter_shift/demo.py
@@ -53,7 +53,7 @@ we can iteratively progress to lower and lower values of the function.
 The Parameter-Shift Rule
 ------------------------
 
-In the quantum case, the expectation value of a circuit with respect to an measurement operator
+In the quantum case, the expectation value of a circuit with respect to a measurement operator
 :math:`\hat{C}` depends smoothly on the the circuit's gate parameters :math:`\theta.` We can write this
 expectation value as :math:`\langle \hat{C}(\theta)\rangle.` This means that the derivatives
 :math:`\nabla_\theta \langle \hat{C} \rangle` exist and gradient descent can be used.

--- a/demonstrations_v2/tutorial_stochastic_parameter_shift/metadata.json
+++ b/demonstrations_v2/tutorial_stochastic_parameter_shift/metadata.json
@@ -8,7 +8,7 @@
     "executable_stable": true,
     "executable_latest": true,
     "dateOfPublication": "2020-05-25T00:00:00+00:00",
-    "dateOfLastModification": "2026-01-14T15:48:14+00:00",
+    "dateOfLastModification": "2026-04-09T16:40:00+00:00",
     "categories": [
         "Optimization"
     ],

--- a/demonstrations_v2/tutorial_stochastic_parameter_shift/metadata.json
+++ b/demonstrations_v2/tutorial_stochastic_parameter_shift/metadata.json
@@ -8,7 +8,7 @@
     "executable_stable": true,
     "executable_latest": true,
     "dateOfPublication": "2020-05-25T00:00:00+00:00",
-    "dateOfLastModification": "2026-04-09T16:40:00+00:00",
+    "dateOfLastModification": "2026-04-09T16:53:00+00:00",
     "categories": [
         "Optimization"
     ],


### PR DESCRIPTION
------------------------------------------------------------------------------------------------------------

**Title:**
Fix typo in documentation

**Summary:**
Fixed a typo in documentation of the file `demonstrations_v2/tutorial_stochastic_parameter_shift`, from 'an measurement' to 'a measurement'.

**Relevant references:**

**Possible Drawbacks:**

**Related GitHub Issues:**

----
If you are writing a demonstration, please answer these questions to facilitate the marketing process.

* GOALS — Why are we working on this now?

  *Eg. Promote a new PL feature or show a PL implementation of a recent paper.*


* AUDIENCE — Who is this for?

  *Eg. Chemistry researchers, PL educators, beginners in quantum computing.*


* KEYWORDS — What words should be included in the marketing post?


* Which of the following types of documentation is most similar to your file? 
(more details [here](https://www.notion.so/xanaduai/Different-kinds-of-documentation-69200645fe59442991c71f9e7d8a77f8))
    
- [ ] Tutorial
- [ ] Demo
- [ ] How-to
