### PR TITLE
Make BlueQubit non-executable

### DIFF
--- a/demonstrations_v2/tutorial_bluequbit/metadata.json
+++ b/demonstrations_v2/tutorial_bluequbit/metadata.json
@@ -6,7 +6,7 @@
         }
     ],
     "executable_stable": true,
-    "executable_latest": true,
+    "executable_latest": false,
     "dateOfPublication": "2024-09-24T00:00:00+00:00",
     "dateOfLastModification": "2026-05-28T00:00:00+00:00",
     "categories": [

--- a/demonstrations_v2/tutorial_bluequbit/metadata.json
+++ b/demonstrations_v2/tutorial_bluequbit/metadata.json
@@ -8,7 +8,7 @@
     "executable_stable": true,
     "executable_latest": false,
     "dateOfPublication": "2024-09-24T00:00:00+00:00",
-    "dateOfLastModification": "2026-05-28T00:00:00+00:00",
+    "dateOfLastModification": "2026-06-15T00:00:00+00:00",
     "categories": [
         "Devices and Performance",
         "Quantum Computing"


### PR DESCRIPTION
There are BlueQubit server side validation that uses some deprecated structure of pennylane (`core` module locations). Nothing much can be done on PennyLane side, and BQ team also confirmed that it's hard to refactor for now. So let's make it non-executable.
[sc-122640]