### PR TITLE
Replace deprecated `qp.layer` with for loops

### DIFF
--- a/demonstrations_v2/braket-parallel-gradients/demo.py
+++ b/demonstrations_v2/braket-parallel-gradients/demo.py
@@ -343,7 +343,8 @@ def circuit(params, **kwargs):
     for i in range(n_wires):  # Prepare an equal superposition over all qubits
         qp.Hadamard(wires=i)
 
-    qp.layer(qaoa_layer, n_layers, params[0], params[1])
+    for i in range(n_layers):
+        qaoa_layer(params[0][i], params[1][i])
     return qp.expval(cost_h)
 
 
@@ -487,7 +488,8 @@ def qaoa_training(n_iterations, n_layers=2):
     def cost_function(params, **kwargs):
         for i in range(n_wires):  # Prepare an equal superposition over all qubits
             qp.Hadamard(wires=i)
-        qp.layer(qaoa_layer, n_layers, params[0], params[1])
+        for i in range(n_layers):
+            qaoa_layer(params[0][i], params[1][i])
         return qp.expval(cost_h)
 
     params = 0.01 * np.random.uniform(size=[2, n_layers])

--- a/demonstrations_v2/braket-parallel-gradients/metadata.json
+++ b/demonstrations_v2/braket-parallel-gradients/metadata.json
@@ -14,7 +14,7 @@
     "executable_stable": false,
     "executable_latest": false,
     "dateOfPublication": "2020-12-08T00:00:00+00:00",
-    "dateOfLastModification": "2026-04-14T15:48:14+00:00",
+    "dateOfLastModification": "2026-05-15T00:00:00+00:00",
     "categories": [
         "Devices and Performance"
     ],

--- a/demonstrations_v2/learning2learn/demo.py
+++ b/demonstrations_v2/learning2learn/demo.py
@@ -237,7 +237,8 @@ def qaoa_from_graph(graph, n_layers=1):
     def circuit(params, **kwargs):
         for w in wires:
             qp.Hadamard(wires=w)
-        qp.layer(qaoa_layer, n_layers, params[0], params[1])
+        for i in range(n_layers):
+            qaoa_layer(params[0][i], params[1][i])
         return qp.expval(cost_h)
 
     # Evaluates the cost Hamiltonian

--- a/demonstrations_v2/learning2learn/metadata.json
+++ b/demonstrations_v2/learning2learn/metadata.json
@@ -8,7 +8,7 @@
     "executable_stable": false,
     "executable_latest": false,
     "dateOfPublication": "2021-03-02T00:00:00+00:00",
-    "dateOfLastModification": "2026-04-14T00:00:00+00:00",
+    "dateOfLastModification": "2026-05-15T00:00:00+00:00",
     "categories": [
         "Quantum Machine Learning"
     ],

--- a/demonstrations_v2/qnspsa/demo.py
+++ b/demonstrations_v2/qnspsa/demo.py
@@ -212,7 +212,8 @@ def qaoa_circuit(params, n_qubits, depth):
     gammas = params[0]
     alphas = params[1]
     # stack building blocks for depth times.
-    qp.layer(qaoa_layer, depth, gammas, alphas)
+    for i in range(depth):
+        qaoa_layer(gammas[i], alphas[i])
 
 
 # define ansatz and loss function

--- a/demonstrations_v2/qnspsa/metadata.json
+++ b/demonstrations_v2/qnspsa/metadata.json
@@ -8,7 +8,7 @@
     "executable_stable": false,
     "executable_latest": false,
     "dateOfPublication": "2022-07-18T00:00:00+00:00",
-    "dateOfLastModification": "2026-04-14T00:00:00+00:00",
+    "dateOfLastModification": "2026-05-15T00:00:00+00:00",
     "categories": [
         "Optimization"
     ],

--- a/demonstrations_v2/tutorial_falqon/demo.py
+++ b/demonstrations_v2/tutorial_falqon/demo.py
@@ -245,7 +245,8 @@ def build_maxclique_ansatz(cost_h, driver_h, delta_t):
         layers = len(beta)
         for w in dev.wires:
             qp.Hadamard(wires=w)
