### PR TITLE
Fix dev faliure due to package issue

### DIFF
--- a/lib/demo/lib/cmds.py
+++ b/lib/demo/lib/cmds.py
@@ -78,7 +78,7 @@ def pip_install(
                 "pip",
                 "install",
                 "--index-strategy",
-                "unsafe-best-match",
+                "unsafe-first-match",
             ]
         )
     else:
@@ -121,7 +121,7 @@ def pip_compile(
         "pip",
         "compile",
         "--index-strategy",
-        "unsafe-best-match",
+        "unsafe-first-match",
         "--no-header",
         "--no-strip-extras",
         "--no-strip-markers",


### PR DESCRIPTION
## Summary

Fix intermittent CI failures in dev demo builds caused by `uv pip compile` querying the PyTorch CPU wheel index for packages that are not hosted there (e.g. `python-dateutil`), which returns HTTP 403 and aborts resolution.

- Switch `uv` index strategy from `unsafe-best-match` to `unsafe-first-match` in `pip_compile` and `pip_install`
- Reduces unnecessary requests to `https://download.pytorch.org/whl/cpu` for standard PyPI packages
- Preserves multi-index resolution so `torch==2.9.0+cpu` can still be resolved from the PyTorch index when needed

## Testing
- Run build dev action and make sure it passes
- https://github.com/PennyLaneAI/demos/actions/runs/28102113294