### PR TITLE
Bump constraints version 0.45

### DIFF
--- a/dependencies/constraints-plc-dev.json
+++ b/dependencies/constraints-plc-dev.json
@@ -1,5 +1,5 @@
 [
-  {"name": "pennylane-catalyst", "version": "0.15.0"},
-  {"name": "pennylane-lightning", "version": "0.45.0"},
-  {"name": "pennylane", "version": "0.45.0"}
+  {"name": "pennylane-catalyst", "version": "0.16.0"},
+  {"name": "pennylane-lightning", "version": "0.46.0"},
+  {"name": "pennylane", "version": "0.46.0"}
 ]

--- a/dependencies/constraints-stable.txt
+++ b/dependencies/constraints-stable.txt
@@ -1,10 +1,10 @@
 # Specifies global constraints for the stable build
 --extra-index-url https://download.pytorch.org/whl/cpu
-pennylane==0.44.*
+pennylane==0.45.*
 pennylane-cirq==0.44.*
-pennylane-qiskit==0.44.*
+pennylane-qiskit==0.45.*
 pennylane-qulacs==0.44.*
-pennylane-catalyst==0.14.*
+pennylane-catalyst==0.15.*
 
 # Install external packages
 matplotlib==3.10.0


### PR DESCRIPTION
Both dev and master need bump. Plugins only have qiskit (and ionq, but didn't see in constraint files) new release so only bumped qiskit