### PR TITLE
Upgrade V2 Sync objects.inv only to use 3.12

### DIFF
--- a/.github/workflows/v2-sync-objects-dot-inv.yml
+++ b/.github/workflows/v2-sync-objects-dot-inv.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: pip install .


### PR DESCRIPTION
#1818 caused V2 Sync objects.inv workflow to fail in certain scenarios (e.g. [here](https://github.com/PennyLaneAI/demos/actions/runs/27852517986/job/82434041514)) due to a Python version mismatch between `master` and `dev` branches.

This PR bumps that workflow's Python version in `master` to match `dev` (v3.12)