### PR TITLE
chore: add note for why `qrack` demo is non-executable

### DIFF
--- a/demonstrations_v2/qrack/metadata.json
+++ b/demonstrations_v2/qrack/metadata.json
@@ -5,10 +5,11 @@
             "username": "dstrano"
         }
     ],
+    "_comment": "Disabled execution because results are sensitive to hardware specs.",
     "executable_stable": false,
     "executable_latest": false,
     "dateOfPublication": "2024-07-10T00:00:00+00:00",
-    "dateOfLastModification": "2026-04-14T00:00:00+00:00",
+    "dateOfLastModification": "2026-06-02T00:00:00+00:00",
     "categories": [
         "Compilation",
         "Devices and Performance"

--- a/demonstrations_v2/qrack/requirements.in
+++ b/demonstrations_v2/qrack/requirements.in
@@ -1,1 +1,2 @@
-pyqrack==1.32.12
+pennylane-qrack
+pyqrack


### PR DESCRIPTION
I tried to make this demo executable (https://github.com/PennyLaneAI/demos/pull/1614) but it uncovered the fact that the results are highly sensitive to hardware specs. Therefore, we decided to leave the demo static for now.

[sc-120749]