### PR TITLE
Fix metadata reminder to work with forks

### DIFF
--- a/.github/workflows/update-metadata-reminder.yml
+++ b/.github/workflows/update-metadata-reminder.yml
@@ -1,9 +1,7 @@
 name: Reminder to update demo metadata
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
-    paths:
-      - demonstrations_v2/**
 
 jobs:
   reminder:
@@ -12,6 +10,13 @@ jobs:
     - uses: actions/github-script@v7
       with:
         script: |
+          const files = await github.paginate(
+            github.rest.pulls.listFiles,
+            { owner: context.repo.owner, repo: context.repo.repo, pull_number: context.issue.number }
+          );
+          const touchesDemos = files.some(f => f.filename.startsWith('demonstrations_v2/'));
+          if (!touchesDemos) return;
+
           github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,


### PR DESCRIPTION
This PR updates the reminder to modify the `dateOfLastModification` so it will work when PRs are opened from forks. One consequence is that the check for changed files must now take place within the body of the script by calling the Github CLI directly, because the action's paths check doesn't work as expected when the workflow trigger is `pull_request_target`.

**Potential risks**:
The new event trigger means the associated GITHUB token will have elevated privileges, but the scope is limited to posting a comment on the PR, and no code is checked out and no secrets are involved, so the risk is minimal.