### PR TITLE
Qrack demo update for PyQrack v2.0.0

### DIFF
--- a/demonstrations_v2/qrack/demo.py
+++ b/demonstrations_v2/qrack/demo.py
@@ -199,11 +199,7 @@ plt.show()
 
 qubits = 60
 dev = qp.device(
-    "qrack.simulator",
-    qubits,
-    isBinaryDecisionTree=False,
-    isStabilizerHybrid=True,
-    isSchmidtDecompose=False,
+    "qrack.simulator", qubits, is_near_clifford_tableau_writer=True
 )
 
 @qjit
@@ -243,7 +239,7 @@ plt.show()
 
 qubits = 24
 dev = qp.device(
-    "qrack.simulator", qubits, isBinaryDecisionTree=True, isStabilizerHybrid=False
+    "qrack.simulator", qubits, is_binary_decision_tree=True
 )
 
 @qjit

--- a/demonstrations_v2/qrack/metadata.json
+++ b/demonstrations_v2/qrack/metadata.json
@@ -8,7 +8,7 @@
     "executable_stable": false,
     "executable_latest": false,
     "dateOfPublication": "2024-07-10T00:00:00+00:00",
-    "dateOfLastModification": "2026-04-14T00:00:00+00:00",
+    "dateOfLastModification": "2026-05-03T00:00:00+00:00",
     "categories": [
         "Compilation",
         "Devices and Performance"

--- a/demonstrations_v2/qrack/requirements.in
+++ b/demonstrations_v2/qrack/requirements.in
@@ -1,1 +1,1 @@
-pyqrack==1.32.12
+pyqrack==2.0.0


### PR DESCRIPTION
**Title:**
Update to Qrack demo

**Summary:**
PyQrack v2.x and PennyLane-Qrack v1.x remove a number of "footguns" regarding sub-optimal simulation settings, but this is a breaking API change for downstream users.

**Relevant references:**
https://github.com/unitaryfoundation/pyqrack/releases/tag/v2.0.0
https://github.com/unitaryfoundation/pennylane-qrack/releases/tag/v1.0.0

**Possible Drawbacks:**
Breaking API change

**Related GitHub Issues:**
None
