### PR TITLE
Use whitelisted runners

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -3,7 +3,7 @@ on: [status]
 
 jobs:
   artifact-comment:
-    runs-on: ubuntu-latest
+    runs-on: Linux-arm-2-core-GitHub-hosted-runners-azure-network
     name: Run CircleCI artifacts redirector
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -3,7 +3,9 @@ on: [status]
 
 jobs:
   artifact-comment:
-    runs-on: Linux-arm-2-core-GitHub-hosted-runners-azure-network
+    runs-on:
+      group: 'PennyLaneAI-Static-IP-Runners'
+      labels: ['pl-2-core-gh-runner']
     name: Run CircleCI artifacts redirector
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/update-dev.yml
+++ b/.github/workflows/update-dev.yml
@@ -25,10 +25,17 @@ jobs:
       }}
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          token: ${{ secrets.NIGHTLY_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0  # We want entire git-history to avoid any merge conflicts
 
       - name: Nightly Merge

--- a/.github/workflows/update-dev.yml
+++ b/.github/workflows/update-dev.yml
@@ -13,7 +13,9 @@ on:
 
 jobs:
   update-dev:
-    runs-on: Linux-arm-2-core-GitHub-hosted-runners-azure-network
+    runs-on:
+      group: 'PennyLaneAI-Static-IP-Runners'
+      labels: ['pl-2-core-gh-runner']
 
     if: >-
       ${{

--- a/.github/workflows/update-dev.yml
+++ b/.github/workflows/update-dev.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   update-dev:
-    runs-on: ubuntu-latest
+    runs-on: Linux-arm-2-core-GitHub-hosted-runners-azure-network
 
     if: >-
       ${{

--- a/.github/workflows/update-metadata-reminder.yml
+++ b/.github/workflows/update-metadata-reminder.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   reminder:
-    runs-on: ubuntu-latest
+    runs-on: Linux-arm-2-core-GitHub-hosted-runners-azure-network
     steps:
     - uses: actions/github-script@v7
       with:

--- a/.github/workflows/update-metadata-reminder.yml
+++ b/.github/workflows/update-metadata-reminder.yml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   reminder:
-    runs-on: Linux-arm-2-core-GitHub-hosted-runners-azure-network
+    runs-on:
+      group: 'PennyLaneAI-Static-IP-Runners'
+      labels: ['pl-2-core-gh-runner']
     steps:
     - uses: actions/github-script@v7
       with:

--- a/.github/workflows/v1-deprecation-warning.yml
+++ b/.github/workflows/v1-deprecation-warning.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   check-directory:
-    runs-on: Linux-arm-2-core-GitHub-hosted-runners-azure-network
+    runs-on:
+      group: 'PennyLaneAI-Static-IP-Runners'
+      labels: ['pl-2-core-gh-runner']
     outputs:
       demonstrations-v1-changes-detected: ${{ steps.determine-changes.outputs.demonstrations-v1-changes-detected }}
     steps:

--- a/.github/workflows/v1-deprecation-warning.yml
+++ b/.github/workflows/v1-deprecation-warning.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check-directory:
-    runs-on: ubuntu-latest
+    runs-on: Linux-arm-2-core-GitHub-hosted-runners-azure-network
     outputs:
       demonstrations-v1-changes-detected: ${{ steps.determine-changes.outputs.demonstrations-v1-changes-detected }}
     steps:

--- a/.github/workflows/v2-build-demos.yml
+++ b/.github/workflows/v2-build-demos.yml
@@ -207,7 +207,7 @@ jobs:
           retention-days: 1
 
   consolidate-artifacts:
-    runs-on: Linux-arm-2-core-GitHub-hosted-runners-azure-network
+    runs-on: ubuntu-latest
     if: ${{ inputs.save-artifact }}
     needs: [generate-build-variables, build-demos]
     steps:
@@ -232,8 +232,3 @@ jobs:
           path: _build/pack/*.zip
           retention-days: ${{ inputs.artifact-retention }}
           overwrite: true
-      
-      - name: Delete partial artifacts
-        uses: geekyeggo/delete-artifact@v6
-        with:
-            name: ${{ needs.generate-build-variables.outputs.artifact-name }}-c*

--- a/.github/workflows/v2-build-demos.yml
+++ b/.github/workflows/v2-build-demos.yml
@@ -207,7 +207,7 @@ jobs:
           retention-days: 1
 
   consolidate-artifacts:
-    runs-on: ubuntu-latest
+    runs-on: Linux-arm-2-core-GitHub-hosted-runners-azure-network
     if: ${{ inputs.save-artifact }}
     needs: [generate-build-variables, build-demos]
     steps:

--- a/.github/workflows/v2-deploy-demos-swc-env.yml
+++ b/.github/workflows/v2-deploy-demos-swc-env.yml
@@ -20,7 +20,7 @@ jobs:
   # Step 1: Prepare the build context
   prepare-build-context:
     if: github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
+    runs-on: Linux-arm-2-core-GitHub-hosted-runners-azure-network
     steps:
       - name: Download Build Context
         uses: XanaduAI/cloud-actions/download-github-workflow-artifact@main

--- a/.github/workflows/v2-deploy-demos-swc-env.yml
+++ b/.github/workflows/v2-deploy-demos-swc-env.yml
@@ -20,7 +20,9 @@ jobs:
   # Step 1: Prepare the build context
   prepare-build-context:
     if: github.event.workflow_run.conclusion == 'success'
-    runs-on: Linux-arm-2-core-GitHub-hosted-runners-azure-network
+    runs-on:
+      group: 'PennyLaneAI-Static-IP-Runners'
+      labels: ['pl-2-core-gh-runner']
     steps:
       - name: Download Build Context
         uses: XanaduAI/cloud-actions/download-github-workflow-artifact@main

--- a/.github/workflows/v2-deploy-demos.yml
+++ b/.github/workflows/v2-deploy-demos.yml
@@ -38,7 +38,9 @@ on:
 
 jobs:
   deploy-demos:
-    runs-on: Linux-2-core-GitHub-hosted-runners-azure-network
+    runs-on:
+      group: 'PennyLaneAI-Static-IP-Runners'
+      labels: ['pl-2-core-gh-runner']
     environment: ${{ inputs.environment }}
     env:
       DEPLOYMENT_ENDPOINT_URL: ${{ secrets.DEPLOYMENT_ENDPOINT_URL }}

--- a/.github/workflows/v2-deploy-demos.yml
+++ b/.github/workflows/v2-deploy-demos.yml
@@ -38,7 +38,7 @@ on:
 
 jobs:
   deploy-demos:
-    runs-on: ubuntu-latest
+    runs-on: Linux-2-core-GitHub-hosted-runners-azure-network
     environment: ${{ inputs.environment }}
     env:
       DEPLOYMENT_ENDPOINT_URL: ${{ secrets.DEPLOYMENT_ENDPOINT_URL }}

--- a/.github/workflows/v2-deploy-pr.yml
+++ b/.github/workflows/v2-deploy-pr.yml
@@ -20,7 +20,9 @@ jobs:
   # Step 1: Prepare the build context
   prepare-build-context:
     if: github.event.workflow_run.conclusion == 'success'
-    runs-on: Linux-arm-2-core-GitHub-hosted-runners-azure-network
+    runs-on:
+      group: 'PennyLaneAI-Static-IP-Runners'
+      labels: ['pl-2-core-gh-runner']
     steps:
       - name: Download Build Context
         uses: XanaduAI/cloud-actions/download-github-workflow-artifact@main
@@ -97,7 +99,9 @@ jobs:
   # If build fails, generate a comment indicating the failure.
   generate-comment:
     if: github.event.workflow_run.event == 'pull_request' && needs.prepare-build-context.outputs.pr_id != ''
-    runs-on: Linux-arm-2-core-GitHub-hosted-runners-azure-network
+    runs-on:
+      group: 'PennyLaneAI-Static-IP-Runners'
+      labels: ['pl-2-core-gh-runner']
     needs: [prepare-build-context, deploy-preview-demos]
     steps:
       - name: Generate Markdown Comment for Successful Deployment

--- a/.github/workflows/v2-deploy-pr.yml
+++ b/.github/workflows/v2-deploy-pr.yml
@@ -20,7 +20,7 @@ jobs:
   # Step 1: Prepare the build context
   prepare-build-context:
     if: github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
+    runs-on: Linux-arm-2-core-GitHub-hosted-runners-azure-network
     steps:
       - name: Download Build Context
         uses: XanaduAI/cloud-actions/download-github-workflow-artifact@main
@@ -97,7 +97,7 @@ jobs:
   # If build fails, generate a comment indicating the failure.
   generate-comment:
     if: github.event.workflow_run.event == 'pull_request' && needs.prepare-build-context.outputs.pr_id != ''
-    runs-on: ubuntu-latest
+    runs-on: Linux-arm-2-core-GitHub-hosted-runners-azure-network
     needs: [prepare-build-context, deploy-preview-demos]
     steps:
       - name: Generate Markdown Comment for Successful Deployment


### PR DESCRIPTION
This PR updates several workflows that require interacting with the Github API to use the pool of whitelisted Azure runners. 

**Note:** The only step in `v2-build-demos.yml` that would have needed this was the partial artifact deletion at the end of the workflow, but these artifact fragments are expired after 1 day anyway, so I've opted to remove this step to keep this fairly heavy workflow executing on public runners to free up the pool.

**Further note:** The checks are failing precisely because of the whitelist issue. I have successfully tested the [update-dev workflow](https://github.com/PennyLaneAI/demos/actions/runs/30638983131/job/91183789855).