-        qp.layer(falqon_layer, layers, beta, cost_h=cost_h, driver_h=driver_h, delta_t=delta_t)
+        for i in range(layers):
+            falqon_layer(beta[i], cost_h=cost_h, driver_h=driver_h, delta_t=delta_t)
 
     return ansatz
 
@@ -445,7 +446,8 @@ def qaoa_layer(gamma, beta):
 def qaoa_circuit(params, **kwargs):
     for w in dev.wires:
         qp.Hadamard(wires=w)
-    qp.layer(qaoa_layer, depth, params[0], params[1])
+    for i in range(depth):
+        qaoa_layer(params[0][i], params[1][i])
 
 
 @qp.qnode(dev)

--- a/demonstrations_v2/tutorial_falqon/metadata.json
+++ b/demonstrations_v2/tutorial_falqon/metadata.json
@@ -11,7 +11,7 @@
     "executable_stable": true,
     "executable_latest": true,
     "dateOfPublication": "2021-05-21T00:00:00+00:00",
-    "dateOfLastModification": "2026-04-17T00:00:00+00:00",
+    "dateOfLastModification": "2026-05-15T00:00:00+00:00",
     "categories": [
         "Optimization"
     ],

--- a/demonstrations_v2/tutorial_qaoa_intro/demo.py
+++ b/demonstrations_v2/tutorial_qaoa_intro/demo.py
@@ -125,8 +125,8 @@ print(qp.draw(circuit, level="device")())
 #     :width: 100%
 #
 #
-# Circuit repetition is implemented in PennyLane using the :func:`~.pennylane.layer` function. This
-# method allows us to take a function containing either quantum operations, a template, or even a
+# Circuit repetition is implemented in PennyLane using a simple for loop. This
+# allows us to take a function containing either quantum operations, a template, or even a
 # single quantum gate, and repeatedly apply it to a set of wires.
 #
 # .. figure:: ../_static/demonstration_assets/qaoa_module/qml_layer.png
@@ -154,13 +154,14 @@ print(qp.draw(circuit)(0.5))
 
 ######################################################################
 #
-# We simply pass this function into the :func:`~.pennylane.layer` function:
+# We simply pass this function into a for loop:
 #
 
 
 @qp.qnode(dev)
 def circuit(params, **kwargs):
-    qp.layer(circ, 3, params)
+    for i in range(3):
+        circ(params[i])
     return [qp.expval(qp.PauliZ(i)) for i in range(2)]
 
 
@@ -309,12 +310,13 @@ depth = 2
 def circuit(params, **kwargs):
     for w in wires:
         qp.Hadamard(wires=w)
-    qp.layer(qaoa_layer, depth, params[0], params[1])
+    for i in range(depth):
+        qaoa_layer(params[0][i], params[1][i])
 
 
 ######################################################################
 #
-# Note that :func:`~.pennylane.layer` allows us to pass variational parameters
+# Note that the for loop allows us to pass variational parameters
 # ``params[0]`` and ``params[1]`` into each layer of the circuit. That's it! The last
 # step is PennyLane's specialty: optimizing the circuit parameters.
 #
@@ -452,7 +454,8 @@ def qaoa_layer(gamma, alpha):
 def circuit(params, **kwargs):
     for w in wires:
         qp.Hadamard(wires=w)
-    qp.layer(qaoa_layer, depth, params[0], params[1])
+    for i in range(depth):
+        qaoa_layer(params[0][i], params[1][i])
 
 
 @qp.qnode(dev)

--- a/demonstrations_v2/tutorial_qaoa_intro/metadata.json
+++ b/demonstrations_v2/tutorial_qaoa_intro/metadata.json
@@ -8,7 +8,7 @@
     "executable_stable": true,
     "executable_latest": true,
     "dateOfPublication": "2020-11-18T00:00:00+00:00",
-    "dateOfLastModification": "2026-04-21T15:48:14+00:00",
+    "dateOfLastModification": "2026-05-15T00:00:00+00:00",
     "categories": [
         "Optimization",
         "Getting Started"


### PR DESCRIPTION
`qp.layer` was deprecated at https://github.com/PennyLaneAI/pennylane/pull/9484

[sc-120075]