### PR TITLE
[CS-120773] Update PR preview URLs

### DIFF
--- a/.github/workflows/v2-deploy-pr.yml
+++ b/.github/workflows/v2-deploy-pr.yml
@@ -105,7 +105,7 @@ jobs:
         id: generate-markdown
         run: |
           comment="### Your preview is ready :tada:!\n\n"
-          comment+="You can view your changes [here](https://pennylane.ai/qml/demonstrations?pr=${{ needs.prepare-build-context.outputs.pr_id }})\n\n"
+          comment+="You can view your changes [here](https://pennylane.ai/demonstrations?pr=${{ needs.prepare-build-context.outputs.pr_id }})\n\n"
 
           comment+="> Deployed at: $(date +'%Y-%m-%d %H:%M:%S') UTC\n\n"
 


### PR DESCRIPTION
### Changes
We've revised [pennylane.ai](https://pennylane.ai/) recently by removing `/qml/` from all of its URL paths. This was done as part of a bigger effort to redefine `pennylane` as larger than just `QML`.
I forgot to update the PR preview URLs along the way. This PR fixes that.