### PR TITLE
Install Pytorch from PyPI

### DIFF
--- a/dependencies/constraints-dev.txt
+++ b/dependencies/constraints-dev.txt
@@ -3,7 +3,6 @@
 # are handled separately in the demo cli.
 
 --extra-index-url https://test.pypi.org/simple/
---extra-index-url https://download.pytorch.org/whl/cpu
 
 # Install plug-ins required for demos
 pennylane-cirq @ git+https://github.com/PennyLaneAI/pennylane-cirq.git#egg=pennylane-cirq
@@ -24,9 +23,7 @@ jax==0.7.1
 jaxlib==0.7.1
 jaxopt==0.8.5
 
-torch==2.9.0+cpu ; sys_platform != 'darwin'
-torch==2.9.0 ; sys_platform == 'darwin'
-torchvision==0.24.0+cpu ; sys_platform != 'darwin'
-torchvision==0.24.0 ; sys_platform == 'darwin'
+torch==2.9.0
+torchvision==0.24.0
 
 optax==0.2.4

--- a/dependencies/constraints-stable.txt
+++ b/dependencies/constraints-stable.txt
@@ -1,5 +1,4 @@
 # Specifies global constraints for the stable build
---extra-index-url https://download.pytorch.org/whl/cpu
 pennylane==0.45.*
 pennylane-cirq==0.44.*
 pennylane-qiskit==0.45.*

--- a/dependencies/constraints-stable.txt
+++ b/dependencies/constraints-stable.txt
@@ -18,9 +18,7 @@ jax==0.7.1
 jaxlib==0.7.1
 jaxopt==0.8.5
 
-torch==2.9.0+cpu ; sys_platform != 'darwin'
-torch==2.9.0 ; sys_platform == 'darwin'
-torchvision==0.24.0+cpu ; sys_platform != 'darwin'
-torchvision==0.24.0 ; sys_platform == 'darwin'
+torch==2.9.0
+torchvision==0.24.0
 
 optax==0.2.4


### PR DESCRIPTION
The pipeline has been installing Pytorch from the Pytorch index, but this often times out resulting in failed builds. This PR switches to installing torch from PyPI. Tested by [building master successfully](https://github.com/PennyLaneAI/demos/actions/runs/28451085504).