### PR TITLE
simplify -> prune for two demos

### DIFF
--- a/demonstrations_v2/tutorial_fermionic_operators/demo.py
+++ b/demonstrations_v2/tutorial_fermionic_operators/demo.py
@@ -192,7 +192,7 @@ for p, q, r, s in itertools.product(range(n), repeat=4):
 # We then simplify the Hamiltonian to remove terms with negligible coefficients and then map it to
 # the qubit basis.
 
-h.simplify()
+h.prune()
 h = jordan_wigner(h)
 
 ##############################################################################

--- a/demonstrations_v2/tutorial_fermionic_operators/metadata.json
+++ b/demonstrations_v2/tutorial_fermionic_operators/metadata.json
@@ -8,7 +8,7 @@
     "executable_stable": true,
     "executable_latest": true,
     "dateOfPublication": "2023-06-27T00:00:00+00:00",
-    "dateOfLastModification": "2026-04-17T15:48:14+00:00",
+    "dateOfLastModification": "2026-05-20T00:00:00+00:00",
     "categories": [
         "Quantum Chemistry"
     ],

--- a/demonstrations_v2/tutorial_liesim_extension/demo.py
+++ b/demonstrations_v2/tutorial_liesim_extension/demo.py
@@ -196,11 +196,11 @@ for i, h1 in enumerate(dla):
 
 for i, h1 in enumerate(dla):
     res = P @ h1 @ P_dagger
-    res.simplify()
+    res.prune()
 
     reconstruct = sum([P0[i, j] * dla[j] for j in range(dim_g)])
     reconstruct += sum([P1[i, j, l] * dla[j] @ dla[l] for j in range(dim_g) for l in range(dim_g)])
-    reconstruct.simplify()
+    reconstruct.prune()
 
     assert res == reconstruct
 

--- a/demonstrations_v2/tutorial_liesim_extension/metadata.json
+++ b/demonstrations_v2/tutorial_liesim_extension/metadata.json
@@ -8,7 +8,7 @@
     "executable_stable": true,
     "executable_latest": true,
     "dateOfPublication": "2024-06-18T00:00:00+00:00",
-    "dateOfLastModification": "2026-04-17T15:48:14+00:00",
+    "dateOfLastModification": "2026-05-20T00:00:00+00:00",
     "categories": [
         "Quantum Computing",
         "Quantum Machine Learning"


### PR DESCRIPTION
These two demos are using the recently deprecated API `.simplify()` for `PauliSentence`, `FermiSentence`, and `BoseSentence` https://github.com/PennyLaneAI/pennylane/pull/9487
 - [x] tutorial_liesim_extension https://github.com/PennyLaneAI/demos/actions/runs/26149945512/job/77031848904
 - [x] tutorial_fermionic_operators https://github.com/PennyLaneAI/demos/actions/runs/26149945512/job/77031848915

[sc-120181]